### PR TITLE
feat(im): wework ws webhook media sender + voice processing timeout guard + audio format expansion

### DIFF
--- a/docs/FEISHU_IM_NOTES.md
+++ b/docs/FEISHU_IM_NOTES.md
@@ -146,6 +146,7 @@
 | 20 | `send_message` 媒体 fallthrough | voices/files/videos 无委托逻辑，掉入空文本分支 | 入口处 early return 委托给 send_voice/send_file | feishu.py |
 | 21 | INSERT 路径消息丢失 | `pending_user_inserts` 仅在工具执行间隙消费，无工具调用时滞留 | 任务完成后 `_rescue_pending_inserts` 回收到中断队列 | gateway.py |
 | 22 | 系统重启后消息被重复回复 | 飞书 WS 断连后重投递旧消息，`_seen_message_ids` 内存字典在重启时清空 | 增加 `create_time` 时间窗口防护：消息创建超过 120 秒的重投递直接丢弃（WebSocket 和 Webhook 路径均覆盖） | feishu.py |
+| 23 | 飞书语音消息处理卡死 | 飞书语音为 Opus 格式（`.opus`），`ensure_whisper_compatible` 只处理 SILK，Opus 直传 Whisper 导致 ffmpeg 内部长时间无输出；Gateway 无超时保护 | (a) `ensure_whisper_compatible` 新增 `.opus/.ogg/.amr/.webm/.wma/.aac` → WAV 的 ffmpeg 转换（30s 超时）(b) Gateway `_process_voice` 增加 60s 下载超时 + 120s 转写超时 (c) `asyncio.gather` 改为 `return_exceptions=True` 避免单个失败拖垮全部 | audio_utils.py, gateway.py |
 
 ---
 

--- a/docs/WEWORK_WS_IM_NOTES.md
+++ b/docs/WEWORK_WS_IM_NOTES.md
@@ -27,6 +27,9 @@
 | 图片回复 | `_prepare_image_items()` | base64 编码，仅在 `finish=true` 时附加，最多 10 张 |
 | 主动推送 (Markdown) | `_send_active_message()` | `cmd: "aibot_send_msg"`，自己生成 `req_id` |
 | response_url 回退 | `_response_url_fallback()` | WS 回复失败时通过 HTTP POST 回退 |
+| Webhook 图片发送 | `_WebhookSender.send_image()` | base64+md5 直发，需配置 `wework_ws_webhook_url` |
+| Webhook 语音发送 | `_WebhookSender.send_voice()` | 非 AMR 先转 AMR → upload_media → 发送 |
+| Webhook 文件发送 | `_WebhookSender.send_file()` | upload_media → 发送 |
 
 ### 3. 文件处理
 
@@ -169,6 +172,10 @@
 WEWORK_WS_ENABLED=true
 WEWORK_WS_BOT_ID=your_bot_id
 WEWORK_WS_SECRET=your_bot_secret
+
+# 可选：群机器人 Webhook URL（用于发送图片/语音/文件）
+# 在企业微信群设置 → 群机器人 → 添加机器人 → 获取 Webhook 地址
+WEWORK_WS_WEBHOOK_URL=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx
 ```
 
 ### im_bots JSON 配置（多 Bot 模式）
@@ -178,7 +185,8 @@ WEWORK_WS_SECRET=your_bot_secret
   "type": "wework_ws",
   "bot_id": "your_bot_id",
   "secret": "your_bot_secret",
-  "ws_url": "wss://openws.work.weixin.qq.com"
+  "ws_url": "wss://openws.work.weixin.qq.com",
+  "webhook_url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx"
 }
 ```
 
@@ -260,7 +268,7 @@ start()
 | 4 | 低 | 流式回复中断无恢复 | 连接断开时进行中的 stream 直接标记失败，尝试 response_url 回退 |
 | 5 | 低 | response_url 缓存无 TTL | 仅按数量清理（200 条），未按时间清理过期 URL |
 | 6 | 低 | 引用消息 (quote) 未解析 | 消息体中的 `quote` 字段已在 raw 中保留，但未映射到 `reply_to` |
