### PR TITLE
chore: upgrade websockets to 15.0.1 and fix deprecated parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ wework = [
 
 # OneBot 协议通道 (NapCat/Lagrange 等)
 onebot = [
-    "websockets>=12.0",
+    "websockets>=15.0.1",
 ]
 
 # QQ 官方机器人
@@ -142,7 +142,7 @@ all = [
     "dingtalk-stream>=0.24.0",
     "aiohttp>=3.9.0",
     "pycryptodome>=3.19.0",
-    "websockets>=12.0",
+    "websockets>=15.0.1",
     "qq-botpy>=1.1.5",
     "pilk>=0.2.1",
     # -- 语音 / 桌面 --

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ pycryptodome>=3.19.0      # 企业微信消息加解密 (AES-256-CBC)
 dingtalk-stream>=0.24.0   # 钉钉 Stream SDK
 
 # OneBot 协议 (NapCat/Lagrange 等)
-websockets>=12.0          # OneBot WebSocket 支持
+websockets>=15.0.1          # OneBot WebSocket 支持
 
 # QQ 官方机器人
 qq-botpy>=1.1.5           # QQ 开放平台官方 Bot SDK

--- a/src/openakita/channels/adapters/onebot.py
+++ b/src/openakita/channels/adapters/onebot.py
@@ -110,7 +110,7 @@ class OneBotAdapter(ChannelAdapter):
         try:
             self._ws = await websockets.connect(
                 self.config.ws_url,
-                extra_headers=headers,
+                additional_headers=headers,
             )
             logger.info(f"OneBot adapter connected to {self.config.ws_url}")
             return True


### PR DESCRIPTION
## Changes

- **Upgrade websockets dependency**: `>=12.0` → `>=15.0.1`
  - Updated in `pyproject.toml` (2 occurrences)
  - Updated in `requirements.txt`

- **Fix deprecated parameter**: `extra_headers` → `additional_headers`
  - Updated in `src/openakita/channels/adapters/onebot.py` (line 113)
  - The `extra_headers` parameter was deprecated in websockets 12.0 and removed in favor of `additional_headers`

## Reason

These changes ensure compatibility with the latest websockets library version.