### PR TITLE
fix(chat): avoid misleading backend-offline network errors

### DIFF
--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -82,6 +82,8 @@
     "startService": "Start Service",
     "connectService": "Connect to Running Service",
     "serviceHint": "Chat requires the backend service running. Start this workspace's service or connect to an existing serve instance.",
+    "backendServiceHint": "Please confirm the backend service (openakita serve) is running and HTTP API port 18900 is reachable.",
+    "backendOnlineUpstreamHint": "Backend service is online (/api/health is reachable). This failure is more likely caused by upstream model network jitter or temporary provider unavailability. Please try again later.",
     "title": "AI Chat Assistant",
     "thoughtFor": "Thought for {{seconds}}s",
     "showChain": "Show thinking chain",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -82,6 +82,8 @@
     "startService": "启动服务",
     "connectService": "连接已有服务",
     "serviceHint": "聊天功能需要后台服务运行中。你可以启动本工作区的服务，或连接一个已运行的 serve 实例。",
+    "backendServiceHint": "请确认后台服务（openakita serve）已启动，且 HTTP API 端口（18900）可访问。",
+    "backendOnlineUpstreamHint": "后端服务已在线（/api/health 可访问）。本次失败更可能是模型上游网络波动或服务暂时不可用，请稍后重试。",
     "title": "AI 聊天助手",
     "thoughtFor": "思考了 {{seconds}}s",
     "showChain": "显示思维链",

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -2495,8 +2495,15 @@ export function ChatView({
         ));
       } else {
         const errMsg = e instanceof Error ? e.message : String(e);
+        let guidance = t("chat.backendServiceHint");
+        try {
+          const healthRes = await fetch(`${apiBase}/api/health`, { signal: AbortSignal.timeout(2000) });
+          if (healthRes.ok) {
+            guidance = t("chat.backendOnlineUpstreamHint");
+          }
+        } catch { /* health probe failed -> keep backend guidance */ }
         setMessages((prev) => prev.map((m) =>
-          m.id === assistantMsg.id ? { ...m, content: `连接失败：${errMsg}\n\n请确认后台服务（openakita serve）已启动，且 HTTP API 端口（18900）可访问。`, streaming: false } : m
+          m.id === assistantMsg.id ? { ...m, content: `连接失败：${errMsg}\n\n${guidance}`, streaming: false } : m
         ));
       }
     } finally {
@@ -2541,7 +2548,7 @@ export function ChatView({
         });
       }
     }
-  }, [inputText, pendingAttachments, isStreaming, activeConvId, planMode, selectedEndpoint, apiBase, slashCommands, thinkingMode, thinkingDepth]);
+  }, [inputText, pendingAttachments, isStreaming, activeConvId, planMode, selectedEndpoint, apiBase, slashCommands, thinkingMode, thinkingDepth, t]);
 
   // ── 处理用户回答 (ask_user) ──
   const handleAskAnswer = useCallback((msgId: string, answer: string) => {


### PR DESCRIPTION
## Summary
- probe `/api/health` when chat fetch throws a network error before showing guidance
- keep the existing backend-start hint only when health check is unreachable
- add localized `zh/en` copy for both backend-unreachable and backend-online-upstream cases

## Test plan
- [x] Trigger chat failure while backend is down; verify backend-start hint is shown
- [x] Trigger chat failure while backend health endpoint is reachable; verify upstream/network hint is shown
- [x] Verify no lint errors in modified files

Made with [Cursor](https://cursor.com)