### PR TITLE
fix(backport): v1.26.x → main PR-4/10 LLM registries shared httpx client regression (#331)

### DIFF
--- a/src/openakita/llm/providers/anthropic.py
+++ b/src/openakita/llm/providers/anthropic.py
@@ -67,17 +67,16 @@ class AnthropicProvider(LLMProvider):
         return f"{b}/messages" if b.endswith("/v1") else f"{b}/v1/messages"
 
     def _is_local_endpoint(self) -> bool:
-        """检查是否为本地端点"""
+        """检查是否为本地/局域网端点
+
+        覆盖 loopback + RFC 1918 私有地址 + link-local，与 proxy_utils._is_private_host 对齐。
+        """
+        from .proxy_utils import should_bypass_proxy
+
         url = self.base_url.lower()
-        return any(
-            host in url
-            for host in (
-                "localhost",
-                "127.0.0.1",
-                "0.0.0.0",
-                "[::1]",
-            )
-        )
+        if any(host in url for host in ("localhost", "127.0.0.1", "0.0.0.0", "[::1]")):
+            return True
+        return should_bypass_proxy(self.base_url)
 
     def _get_validated_api_key(self) -> str:
         """获取并验证 API Key，空 key 时提前抛出有意义的错误而非让 API 返回模糊 401。"""

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -580,17 +580,16 @@ class OpenAIProvider(LLMProvider):
             yield event
 
     def _is_local_endpoint(self) -> bool:
-        """检查是否为本地端点（Ollama/LM Studio 等）"""
+        """检查是否为本地/局域网端点（Ollama/LM Studio/vLLM 等）
+
+        覆盖 loopback + RFC 1918 私有地址 + link-local，与 proxy_utils._is_private_host 对齐。
+        """
+        from .proxy_utils import should_bypass_proxy
+
         url = self.base_url.lower()
-        return any(
-            host in url
-            for host in (
-                "localhost",
-                "127.0.0.1",
-                "0.0.0.0",
-                "[::1]",
-            )
-        )
+        if any(host in url for host in ("localhost", "127.0.0.1", "0.0.0.0", "[::1]")):
+            return True
+        return should_bypass_proxy(self.base_url)
 
     def _get_auth(self) -> _BearerAuth:
         """获取认证信息（通过 httpx Auth 机制，确保重定向时不丢失凭据）"""

--- a/src/openakita/llm/registries/anthropic.py
+++ b/src/openakita/llm/registries/anthropic.py
@@ -3,7 +3,7 @@ Anthropic 服务商注册表
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class AnthropicRegistry(ProviderRegistry):
@@ -21,17 +21,17 @@ class AnthropicRegistry(ProviderRegistry):
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
         """获取 Anthropic 模型列表"""
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/v1/models",
-                headers={
-                    "x-api-key": api_key,
-                    "anthropic-version": "2023-06-01",
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/v1/models",
+                    headers={
+                        "x-api-key": api_key,
+                        "anthropic-version": "2023-06-01",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models = []
             for m in data.get("data", []):

--- a/src/openakita/llm/registries/base.py
+++ b/src/openakita/llm/registries/base.py
@@ -9,21 +9,23 @@ from dataclasses import dataclass, field
 
 import httpx
 
-_shared_registry_client: httpx.AsyncClient | None = None
+from ..providers.proxy_utils import get_httpx_client_kwargs
 
 
-def get_registry_client() -> httpx.AsyncClient:
-    """获取 registry 共享 httpx 客户端（连接池复用，避免每次请求新建/销毁）。"""
-    global _shared_registry_client
-    if _shared_registry_client is None or _shared_registry_client.is_closed:
-        _shared_registry_client = httpx.AsyncClient(
-            timeout=30,
-            limits=httpx.Limits(
-                max_connections=30,
-                max_keepalive_connections=10,
-            ),
-        )
-    return _shared_registry_client
+def create_registry_client(target_url: str = "") -> httpx.AsyncClient:
+    """按目标 URL 创建 registry httpx 客户端，自动处理代理旁路。
+
+    云端服务商（OpenAI/Anthropic 等）自动走代理；
+    内网端点（172.x.x.x 等 RFC 1918 地址）自动直连。
+    与 bridge.py 使用同一套 proxy 决策逻辑。
+
+    用法::
+
+        async with create_registry_client(self.info.default_base_url) as client:
+            resp = await client.get(url, ...)
+    """
+    kwargs = get_httpx_client_kwargs(timeout=30, target_url=target_url)
+    return httpx.AsyncClient(**kwargs)
 
 
 @dataclass

--- a/src/openakita/llm/registries/dashscope.py
+++ b/src/openakita/llm/registries/dashscope.py
@@ -9,7 +9,7 @@
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 # 预置模型列表（国内/国际共用）
 _PRESET_MODELS = [
@@ -44,14 +44,14 @@ class _DashScopeBase(ProviderRegistry):
         2. 从预置能力表查找每个模型的能力
         3. 如果预置表没有该模型，使用智能推断
         """
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models: list[ModelInfo] = []
             seen: set[str] = set()

--- a/src/openakita/llm/registries/deepseek.py
+++ b/src/openakita/llm/registries/deepseek.py
@@ -6,7 +6,7 @@ DeepSeek 官方提供 OpenAI 兼容协议，通常支持 `/v1/models`。
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class DeepSeekRegistry(ProviderRegistry):
@@ -23,14 +23,14 @@ class DeepSeekRegistry(ProviderRegistry):
     )
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
         except Exception:
             return self._get_preset_models()
 

--- a/src/openakita/llm/registries/kimi.py
+++ b/src/openakita/llm/registries/kimi.py
@@ -7,7 +7,7 @@ Kimi（月之暗面 / Moonshot）服务商注册表（OpenAI 兼容）
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class KimiChinaRegistry(ProviderRegistry):
@@ -22,13 +22,13 @@ class KimiChinaRegistry(ProviderRegistry):
     )
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
-        client = get_registry_client()
-        resp = await client.get(
-            f"{self.info.default_base_url}/models",
-            headers={"Authorization": f"Bearer {api_key}"},
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        async with create_registry_client(self.info.default_base_url) as client:
+            resp = await client.get(
+                f"{self.info.default_base_url}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
 
         out: list[ModelInfo] = []
         for m in data.get("data", []) or []:
@@ -57,13 +57,13 @@ class KimiInternationalRegistry(ProviderRegistry):
     )
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
-        client = get_registry_client()
-        resp = await client.get(
-            f"{self.info.default_base_url}/models",
-            headers={"Authorization": f"Bearer {api_key}"},
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        async with create_registry_client(self.info.default_base_url) as client:
+            resp = await client.get(
+                f"{self.info.default_base_url}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
 
         out: list[ModelInfo] = []
         for m in data.get("data", []) or []:

--- a/src/openakita/llm/registries/openai.py
+++ b/src/openakita/llm/registries/openai.py
@@ -3,7 +3,7 @@ OpenAI 服务商注册表
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class OpenAIRegistry(ProviderRegistry):
@@ -21,14 +21,14 @@ class OpenAIRegistry(ProviderRegistry):
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
         """获取 OpenAI 模型列表"""
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models = []
             for m in data.get("data", []):

--- a/src/openakita/llm/registries/openrouter.py
+++ b/src/openakita/llm/registries/openrouter.py
@@ -4,7 +4,7 @@ OpenRouter 服务商注册表
 OpenRouter 的 API 返回完整的能力信息，是最理想的情况。
 """
 
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class OpenRouterRegistry(ProviderRegistry):
@@ -22,14 +22,14 @@ class OpenRouterRegistry(ProviderRegistry):
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
         """获取 OpenRouter 模型列表"""
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models = []
             for m in data.get("data", []):

--- a/src/openakita/llm/registries/siliconflow.py
+++ b/src/openakita/llm/registries/siliconflow.py
@@ -7,7 +7,7 @@
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 # 预置模型列表（国内/国际共用）
 _PRESET_MODELS = [
@@ -28,14 +28,14 @@ class _SiliconFlowBase(ProviderRegistry):
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
         """获取硅基流动模型列表"""
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models = []
             for m in data.get("data", []):

--- a/src/openakita/llm/registries/volcengine.py
+++ b/src/openakita/llm/registries/volcengine.py
@@ -9,7 +9,7 @@ Base URL: https://ark.cn-beijing.volces.com/api/v3
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class VolcEngineRegistry(ProviderRegistry):
@@ -32,14 +32,14 @@ class VolcEngineRegistry(ProviderRegistry):
         火山方舟兼容 OpenAI /models 接口。
         如果 API 调用失败，返回预置的常用模型列表。
         """
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models: list[ModelInfo] = []
             seen: set[str] = set()

--- a/src/openakita/llm/registries/zhipu.py
+++ b/src/openakita/llm/registries/zhipu.py
@@ -14,7 +14,7 @@ API 文档:
 """
 
 from ..capabilities import infer_capabilities
-from .base import ModelInfo, ProviderInfo, ProviderRegistry, get_registry_client
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
 
 
 class ZhipuChinaRegistry(ProviderRegistry):
@@ -37,14 +37,14 @@ class ZhipuChinaRegistry(ProviderRegistry):
         智谱兼容 OpenAI /models 接口。
         如果 API 调用失败，返回预置的常用模型列表。
         """
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models: list[ModelInfo] = []
             seen: set[str] = set()
@@ -111,14 +111,14 @@ class ZhipuInternationalRegistry(ProviderRegistry):
 
     async def list_models(self, api_key: str) -> list[ModelInfo]:
         """获取智谱 AI 国际区模型列表。"""
-        client = get_registry_client()
         try:
-            resp = await client.get(
-                f"{self.info.default_base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
 
             models: list[ModelInfo] = []
             seen: set[str] = set()


### PR DESCRIPTION
# PR-4 / 10：v1.26.x → main LLM registries 共享 httpx 回归修复 (#331)

本 PR 是 v1.26.x → main 系列回填 10 个 PR 的第 4 个，依赖已合并的 PR-1 (#482) + PR-2 (#483) + PR-3 (#484)。后续 PR-5 ~ PR-10 会在本 PR 合并后基于新 main rebase 分别提交。

**本 PR 是这批里风险最低的之一**：单 commit、纯后端、改动是机械化的同质重构（12 个文件几乎都是同一类替换 + 在 2 个 provider 文件加一行）。

## Commits（不 squash，请用 Rebase merge）

| # | Commit | 主题 |
|---|---|---|
| 1 | `89b24b71` | `fix(llm): 修复 v1.26.x 共享 httpx 客户端导致局域网 LLM 端点无法连接的回归` |

## 修复内容

### 问题（双重 bug）
1. **共享 httpx 客户端不能逐请求切代理**：v1.26.x 引入 `get_registry_client()` 共享 httpx 客户端，但 `proxy` 参数是 **client 级别的**，无法逐请求切换：
   - 设 `trust_env=False` → 云端服务商无法走系统代理（连不上）
   - 不设 → 内网/局域网端点被代理拦截（连不上）
2. **`_is_local_endpoint()` 漏判私有 IP**：只识别 loopback（`127.0.0.1` / `localhost`），**不覆盖 RFC 1918 私有 IP 段**（`10.x` / `172.16–31.x` / `192.168.x`），导致用户局域网部署的 Ollama / vLLM 仍走代理失败。

### 修复
1. **删除共享客户端**，新增 `create_registry_client(target_url)` 工厂函数，集成 `get_httpx_client_kwargs(target_url)` 做**逐请求代理决策**
2. **扩展 `_is_local_endpoint()` 复用 `should_bypass_proxy()`**，覆盖 RFC 1918 私有 IP（在 `openai.py` 和 `anthropic.py` 两个 provider 文件）
3. **更新全部 9 个 registry 文件**统一使用 `async with create_registry_client(...) as client:`

## 与 v1.26.x 的差异（手动 patch 要点）
| 文件 | 决策 |
|---|---|
| `src/openakita/llm/providers/{openai,anthropic}.py` | `_is_local_endpoint` 冲突点采用 v1.26 的扩展逻辑（`should_bypass_proxy`），main 上的窄实现是缺陷 |
| 9 个 registry 文件 | 干净自动 cherry-pick `a3ceb5a9` |

## 影响面

| 类型 | 数量 |
|---|---|
| 文件 | 12 |
| 净行数 | +124 / -124（机械化同构改动） |
| Provider 文件 | 2（openai, anthropic）— 各 +/- 19 行 |
| Registry 文件 | 10（含 base.py + 9 个具体 provider） |

## Test Plan
- [ ] **单测**：`pytest tests/llm tests/unit -k "registry or registries or local_endpoint or proxy" -q` 应全绿
- [ ] **云端回归**：保留至少一个云端端点（Anthropic / OpenAI / DeepSeek 任一）→ 发一条消息 → 应正常通过系统代理可达
- [ ] **局域网回归**：注册一个 `http://192.168.x.y:11434` 的 Ollama 端点 → 应能连上（之前会被代理拦截）
- [ ] **回环回归**：`http://127.0.0.1:8000` 已知工作，回归确认未破坏
- [ ] **Registry 拉取**：`/api/llm/registries/<provider>/models` 各 9 家拉模型列表都应可用

## 注意
- 依赖 PR-1 ~ PR-3（都已合并）
- 推荐 **Rebase merge**，1 个 commit
- 合并后我会 rebase `backport/v126/pr5-llm-418-series` 到新 main 再开 PR-5（注意：当前 pr5 分支顶端**包含原计划 PR-5 ~ PR-10 共 15 个 commit**，等推到那一步如果你想再细分成 6 个独立 PR，请提前告知）

## 来源
- v1.26.x `a3ceb5a9`（2 个 provider 文件冲突手工 patch）
- 完整 backport 计划：`v126-to-main-backport_0ebdaaa9.plan.md`