-| 7 | 低 | 语音消息只取转文字结果 | `voice.content` 是企业微信自动转写的文字，原始音频不可获取 |
+| 7 | 低 | ~~语音消息只取转文字结果~~ (已优化) | `voice.content` 是企业微信自动转写的文字，原始音频不可获取。已统一 WS/Bot 输出格式：转写成功→直接用文本（无前缀），失败→`[语音消息，平台未能识别，请重新发送或改用文字]` |
 
 ---
 
@@ -277,6 +285,9 @@ start()
 - [ ] 心跳超时判定是否在发送前检查？
 - [ ] `_reject_all_pending` 是否在断开/重连时调用？
 - [ ] `is_mentioned` 是否保持为 True（平台已预过滤）？
+- [ ] 语音输出格式是否与 `wework_bot.py` 保持一致（转写成功→直接文本，失败→统一提示）？
+- [ ] `_WebhookSender` 是否在 `stop()` 时关闭 httpx 客户端？
+- [ ] 新增的媒体发送方法是否优先尝试 webhook 通道？
 
 ---
 

--- a/src/openakita/channels/adapters/wework_bot.py
+++ b/src/openakita/channels/adapters/wework_bot.py
@@ -991,13 +991,15 @@ class WeWorkBotAdapter(ChannelAdapter):
         企业微信已自动将语音转为文字。
         """
         voice_data = msg_data.get("voice", {})
-        transcription = voice_data.get("content", "")
+        transcription = voice_data.get("content", "").strip()
 
-        # 语音已自动转文字，作为文本消息处理
         if transcription:
-            content = MessageContent(text=f"[语音转文字] {transcription}")
+            content = MessageContent(text=transcription)
         else:
-            content = MessageContent(text="[语音消息，无法识别]")
+            logger.warning("[WeWorkBot] Voice transcription empty, msgid=%s", msgid)
+            content = MessageContent(
+                text="[语音消息，平台未能识别，请重新发送或改用文字]"
+            )
 
         is_direct_message = chat_type == "private"
         # 智能机器人 HTTP 回调只在群聊被 @时投递，故群语音消息 is_mentioned=True

--- a/src/openakita/channels/adapters/wework_ws.py
+++ b/src/openakita/channels/adapters/wework_ws.py
@@ -143,6 +143,157 @@ def _decrypt_file(encrypted: bytes, aes_key_b64: str) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# Webhook 辅助发送器（图片/语音/文件）
+# ---------------------------------------------------------------------------
+class _WebhookSender:
+    """通过企微群机器人 Webhook URL 发送富媒体消息（图片/语音/文件）。
+
+    WS 长连接的 aibot_respond_msg 只支持文本 stream + msg_item 图片，
+    且 msg_item 在当前版本不一定渲染。此类通过群 Webhook 实现可靠的
+    图片/语音/文件发送，作为辅助通道。
+
+    Webhook API 参考:
+    https://developer.work.weixin.qq.com/document/path/91770
+    """
+
+    def __init__(self, webhook_url: str):
+        from urllib.parse import parse_qs, urlparse
+
+        self._send_url = webhook_url
+        parsed = urlparse(webhook_url)
+        self._key = parse_qs(parsed.query).get("key", [""])[0]
+        self._upload_url = (
+            "https://qyapi.weixin.qq.com/cgi-bin/webhook/upload_media"
+            f"?key={self._key}&type={{media_type}}"
+        )
+        self._client: Any = None
+
+    async def _ensure_client(self):
+        if self._client is None or self._client.is_closed:
+            _import_httpx()
+            self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        return self._client
+
+    async def send_image(self, image_path: str) -> bool:
+        """发送图片（base64 + md5，无需上传）。"""
+        try:
+            path = Path(image_path)
+            if not path.exists():
+                logger.warning(f"[WebhookSender] Image not found: {image_path}")
+                return False
+            data = path.read_bytes()
+            b64 = base64.b64encode(data).decode("ascii")
+            md5 = hashlib.md5(data).hexdigest()
+            payload = {
+                "msgtype": "image",
+                "image": {"base64": b64, "md5": md5},
+            }
+            return await self._post(payload)
+        except Exception as e:
+            logger.error(f"[WebhookSender] send_image failed: {e}")
+            return False
+
+    async def send_voice(self, voice_path: str) -> bool:
+        """发送语音（需先转 AMR 再 upload_media 获取 media_id）。"""
+        try:
+            amr_path = await self._ensure_amr(voice_path)
+            media_id = await self._upload_media(amr_path, "voice")
+            if not media_id:
+                return False
+            payload = {
+                "msgtype": "voice",
+                "voice": {"media_id": media_id},
+            }
+            return await self._post(payload)
+        except Exception as e:
+            logger.error(f"[WebhookSender] send_voice failed: {e}")
+            return False
+
+    async def send_file(self, file_path: str) -> bool:
+        """发送文件（upload_media 获取 media_id）。"""
+        try:
+            media_id = await self._upload_media(file_path, "file")
+            if not media_id:
+                return False
+            payload = {
+                "msgtype": "file",
+                "file": {"media_id": media_id},
+            }
+            return await self._post(payload)
+        except Exception as e:
+            logger.error(f"[WebhookSender] send_file failed: {e}")
+            return False
+
+    async def _upload_media(self, file_path: str, media_type: str) -> str | None:
+        """上传媒体文件到企微获取 media_id。"""
+        client = await self._ensure_client()
+        url = self._upload_url.format(media_type=media_type)
+        path = Path(file_path)
+        try:
+            files = {"media": (path.name, path.read_bytes())}
+            resp = await client.post(url, files=files)
+            result = resp.json()
+            if result.get("errcode", 0) != 0:
+                logger.error(
+                    f"[WebhookSender] upload_media failed: "
+                    f"{result.get('errcode')} {result.get('errmsg')}"
+                )
+                return None
+            media_id = result.get("media_id", "")
+            logger.info(f"[WebhookSender] Uploaded {media_type}: {path.name} → {media_id[:20]}...")
+            return media_id
+        except Exception as e:
+            logger.error(f"[WebhookSender] upload_media error: {e}")
+            return None
+
+    async def _ensure_amr(self, voice_path: str) -> str:
+        """确保语音文件为 AMR 格式（Webhook voice 要求 AMR）。"""
+        path = Path(voice_path)
+        if path.suffix.lower() == ".amr":
+            return voice_path
+
+        amr_path = str(path.with_suffix(".amr"))
+        if Path(amr_path).exists() and Path(amr_path).stat().st_size > 0:
+            return amr_path
+
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg", "-i", voice_path,
+            "-ar", "8000", "-ac", "1", "-ab", "12.2k",
+            "-y", amr_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        if proc.returncode != 0:
+            logger.error(f"[WebhookSender] AMR conversion failed: {stderr[:300]}")
+            raise RuntimeError(f"AMR conversion failed for {path.name}")
+        logger.info(f"[WebhookSender] Converted to AMR: {path.name}")
+        return amr_path
+
+    async def _post(self, payload: dict) -> bool:
+        """发送 Webhook 请求。"""
+        client = await self._ensure_client()
+        try:
+            resp = await client.post(self._send_url, json=payload)
+            result = resp.json()
+            if result.get("errcode", 0) != 0:
+                logger.error(
+                    f"[WebhookSender] Post failed: "
+                    f"{result.get('errcode')} {result.get('errmsg')}"
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.error(f"[WebhookSender] Post error: {e}")
+            return False
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+
+# ---------------------------------------------------------------------------
 # 适配器
 # ---------------------------------------------------------------------------
 class WeWorkWsAdapter(ChannelAdapter):
@@ -169,6 +320,7 @@ class WeWorkWsAdapter(ChannelAdapter):
         channel_name: str | None = None,
         bot_id_alias: str | None = None,
         agent_profile_id: str = "default",
+        webhook_url: str = "",
     ):
         super().__init__(
             channel_name=channel_name,
@@ -179,6 +331,11 @@ class WeWorkWsAdapter(ChannelAdapter):
         self.config = WeWorkWsConfig(bot_id=bot_id, secret=secret, ws_url=ws_url)
         self.media_dir = Path(media_dir) if media_dir else Path("data/media/wework_ws")
         self.media_dir.mkdir(parents=True, exist_ok=True)
+
+        # Webhook 辅助发送器（用于发送图片/语音/文件）
+        self._webhook: _WebhookSender | None = (
+            _WebhookSender(webhook_url) if webhook_url else None
+        )
 
         # WebSocket state
         self._ws: Any = None
@@ -236,6 +393,8 @@ class WeWorkWsAdapter(ChannelAdapter):
         if self._ws:
             await self._ws.close()
             self._ws = None
+        if self._webhook:
+            await self._webhook.close()
         self._reject_all_pending("adapter stopped")
         logger.info("WeWork WS adapter stopped")
 
@@ -533,8 +692,17 @@ class WeWorkWsAdapter(ChannelAdapter):
 
         if msgtype == "voice":
             voice_data = body.get("voice", {})
+            platform_text = voice_data.get("content", "").strip()
+            if platform_text:
+                return (MessageContent(text=platform_text), media_list)
+            logger.warning(
+                "[WeWorkWS] Voice transcription empty, msgid=%s",
+                body.get("msgid"),
+            )
             return (
-                MessageContent(text=voice_data.get("content", "[语音消息]")),
+                MessageContent(
+                    text="[语音消息，平台未能识别，请重新发送或改用文字]"
+                ),
                 media_list,
             )
 
@@ -637,8 +805,15 @@ class WeWorkWsAdapter(ChannelAdapter):
         reply_to: str | None = None,
         **kwargs,
     ) -> str:
-        """Queue image for the next stream reply (if req_id and msg_item enabled),
-        else markdown fallback."""
+        """Send image: prefer webhook, fallback to msg_item or markdown hint."""
+        # 1. Webhook 通道（最可靠）
+        if self._webhook:
+            ok = await self._webhook.send_image(image_path)
+            if ok:
+                logger.info(f"[send_image] Sent via webhook: {Path(image_path).name}")
+                return "webhook:image_sent"
+
+        # 2. msg_item 内联（stream reply 中）
         from openakita.config import settings
 
         req_id = (kwargs.get("metadata") or {}).get("req_id", "")
@@ -660,6 +835,8 @@ class WeWorkWsAdapter(ChannelAdapter):
                 f"compressed={len(data)}, b64={len(b64)}"
             )
             return f"queued:{req_id}"
+
+        # 3. Markdown hint fallback
         path = Path(image_path)
         label = caption or path.name
         if req_id:
@@ -718,7 +895,14 @@ class WeWorkWsAdapter(ChannelAdapter):
         caption: str | None = None,
         **kwargs,
     ) -> str:
-        """Send a file. In reply context, silently skip (agent text reply suffices)."""
+        """Send a file: prefer webhook, fallback to markdown hint."""
+        # Webhook 通道
+        if self._webhook:
+            ok = await self._webhook.send_file(file_path)
+            if ok:
+                logger.info(f"[send_file] Sent via webhook: {Path(file_path).name}")
+                return "webhook:file_sent"
+
         req_id = (kwargs.get("metadata") or {}).get("req_id", "")
         if req_id:
             logger.info(
@@ -740,6 +924,25 @@ class WeWorkWsAdapter(ChannelAdapter):
         desc = f"> 📎 **{label}**{size_part}\n> （企业微信长连接暂不支持发送文件）"
         logger.debug(f"WS long-connection does not support file, sending hint: {path.name}")
         return await self._send_active_message(chat_id, desc)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        voice_path: str,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        **kwargs,
+    ) -> str:
+        """Send voice: only available via webhook."""
+        if self._webhook:
+            ok = await self._webhook.send_voice(voice_path)
+            if ok:
+                logger.info(f"[send_voice] Sent via webhook: {Path(voice_path).name}")
+                return "webhook:voice_sent"
+            logger.warning(f"[send_voice] Webhook send_voice failed: {Path(voice_path).name}")
+        raise NotImplementedError(
+            "WeWork WS adapter requires wework_ws_webhook_url to send voice messages"
+        )
 
     async def _send_stream_reply(
         self, req_id: str, text: str, message: OutgoingMessage

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -2316,20 +2316,27 @@ class MessageGateway:
             try:
                 async with sem:
                     if not voice.local_path:
-                        local_path = await adapter.download_media(voice)
+                        local_path = await asyncio.wait_for(
+                            adapter.download_media(voice), timeout=60
+                        )
                         voice.local_path = str(local_path)
                         logger.info(f"Voice downloaded: {voice.local_path}")
 
-                # 转写放在 download 之后；转写内部已使用线程池，不阻塞事件循环
                 if voice.local_path and not voice.transcription:
-                    transcription = await self._transcribe_voice_local(voice.local_path)
+                    transcription = await asyncio.wait_for(
+                        self._transcribe_voice_local(voice.local_path), timeout=120
+                    )
                     if transcription:
                         voice.transcription = transcription
                         logger.info(f"Voice transcribed: {transcription}")
                     else:
                         voice.transcription = "[语音识别失败]"
+            except TimeoutError:
+                logger.error(f"Voice processing timed out: {voice.filename}")
+                voice.transcription = "[语音处理超时]"
             except Exception as e:
                 logger.error(f"Failed to process voice: {e}")
+                voice.transcription = "[语音处理失败]"
 
         async def _process_image(img) -> None:
             try:
@@ -2375,7 +2382,7 @@ class MessageGateway:
             tasks.append(_process_file(fil))
 
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=False)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _transcribe_voice_local(self, audio_path: str) -> str | None:
         """

