### PR TITLE
docs(readme-cn): use gif quick setup preview

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -77,7 +77,7 @@ OpenAkita 提供跨平台的 **桌面终端** 应用（基于 Tauri + React）�
 不需要命令行，不需要改配置文件。**3 分钟从安装到对话**：
 
 <p align="center">
-  <img src="docs/assets/desktop_quick_config.png" alt="OpenAkita 快速配置 vs 完整配置" width="800" />
+  <img src="docs/assets/desktop_quick_config.gif" alt="OpenAkita 快速配置 vs 完整配置" width="800" />
 </p>
 
 <table>


### PR DESCRIPTION
## Summary
- Update `README_CN.md` to use the animated quick setup asset.
- Replace `docs/assets/desktop_quick_config.png` reference with `docs/assets/desktop_quick_config.gif`.

## Test plan
- [x] Verify README_CN renders the GIF preview.
- [x] Confirm the GIF asset path is valid in the repository.