### PR TITLE
fix(backport): v1.26.x → main PR-1/10 critical API/state/onboarding fixes

### DIFF
--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -250,7 +250,7 @@ fn write_root_config(config: &RootConfig) -> Result<(), String> {
 
     let p = root_config_path();
     let data = serde_json::to_string_pretty(config).map_err(|e| format!("serialize root config failed: {e}"))?;
-    fs::write(&p, data).map_err(|e| format!("write root_config.json failed: {e}"))?;
+    atomic_write_with_backup(&p, data.as_bytes())?;
 
     // 同步写入纯文本文件，供 NSIS 安装脚本简单读取（无需解析 JSON）
     // NSIS Unicode 模式的 FileRead 在无 BOM 时按 ANSI(系统代码页) 解读，
@@ -2151,10 +2151,71 @@ fn openakita_stop_all_processes() -> Vec<u32> {
 
 fn read_state_file() -> AppStateFile {
     let p = state_file_path();
-    let Ok(content) = fs::read_to_string(&p) else {
-        return AppStateFile::default();
+    if let Ok(content) = fs::read_to_string(&p) {
+        if let Ok(state) = serde_json::from_str::<AppStateFile>(&content) {
+            if !state.workspaces.is_empty() {
+                return state;
+            }
+            // workspaces is empty — could be a truncated/corrupted write.
+            // Fall through to disk recovery, but preserve other fields.
+            let recovered = rebuild_state_from_disk(Some(state));
+            if !recovered.workspaces.is_empty() {
+                eprintln!(
+                    "state.json had empty workspaces but {} workspace dir(s) found on disk — recovered",
+                    recovered.workspaces.len()
+                );
+                let _ = write_state_file(&recovered);
+            }
+            return recovered;
+        }
+        // JSON parse failed (truncated / corrupted file)
+        eprintln!("warning: state.json is corrupted, attempting disk recovery");
+    }
+    // File missing or unreadable — try to recover from workspaces/ directory
+    let recovered = rebuild_state_from_disk(None);
+    if !recovered.workspaces.is_empty() {
+        eprintln!(
+            "state.json missing but {} workspace dir(s) found on disk — recovered",
+            recovered.workspaces.len()
+        );
+        let _ = write_state_file(&recovered);
+    }
+    recovered
+}
+
+/// Scan workspaces/ directory to rebuild state when state.json is missing or corrupted.
+/// A subdirectory is considered a valid workspace only if it contains a `data/` child.
+fn rebuild_state_from_disk(partial: Option<AppStateFile>) -> AppStateFile {
+    let mut state = partial.unwrap_or_default();
+    let ws_dir = workspaces_dir();
+    let Ok(entries) = fs::read_dir(&ws_dir) else {
+        return state;
     };
-    serde_json::from_str(&content).unwrap_or_default()
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if !path.join("data").exists() {
+            continue;
+        }
+        let id = entry.file_name().to_string_lossy().to_string();
+        if state.workspaces.iter().any(|w| w.id == id) {
+            continue;
+        }
+        state.workspaces.push(WorkspaceMeta {
+            id: id.clone(),
+            name: id.clone(),
+        });
+    }
+    if state.current_workspace_id.is_none() && !state.workspaces.is_empty() {
+        // Prefer "default" if it exists, otherwise pick the first one
+        let preferred = state.workspaces.iter()
+            .find(|w| w.id == "default")
+            .unwrap_or(&state.workspaces[0]);
+        state.current_workspace_id = Some(preferred.id.clone());
+    }
+    state
 }
 
 fn write_state_file(state: &AppStateFile) -> Result<(), String> {
@@ -2162,8 +2223,42 @@ fn write_state_file(state: &AppStateFile) -> Result<(), String> {
     if let Some(parent) = p.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create_dir_all failed: {e}"))?;
     }
-    let data = serde_json::to_string_pretty(state).map_err(|e| format!("serialize failed: {e}"))?;
-    fs::write(&p, data).map_err(|e| format!("write state.json failed: {e}"))?;
+    let data = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("serialize failed: {e}"))?;
+    atomic_write_with_backup(&p, data.as_bytes())
+}
+
+/// Crash-safe file write: backup existing file, write to .tmp, then atomic rename.
+/// On Windows rename failure (file locked), retries up to 3 times before falling back
+/// to direct write.
+fn atomic_write_with_backup(path: &Path, content: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create parent dir failed: {e}"))?;
+    }
+    if path.exists() {
+        let bak = path.with_extension("json.bak");
+        let _ = fs::copy(path, &bak);
+    }
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, content).map_err(|e| format!("write tmp failed: {e}"))?;
+    for attempt in 0..3u64 {
+        match fs::rename(&tmp, path) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if attempt < 2 {
+                    std::thread::sleep(std::time::Duration::from_millis(100 * (attempt + 1)));
+                } else {
+                    eprintln!("atomic rename failed after 3 retries ({e}), falling back to direct write");
+                    if let Err(e2) = fs::write(path, content) {
+                        let _ = fs::remove_file(&tmp);
+                        return Err(format!("write failed: {e2}"));
+                    }
+                    let _ = fs::remove_file(&tmp);
+                    return Ok(());
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/apps/setup-center/src/App.tsx
+++ b/apps/setup-center/src/App.tsx
@@ -3893,7 +3893,6 @@ function MainApp() {
         if (earlyProbe) {
           log("[OK] 后端已在运行（由 ob-welcome 提前启动）");
           setServiceStatus({ running: true, pid: null, pidFile: "" });
-          setDataMode("remote");
           httpReady = true;
           updateTask("service-start", { status: "done", detail: "已在运行" });
           logTask("启动后端服务", "done", "已在运行");
@@ -4336,7 +4335,6 @@ function MainApp() {
                             const res = await fetch("http://127.0.0.1:18900/api/health", { signal: AbortSignal.timeout(3000) });
                             if (res.ok) {
                               setServiceStatus({ running: true, pid: null, pidFile: "" });
-                              setDataMode("remote");
                               break;
                             }
                           } catch { /* not ready yet */ }

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -29,7 +29,10 @@ router = APIRouter()
 @router.get("/api/commands")
 async def list_commands():
     """Return available slash commands for the Desktop UI."""
-    from ...commands.registry import CommandScope, get_commands
+    try:
+        from ...commands.registry import CommandScope, get_commands
+    except ImportError:
+        return []
 
     return [
         {
@@ -412,7 +415,6 @@ async def _stream_chat(
         conversation_id = chat_request.conversation_id or f"api_{_uuid.uuid4().hex[:12]}"
         session = None
         session_messages_history: list[dict] = []
-        _msg_added = True
 
         if session_manager and conversation_id:
             try:
@@ -426,25 +428,14 @@ async def _stream_chat(
                     if chat_request.agent_profile_id:
                         _apply_agent_profile(session, chat_request.agent_profile_id)
 
-                    # 先添加用户消息，再获取完整历史（含当前消息）
-                    # 这与 IM 路径一致：gateway 先 add_message，再传 session_messages
                     if chat_request.message:
-                        _msg_added = session.add_message("user", chat_request.message)
+                        session.add_message("user", chat_request.message)
                     session_messages_history = (
                         list(session.context.messages) if hasattr(session, "context") else []
                     )
                     session_manager.mark_dirty()
             except Exception as e:
                 logger.warning(f"[Chat API] Session management error: {e}")
-
-        # ── Dedup short-circuit: skip LLM if message is identical duplicate ──
-        if session and not _msg_added and chat_request.message:
-            logger.info(
-                "[Chat API] Dedup: identical message within time window, skipping LLM"
-            )
-
-            yield _sse("done")
-            return
 
         # ── Background agent task: decoupled from SSE lifecycle ──
         async def _agent_runner():


### PR DESCRIPTION
# PR-1 / 10：v1.26.x → main 关键 API / 状态 / Onboarding 修复

本 PR 是 v1.26.x → main 系列回填 10 个 PR 的第 1 个，仅包含 3 个不可拆分的关键 fix，对应当前 main 上明确缺失或回归的问题。后续 PR-2 ~ PR-10 会在本 PR 合并后基于新 main rebase 分别提交。

## Commits（不 squash，请用 Rebase merge 保留历史）

| # | Commit | 主题 |
|---|---|---|
| 1 | `8902e7480` | `fix(api): backport v1.26.x e08f5689 - remove broken dedup short-circuit` |
| 2 | `2dddcd26` | `fix(state): atomic write + disk recovery for state.json to prevent data loss on crash` |
| 3 | `d57f0480` | `fix(onboarding): remove incorrect setDataMode('remote') in Tauri local service paths` |

## 修复内容

### 1. `src/openakita/api/routes/chat.py`：去除错误的 dedup 短路（修复 #427）
- `Session.add_message()` 返回 `None`，原代码 `_msg_added = session.add_message(...)` 让 `_msg_added` 永远为 falsy
- 后续 `if session and not _msg_added and chat_request.message:` 会无条件触发短路 → **LLM 永远不被调用**
- 同时把 `from ...commands.registry import CommandScope, get_commands` 包了 `try/except ImportError`，避免该模块缺失时 500
- 与 v1.26.x `e08f56895c0d2405c033346dc5e646bc77b1960a` 等价；冲突点 `_is_multi_agent_enabled()` 在 main 上不存在，保留 main 简单条件 `if chat_request.agent_profile_id:`

### 2. `apps/setup-center/src-tauri/src/main.rs`：`state.json` 原子写 + 磁盘恢复
- 原 `fs::write` 是 truncate-then-write，断电 / 进程杀死会留下 0 字节或残缺 JSON
- `is_first_run()` 完全依赖 `state.json` 中是否有 workspaces，破坏后会触发 onboarding，让用户感知"IM/LLM/Memory 数据全没了"（实际磁盘上还在）
- 改动：
  - `write_state_file` / `write_root_config` 切到 `atomic_write_with_backup`（tmp + rename + `.bak`）
  - `read_state_file` 在文件丢失/为空/损坏时自动扫描 `workspaces/` 目录重建注册表
- 干净 cherry-pick `486346ba`

### 3. `apps/setup-center/src/App.tsx`：去掉 onboarding 中错误的 `setDataMode('remote')`
- `earlyProbe` 与 `ob-welcome` 早启分支在本地后端健康检查通过后调用了 `setDataMode('remote')`
- 把"HTTP API 可达"和"远程模式"混为一谈，导致：
  1. 顶栏错误显示 `remote` badge
  2. 心跳跳过 IPC PID alive check（过早判定 DEAD 而非 DEGRADED）
  3. 服务重启绕过 IPC 进程管理
- `serviceStatus.running=true` 已经让 `shouldUseHttpApi()` 为真，原本就不需要 `setDataMode('remote')`
- 干净 cherry-pick `96c19cfa`

## 影响面

| 文件 | +/- |
|---|---|
| `apps/setup-center/src-tauri/src/main.rs` | +103 / -4 |
| `apps/setup-center/src/App.tsx` | -2 |
| `src/openakita/api/routes/chat.py` | +3 / -16 |

## Test Plan
- [ ] **后端**：`pytest tests/unit -k chat -q`（之前已在本地通过 1256/1275 测试，剩余 19 个失败为 main 上预先存在的 `test_avatar_speaker_providers.py`，与本 PR 无关）
- [ ] **Tauri 桌面端**：手工模拟 `state.json` 写入过程被 kill，重启 Setup Center → 不应进入 onboarding，应自动从 `workspaces/` 重建
- [ ] **Onboarding**：全新工作区进入引导流程 → 顶栏不应误显示 `remote` 模式
- [ ] **聊天回归**：随便发一条消息 → LLM 必须真的被调用（旧版本会被 dedup 短路吞掉）

## 注意
- 本 PR **必须最先合并**，PR-2 / PR-3 都依赖本 PR
- 推荐 **Rebase merge**（不要 Squash，保留 3 个 commit 历史方便回滚单个 fix）
- 合并后我会 rebase `backport/v126/pr2-env-config-write` 到新 main 再开 PR-2

## 来源
- v1.26.x `e08f5689` / `486346ba` / `96c19cfa`
- 完整 backport 计划：`v126-to-main-backport_0ebdaaa9.plan.md`