--- a/src/openakita/channels/media/audio_utils.py
+++ b/src/openakita/channels/media/audio_utils.py
@@ -88,12 +88,45 @@ def _silk_to_wav_pilk(silk_path: str, wav_path: str) -> bool:
             pass
 
 
+def _ffmpeg_to_wav(src_path: str, wav_path: str) -> bool:
+    """通过 ffmpeg 将非标准音频格式转换为 16kHz mono WAV。"""
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        logger.warning("ffmpeg not available for audio conversion")
+        return False
+
+    cmd = [
+        "ffmpeg", "-i", src_path,
+        "-ar", "16000", "-ac", "1", "-sample_fmt", "s16",
+        "-y", wav_path,
+    ]
+    try:
+        extra: dict = {}
+        if os.name == "nt":
+            extra["creationflags"] = subprocess.CREATE_NO_WINDOW
+        subprocess.run(cmd, capture_output=True, timeout=30, check=True, **extra)
+        logger.info(f"Audio converted via ffmpeg: {Path(src_path).name} → {Path(wav_path).name}")
+        return True
+    except subprocess.TimeoutExpired:
+        logger.error(f"ffmpeg conversion timed out for {Path(src_path).name}")
+        return False
+    except subprocess.CalledProcessError as e:
+        logger.error(f"ffmpeg conversion failed for {Path(src_path).name}: {e.stderr[:300] if e.stderr else e}")
+        return False
+    except Exception as e:
+        logger.error(f"ffmpeg conversion error: {e}")
+        return False
+
+
 def ensure_whisper_compatible(audio_path: str) -> str:
     """
     确保音频文件可被 Whisper (ffmpeg) 处理。
 
-    - 如果是 SILK 格式，自动转换为 WAV 并返回 WAV 路径
-    - 如果不是 SILK 格式，原样返回
+    - SILK 格式 → pilk 转换为 WAV
+    - opus/ogg/amr/webm/wma/aac → ffmpeg 转换为 WAV
+    - wav/mp3/flac 等标准格式 → 原样返回
 
     Args:
         audio_path: 原始音频文件路径
@@ -101,28 +134,43 @@ def ensure_whisper_compatible(audio_path: str) -> str:
     Returns:
         可被 Whisper 处理的音频文件路径（可能是转换后的 WAV）
     """
