### PR TITLE
fix(backport): v1.26.x → main PR-2/10 .env config write boundaries (#428)

### DIFF
--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -947,35 +947,43 @@ def _create_settings_safe() -> Settings:
     """
     import re
 
-    try:
-        return Settings()
-    except Exception as first_err:
-        err_msg = str(first_err)
-        logger.error(f"[Config] Settings init failed: {err_msg}")
+    max_retries = 3
+    last_err: Exception | None = None
 
-        env_path = Path.cwd() / ".env"
-        if not env_path.exists():
-            raise
-
-        field_match = re.search(r'field "(\w+)"', err_msg)
-        if not field_match:
-            raise
-
-        bad_field = field_match.group(1).upper()
-        logger.warning(f"[Config] Removing poisoned key '{bad_field}' from .env and retrying")
-
+    for attempt in range(max_retries + 1):
         try:
-            lines = env_path.read_text(encoding="utf-8", errors="replace").splitlines()
-            cleaned = [
-                ln for ln in lines
-                if not ln.strip().startswith(f"{bad_field}=")
-            ]
-            env_path.write_text("\n".join(cleaned) + "\n", encoding="utf-8")
-        except Exception as io_err:
-            logger.error(f"[Config] Failed to repair .env: {io_err}")
-            raise first_err from io_err
+            return Settings()
+        except Exception as e:
+            last_err = e
+            if attempt == max_retries:
+                break
 
-        return Settings()
+            err_msg = str(e)
+            logger.error(f"[Config] Settings init failed (attempt {attempt + 1}): {err_msg}")
+
+            env_path = Path.cwd() / ".env"
+            if not env_path.exists():
+                break
+
+            field_match = re.search(r'field "(\w+)"', err_msg)
+            if not field_match:
+                break
+
+            bad_field = field_match.group(1).upper()
+            logger.warning(f"[Config] Removing poisoned key '{bad_field}' from .env and retrying")
+
+            try:
+                lines = env_path.read_text(encoding="utf-8", errors="replace").splitlines()
+                cleaned = [
+                    ln for ln in lines
+                    if not ln.strip().startswith(f"{bad_field}=")
+                ]
+                env_path.write_text("\n".join(cleaned) + "\n", encoding="utf-8")
+            except Exception as io_err:
+                logger.error(f"[Config] Failed to repair .env: {io_err}")
+                break
+
+    raise last_err  # type: ignore[misc]
 
 
 # 全局配置实例

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -937,8 +937,49 @@ class RuntimeState:
             logger.error(f"[RuntimeState] Failed to load: {e}")
 
 
+def _create_settings_safe() -> Settings:
+    """Create the global Settings instance with recovery for poisoned .env files.
+
+    If a field in .env has an unparseable value (e.g. Python repr instead of JSON
+    for complex types), remove that field from .env and retry. This handles the
+    case where _PERSISTABLE_KEYS fields were incorrectly written to .env by older
+    code — those fields are managed by RuntimeState, not .env.
+    """
+    import re
+
+    try:
+        return Settings()
+    except Exception as first_err:
+        err_msg = str(first_err)
+        logger.error(f"[Config] Settings init failed: {err_msg}")
+
+        env_path = Path.cwd() / ".env"
+        if not env_path.exists():
+            raise
+
+        field_match = re.search(r'field "(\w+)"', err_msg)
+        if not field_match:
+            raise
+
+        bad_field = field_match.group(1).upper()
+        logger.warning(f"[Config] Removing poisoned key '{bad_field}' from .env and retrying")
+
+        try:
+            lines = env_path.read_text(encoding="utf-8", errors="replace").splitlines()
+            cleaned = [
+                ln for ln in lines
+                if not ln.strip().startswith(f"{bad_field}=")
+            ]
+            env_path.write_text("\n".join(cleaned) + "\n", encoding="utf-8")
+        except Exception as io_err:
+            logger.error(f"[Config] Failed to repair .env: {io_err}")
+            raise first_err from io_err
+
+        return Settings()
+
+
 # 全局配置实例
-settings = Settings()
+settings = _create_settings_safe()
 
 # 全局运行时状态管理器
 runtime_state = RuntimeState()

--- a/src/openakita/tools/handlers/config.py
+++ b/src/openakita/tools/handlers/config.py
@@ -514,10 +514,11 @@ class ConfigHandler:
                 f"[ConfigHandler] set: updated {len(env_entries)} .env entries, reloaded fields: {changed_fields}"
             )
 
-            try:
-                runtime_state.load()
-            except Exception as e:
-                logger.warning(f"[ConfigHandler] runtime_state.load failed: {e}")
+            if not persist_dirty:
+                try:
+                    runtime_state.load()
+                except Exception as e:
+                    logger.warning(f"[ConfigHandler] runtime_state.load failed: {e}")
 
         if persist_dirty:
             try:

--- a/src/openakita/tools/handlers/config.py
+++ b/src/openakita/tools/handlers/config.py
@@ -178,6 +178,14 @@ def _unique_env_key(base: str, used: set[str]) -> str:
     return f"{base}_{int(__import__('time').time())}"
 
 
+def _serialize_env_value(value: Any) -> str:
+    """Serialize a config value for .env storage. Uses json.dumps for complex
+    types (list/dict) to produce valid JSON instead of Python repr."""
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
 def _update_env_content(existing: str, entries: dict[str, str]) -> str:
     """合并 entries 到现有 .env 内容（保留注释和顺序）"""
     lines = existing.splitlines()
@@ -429,37 +437,36 @@ class ConfigHandler:
     # set: 修改配置
     # ------------------------------------------------------------------
     def _set_config(self, params: dict) -> str:
-        from ...config import Settings, runtime_state, settings
+        from ...config import Settings, _PERSISTABLE_KEYS, runtime_state, settings
 
         updates = params.get("updates")
         if not updates or not isinstance(updates, dict):
             return '❌ updates 参数缺失或格式错误，应为 {"KEY": "value"} 字典'
 
-        # 项目根目录
         project_root = Path(settings.project_root)
         env_path = project_root / ".env"
 
         changes: list[str] = []
         env_entries: dict[str, str] = {}
+        persist_dirty = False
         restart_needed: list[str] = []
         errors: list[str] = []
+
+        _persistable_set = set(_PERSISTABLE_KEYS)
 
         for env_key, new_value in updates.items():
             field_name = env_key.lower()
 
-            # 黑名单检查
             if field_name in _READONLY_FIELDS:
                 errors.append(f"`{env_key}`: 只读字段，不允许修改")
                 continue
 
-            # 检查字段是否存在
             if field_name not in Settings.model_fields:
                 errors.append(f"`{env_key}`: 未知配置项。可用 action=discover 查看可配置项")
                 continue
 
             field_info = Settings.model_fields[field_name]
 
-            # 类型校验和转换
             _, err = self._validate_value(field_name, field_info, new_value)
             if err:
                 errors.append(f"`{env_key}`: {err}")
@@ -473,7 +480,12 @@ class ConfigHandler:
 
             new_display = _mask_value(new_value) if _is_sensitive(field_name) else str(new_value)
 
-            env_entries[env_key.upper()] = str(new_value)
+            if field_name in _persistable_set:
+                setattr(settings, field_name, new_value)
+                persist_dirty = True
+            else:
+                env_entries[env_key.upper()] = _serialize_env_value(new_value)
+
             changes.append(f"- `{env_key.upper()}`: {old_display} → {new_display}")
 
             if _needs_restart(field_name, field_info):
@@ -484,7 +496,6 @@ class ConfigHandler:
             if not changes:
                 return f"❌ 所有修改都被拒绝:\n{error_lines}"
 
-        # 写入 .env
         if env_entries:
             existing = ""
             if env_path.exists():
@@ -492,31 +503,26 @@ class ConfigHandler:
             new_content = _update_env_content(existing, env_entries)
             env_path.write_text(new_content, encoding="utf-8")
 
-            # 同步到 os.environ
             for key, value in env_entries.items():
                 if value:
                     os.environ[key] = value
                 elif key in os.environ:
                     del os.environ[key]
 
-            # 热重载 settings（reload 已跳过 _PERSISTABLE_KEYS 字段）
             changed_fields = settings.reload()
             logger.info(
-                f"[ConfigHandler] set: updated {len(env_entries)} entries, reloaded fields: {changed_fields}"
+                f"[ConfigHandler] set: updated {len(env_entries)} .env entries, reloaded fields: {changed_fields}"
             )
 
-            # 双重保险：恢复运行时持久化字段（防止旧版 reload 或异常路径覆盖）
             try:
                 runtime_state.load()
             except Exception as e:
                 logger.warning(f"[ConfigHandler] runtime_state.load failed: {e}")
 
-            # 持久化 runtime_state（如果修改了可持久化的字段）
+        if persist_dirty:
             try:
-                from ...config import _PERSISTABLE_KEYS
-
-                if any(k.lower() in _PERSISTABLE_KEYS for k in env_entries):
-                    runtime_state.save()
+                runtime_state.save()
+                logger.info("[ConfigHandler] set: runtime_state saved (persistable keys updated)")
             except Exception as e:
                 logger.warning(f"[ConfigHandler] runtime_state save failed: {e}")
 


### PR DESCRIPTION
# PR-2 / 10：v1.26.x → main `.env` 配置写入边界 (#428)

本 PR 是 v1.26.x → main 系列回填 10 个 PR 的第 2 个，依赖已合并的 [#482 (PR-1)](https://github.com/openakita/openakita/pull/482)。后续 PR-3 ~ PR-10 会在本 PR 合并后基于新 main rebase 分别提交。

## Commits（不 squash，请用 Rebase merge）

| # | Commit | 主题 |
|---|---|---|
| 1 | `48f4663f` | `fix(config): prevent _set_config from writing complex types to .env` |
| 2 | `6716d0ed` | `fix(config): harden _set_config and _create_settings_safe edge cases` |

## 修复内容

### 1. `_set_config` 把复杂类型写进 `.env` 导致重启 crash（修复 #428）
**根因**：`_set_config` 用 `str()` 序列化 `list` / `dict` 类型字段（如 `im_bots`）写入 `.env`，得到的是 Python repr（单引号）。重启时 pydantic-settings 用 `json.loads()` 解析就 `JSONDecodeError` 直接崩溃。

**三层修复**：
1. **`_PERSISTABLE_KEYS` 字段完全不写 `.env`**：改为内存 setattr + 经 `runtime_state.save()` 写入 `runtime_state.json`（单一数据源）
2. **新增 `_serialize_env_value()` 帮手**：list/dict 类型用 `json.dumps`，避免 repr 污染
3. **`_create_settings_safe()` 自愈**：包一层 `Settings()` 初始化，如果 `.env` 中有已污染字段就自动移除并重试 init —— **对已部署用户的 corrupt `.env` 自动恢复**

### 2. 加固 `_set_config` / `_create_settings_safe` 边界
- **修复 race**：当一次请求同时修改 persistable key 和 .env key 时，`runtime_state.load()` 会用旧值覆盖刚 setattr 的内存改动。现在 `persist_dirty=True` 时跳过 `runtime_state.load()`。
- **循环式恢复**：`_create_settings_safe` 用循环（最多 3 次）处理 `.env` 多字段同时被污染的极端情况，替代原本的一次性 try-except。

## 与 v1.26.x 的差异（手动冲突解决要点）
| 文件 | 决策 |
|---|---|
| `src/openakita/tools/handlers/config.py` | 在 `persist_dirty` 分支保留 v1.26 **无条件** `runtime_state.save()`（main 上的条件检查被识别为 bug，会漏存） |
| `src/openakita/tools/handlers/config.py` | 采用 v1.26 更详细的 `.env` 更新日志信息 |

## 影响面

| 文件 | +/- |
|---|---|
| `src/openakita/config.py` | +50 / -1 |
| `src/openakita/tools/handlers/config.py` | +27 / -20 |

## Test Plan
- [ ] **单测**：`pytest tests/unit -k "config" -q` 应全绿
- [ ] **重启回归**：在 `.env` 里手动塞 `IM_BOTS="['x']"`（单引号 repr）→ 重启服务 → 不应崩溃，应该自动移除该字段并恢复
- [ ] **race 回归**：同一次请求同时改 `app.session_max_history`（persistable）和 `proxy.url`（.env）→ 两个值都应正确生效，不会被对方覆盖
- [ ] **复杂类型**：用 `tools/set_config` 写入 `im_bots = [...]` → 应进 `runtime_state.json` 而非 `.env`

## 注意
- 依赖 PR-1（已合并）
- 推荐 **Rebase merge**，保留 2 个 commit 历史
- 合并后我会 rebase `backport/v126/pr3-workspace-isolation` 到新 main 再开 PR-3

## 来源
- v1.26.x `970e5115` + `ffc383c4`（手工 patch）
- 完整 backport 计划：`v126-to-main-backport_0ebdaaa9.plan.md`
