### PR TITLE
fix: replace 4 bare excepts with except Exception

### DIFF
--- a/skills/file-manager/scripts/file_ops.py
+++ b/skills/file-manager/scripts/file_ops.py
@@ -227,7 +227,7 @@ def search_files(directory: str, pattern: str, content: str = None) -> dict:
                             lines.append({"line": i, "content": line.strip()[:100]})
                     match_info["matches"] = lines[:10]  # 最多10个匹配
                     matches.append(match_info)
-            except:
+            except Exception:
                 pass
         else:
             matches.append(match_info)

--- a/skills/slack-gif-creator/core/validators.py
+++ b/skills/slack-gif-creator/core/validators.py
@@ -53,7 +53,7 @@ def validate_gif(
                 duration_ms = img.info.get("duration", 100)
                 total_duration = (duration_ms * frame_count) / 1000
                 fps = frame_count / total_duration if total_duration > 0 else 0
-            except:
+            except Exception:
                 total_duration = None
                 fps = None
 

--- a/tests/legacy/test_telegram_simple.py
+++ b/tests/legacy/test_telegram_simple.py
@@ -288,7 +288,7 @@ async def main():
         else:
             rlist, _, _ = select.select([sys.stdin], [], [], 5)
             answer = sys.stdin.readline().strip().lower() if rlist else 'n'
-    except:
+    except Exception:
         answer = 'n'
         print("(自动跳过)")
     

--- a/tests/test_telegram_simple.py
+++ b/tests/test_telegram_simple.py
@@ -288,7 +288,7 @@ async def main():
         else:
             rlist, _, _ = select.select([sys.stdin], [], [], 5)
             answer = sys.stdin.readline().strip().lower() if rlist else 'n'
-    except:
+    except Exception:
         answer = 'n'
         print("(自动跳过)")
     


### PR DESCRIPTION
Replace 4 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.