-    if not is_silk_file(audio_path):
+    # 1. SILK 格式特殊处理（pilk 转换）
+    if is_silk_file(audio_path):
+        logger.info(f"Detected SILK format: {Path(audio_path).name}, converting to WAV...")
+
+        src = Path(audio_path)
+        wav_path = str(src.with_suffix(".wav"))
+
+        if os.path.exists(wav_path) and os.path.getsize(wav_path) > 0:
+            logger.info(f"Using cached WAV: {wav_path}")
+            return wav_path
+
+        if _silk_to_wav_pilk(str(src), wav_path):
+            return wav_path
+
+        logger.warning(
+            f"SILK conversion failed for {src.name}. "
+            "Falling back to original file (may fail with ffmpeg)."
+        )
         return audio_path
 
-    logger.info(f"Detected SILK format: {Path(audio_path).name}, converting to WAV...")
-
-    # 生成 WAV 输出路径（与源文件同目录，避免跨盘）
+    # 2. 非标准格式 → ffmpeg 转 WAV（飞书 Opus、钉钉 OGG 等）
     src = Path(audio_path)
-    wav_path = str(src.with_suffix(".wav"))
+    suffix = src.suffix.lower()
+    need_convert = {".opus", ".ogg", ".amr", ".webm", ".wma", ".aac"}
+    if suffix in need_convert:
+        wav_path = str(src.with_suffix(".wav"))
+        if os.path.exists(wav_path) and os.path.getsize(wav_path) > 0:
+            logger.info(f"Using cached WAV: {wav_path}")
+            return wav_path
 
-    # 如果已转换过且文件存在，直接返回
-    if os.path.exists(wav_path) and os.path.getsize(wav_path) > 0:
-        logger.info(f"Using cached WAV: {wav_path}")
-        return wav_path
+        if _ffmpeg_to_wav(str(src), wav_path):
+            return wav_path
 
-    if _silk_to_wav_pilk(str(src), wav_path):
-        return wav_path
+        logger.warning(f"ffmpeg conversion failed for {src.name}, returning original")
+        return audio_path
 
-    # 转换失败，返回原路径（让 Whisper/ffmpeg 尝试，虽然大概率还是会失败）
-    logger.warning(
-        f"SILK conversion failed for {src.name}. "
-        "Falling back to original file (may fail with ffmpeg)."
-    )
+    # 3. wav/mp3/flac 等标准格式原样返回
     return audio_path
 
 

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -293,6 +293,10 @@ class Settings(BaseSettings):
         default=False,
         description="流式回复中使用 msg_item 发送图片（当前企业微信版本可能不渲染，默认关闭）",
     )
+    wework_ws_webhook_url: str = Field(
+        default="",
+        description="企业微信群机器人 Webhook URL（用于 WS 模式下发送图片/语音/文件）",
+    )
 
     # 钉钉
     dingtalk_enabled: bool = Field(default=False, description="是否启用钉钉")

--- a/src/openakita/main.py
+++ b/src/openakita/main.py
@@ -512,6 +512,7 @@ def _create_bot_adapter(bot_type: str, creds: dict, *, channel_name: str, bot_id
             secret=creds.get("secret", ""),
             ws_url=creds.get("ws_url", "wss://openws.work.weixin.qq.com"),
             channel_name=channel_name, bot_id_alias=bot_id, agent_profile_id=agent_profile_id,
+            webhook_url=creds.get("webhook_url", ""),
         )
     elif bot_type == "onebot":
         from .channels.adapters import OneBotAdapter
@@ -731,6 +732,7 @@ async def start_im_channels(agent_or_master):
                 wework_ws = WeWorkWsAdapter(
                     bot_id=settings.wework_ws_bot_id,
                     secret=settings.wework_ws_secret,
+                    webhook_url=settings.wework_ws_webhook_url,
                 )
                 await _message_gateway.register_adapter(wework_ws)
                 adapters_started.append("wework_ws")


### PR DESCRIPTION
## Summary

- Added WebhookSender for WeWork WS adapter to send images/voice/files via group bot webhook
- Added voice processing timeout guards in Gateway (60s download + 120s transcription)
- Expanded audio format support: opus/ogg/amr/webm/wma/aac now auto-convert to WAV via ffmpeg
- Unified WeWork Bot voice output format (no more prefix, consistent failure message)
- Updated dev notes for Feishu and WeWork integrations

## Changes

- **wework_ws.py**: New _WebhookSender class (image/voice/file), send_voice method, webhook fallback chain
- **gateway.py**: asyncio.wait_for timeouts on download/transcription, return_exceptions=True
- **audio_utils.py**: New _ffmpeg_to_wav(), expanded ensure_whisper_compatible() for 6 additional formats
- **wework_bot.py**: Unified voice transcription output format
- **config.py / main.py**: New wework_ws_webhook_url setting
- **docs**: Updated FEISHU_IM_NOTES.md and WEWORK_WS_IM_NOTES.md

## Test Plan

- [ ] Verify webhook image/voice/file sending via WeWork group bot
- [ ] Verify voice download timeout (>60s) and transcription timeout (>120s) handling
- [ ] Verify opus/ogg/amr audio files correctly convert to WAV for Whisper
- [ ] Verify WeWork Bot voice output format consistency

Made with [Cursor](https://cursor.com)