### PR TITLE
fix(backport): v1.26.x → main PR-5/5 LLM/session/endpoint comprehensive fixes (15 commits)

### DIFF
--- a/apps/setup-center/src/App.tsx
+++ b/apps/setup-center/src/App.tsx
@@ -1608,31 +1608,6 @@ function MainApp() {
     }
   }
 
-  async function readEndpointsJson(): Promise<{ endpoints: any[]; settings: any }> {
-    if (!currentWorkspaceId && !shouldUseHttpApi()) return { endpoints: [], settings: {} };
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      const parsed = raw ? JSON.parse(raw) : { endpoints: [], settings: {} };
-      const eps = Array.isArray(parsed?.endpoints) ? parsed.endpoints : [];
-      const settings = parsed?.settings && typeof parsed.settings === "object" ? parsed.settings : {};
-      return { endpoints: eps, settings };
-    } catch {
-      return { endpoints: [], settings: {} };
-    }
-  }
-
-  async function writeEndpointsJson(endpoints: any[], settings: any) {
-    // readWorkspaceFile and writeWorkspaceFile already do HTTP-first internally
-    let existing: any = {};
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      existing = raw ? JSON.parse(raw) : {};
-    } catch { /* ignore */ }
-    const base = { ...existing, endpoints, settings: settings || {} };
-    const next = JSON.stringify(base, null, 2) + "\n";
-    await writeWorkspaceFile("data/llm_endpoints.json", next);
-  }
-
   // ── 配置读写路由 ──
   // 路由原则：
   //   后端运行中 (serviceStatus?.running) 或远程模式 → 必须走 HTTP API（后端负责持久化 + 热加载）
@@ -1688,7 +1663,14 @@ function MainApp() {
         if (relativePath === "data/llm_endpoints.json") {
           const res = await safeFetch(`${base}/api/config/endpoints`);
           const data = await res.json();
-          return JSON.stringify(data.raw || { endpoints: data.endpoints || [] });
+          const raw = data.raw;
+          const hasEndpoints = raw && typeof raw === "object" && Array.isArray(raw.endpoints) && raw.endpoints.length > 0;
+          if (hasEndpoints) return JSON.stringify(raw);
+          const fallback = { endpoints: data.endpoints || [] };
+          if (Array.isArray(raw?.compiler_endpoints)) fallback.compiler_endpoints = raw.compiler_endpoints;
+          if (Array.isArray(raw?.stt_endpoints)) fallback.stt_endpoints = raw.stt_endpoints;
+          if (raw?.settings) fallback.settings = raw.settings;
+          return JSON.stringify(fallback);
         }
         if (relativePath === "data/skills.json") {
           const res = await safeFetch(`${base}/api/config/skills`);
@@ -1717,18 +1699,6 @@ function MainApp() {
     if (shouldUseHttpApi()) {
       try {
         const base = httpApiBase();
-        if (relativePath === "data/llm_endpoints.json") {
-          await safeFetch(`${base}/api/config/endpoints`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: JSON.parse(content) }),
-          });
-          const reloaded = await triggerConfigReload();
-          if (!reloaded) {
-            toast.warning("配置已保存，但热重载未生效。建议重启后端服务以应用更改。", { duration: 6000 });
-          }
-          return;
-        }
         if (relativePath === "data/skills.json") {
           await safeFetch(`${base}/api/config/skills`, {
             method: "POST",
@@ -4068,69 +4038,54 @@ function MainApp() {
       }
 
       // ── STEP: llm-config (via HTTP API, after backend is ready) ──
-      if (savedEndpoints.length > 0) {
+      if (savedEndpoints.length > 0 || savedCompilerEndpoints.length > 0 || savedSttEndpoints.length > 0) {
         updateTask("llm-config", { status: "running" });
         logTask("保存 LLM 配置", "running");
-        if (httpReady) {
+        if (!httpReady) {
+          const msg = "HTTP 服务未就绪，无法保存 LLM 配置。请确保后端已启动。";
+          log(`⚠ ${msg}`);
+          updateTask("llm-config", { status: "error", detail: msg });
+          logTask("保存 LLM 配置", "error", msg);
+          hasErr = true;
+        } else {
           try {
             const base = httpApiBase();
-            for (const ep of savedEndpoints) {
-              const apiKey = envDraft[(ep as any).api_key_env] || "";
-              await safeFetch(`${base}/api/config/save-endpoint`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  endpoint: ep,
-                  api_key: apiKey || null,
-                  endpoint_type: "endpoints",
-                }),
-              });
+            let epErrors: string[] = [];
+            const allBatches: Array<{ eps: typeof savedEndpoints; type: string }> = [
+              { eps: savedEndpoints, type: "endpoints" },
+              { eps: savedCompilerEndpoints, type: "compiler_endpoints" },
+              { eps: savedSttEndpoints, type: "stt_endpoints" },
+            ];
+            for (const { eps, type } of allBatches) {
+              for (const ep of eps) {
+                const apiKey = envDraft[(ep as any).api_key_env] || "";
+                const res = await safeFetch(`${base}/api/config/save-endpoint`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    endpoint: ep,
+                    api_key: apiKey || null,
+                    endpoint_type: type,
+                  }),
+                });
+                const data = await res.json();
+                if (data.status === "error" || data.status === "conflict") {
+                  epErrors.push(`${(ep as any).name || type}: ${data.error || "unknown error"}`);
+                }
+              }
             }
-            for (const ep of savedCompilerEndpoints) {
-              const apiKey = envDraft[(ep as any).api_key_env] || "";
-              await safeFetch(`${base}/api/config/save-endpoint`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  endpoint: ep,
-                  api_key: apiKey || null,
-                  endpoint_type: "compiler_endpoints",
-                }),
-              });
+            if (epErrors.length > 0) {
+              const detail = epErrors.join("; ");
+              log(`⚠ 部分端点保存失败: ${detail}`);
+              updateTask("llm-config", { status: "error", detail: detail.slice(0, 120) });
+              logTask("保存 LLM 配置", "error", detail);
+              hasErr = true;
+            } else {
+              const total = savedEndpoints.length + savedCompilerEndpoints.length + savedSttEndpoints.length;
+              log(t("onboarding.progress.llmConfigSaved"));
+              updateTask("llm-config", { status: "done", detail: `${total} 个端点` });
+              logTask("保存 LLM 配置", "done", `${total} 个端点`);
             }
-            for (const ep of savedSttEndpoints) {
-              const apiKey = envDraft[(ep as any).api_key_env] || "";
-              await safeFetch(`${base}/api/config/save-endpoint`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  endpoint: ep,
-                  api_key: apiKey || null,
-                  endpoint_type: "stt_endpoints",
-                }),
-              });
-            }
-            log(t("onboarding.progress.llmConfigSaved"));
-            updateTask("llm-config", { status: "done", detail: `${savedEndpoints.length + savedCompilerEndpoints.length + savedSttEndpoints.length} 个端点` });
-            logTask("保存 LLM 配置", "done", `${savedEndpoints.length + savedCompilerEndpoints.length + savedSttEndpoints.length} 个端点`);
-          } catch (e) {
-            log(`[!] LLM 配置保存失败: ${String(e)}`);
-            updateTask("llm-config", { status: "error", detail: String(e).slice(0, 120) });
-            logTask("保存 LLM 配置", "error", String(e));
-            hasErr = true;
-          }
-        } else {
-          log("[!] HTTP 服务未就绪，使用 Tauri 直接写入 LLM 配置");
-          try {
-            const llmData = { endpoints: savedEndpoints, compiler_endpoints: savedCompilerEndpoints, stt_endpoints: savedSttEndpoints, settings: {} };
-            await invoke("workspace_write_file", {
-              workspaceId: activeWsId,
-              relativePath: "data/llm_endpoints.json",
-              content: JSON.stringify(llmData, null, 2),
-            });
-            log(t("onboarding.progress.llmConfigSaved"));
-            updateTask("llm-config", { status: "done", detail: `${savedEndpoints.length} 个端点 (Tauri)` });
-            logTask("保存 LLM 配置", "done", `${savedEndpoints.length} 个端点 (Tauri 回退)`);
           } catch (e) {
             log(`[!] LLM 配置保存失败: ${String(e)}`);
             updateTask("llm-config", { status: "error", detail: String(e).slice(0, 120) });

--- a/apps/setup-center/src/App.tsx
+++ b/apps/setup-center/src/App.tsx
@@ -3823,7 +3823,7 @@ function MainApp() {
     }
     taskDefs.push({ id: "service-start", label: "启动后端服务", status: "pending" });
     taskDefs.push({ id: "http-wait", label: "等待 HTTP 服务就绪", status: "pending" });
-    taskDefs.push({ id: "llm-config", label: "保存 LLM 配置", status: savedEndpoints.length > 0 ? "pending" : "skipped" });
+    taskDefs.push({ id: "llm-config", label: "保存 LLM 配置", status: (savedEndpoints.length > 0 || savedCompilerEndpoints.length > 0 || savedSttEndpoints.length > 0) ? "pending" : "skipped" });
     taskDefs.push({ id: "env-save", label: "保存环境变量", status: "pending" });
     setObTasks(taskDefs);
 
@@ -3872,21 +3872,6 @@ function MainApp() {
       }
       updateTask("workspace", { status: "done" });
       logTask("准备工作区", "done");
-
-      // ── STEP: llm-config ──
-      if (savedEndpoints.length > 0) {
-        updateTask("llm-config", { status: "running" });
-        logTask("保存 LLM 配置", "running");
-        const llmData = { endpoints: savedEndpoints, settings: {} };
-        await invoke("workspace_write_file", {
-          workspaceId: activeWsId,
-          relativePath: "data/llm_endpoints.json",
-          content: JSON.stringify(llmData, null, 2),
-        });
-        log(t("onboarding.progress.llmConfigSaved"));
-        updateTask("llm-config", { status: "done", detail: `${savedEndpoints.length} 个端点` });
-        logTask("保存 LLM 配置", "done", `${savedEndpoints.length} 个端点`);
-      }
 
       // ── STEP: backend-check ──
       updateTask("backend-check", { status: "running" });

--- a/apps/setup-center/src/views/LLMView.tsx
+++ b/apps/setup-center/src/views/LLMView.tsx
@@ -195,26 +195,6 @@ export function LLMView(props: LLMViewProps) {
     return Math.floor(x);
   }
 
-  function allocateUniqueEnvVar(
-    endpoint: Record<string, unknown>,
-    config: Record<string, unknown>,
-  ): string {
-    const used = new Set<string>();
-    for (const listKey of ["endpoints", "compiler_endpoints", "stt_endpoints"]) {
-      for (const ep of (config[listKey] as any[] || [])) {
-        if (ep?.api_key_env) used.add(ep.api_key_env);
-      }
-    }
-    const provider = String(endpoint.provider || "custom").toUpperCase().replace(/-/g, "_");
-    const baseName = `${provider}_API_KEY`;
-    if (!used.has(baseName)) return baseName;
-    for (let i = 2; i < 100; i++) {
-      const candidate = `${baseName}_${i}`;
-      if (!used.has(candidate)) return candidate;
-    }
-    return `${baseName}_${Math.random().toString(36).slice(2, 8)}`;
-  }
-
   const providerApplyUrl = useMemo(() => getProviderApplyUrl(selectedProvider?.slug || ""), [selectedProvider?.slug]);
 
   // ── Effects ──
@@ -432,87 +412,6 @@ export function LLMView(props: LLMViewProps) {
     }
   }
 
-  async function saveEndpointLocal(
-    endpoint: Record<string, unknown>,
-    apiKey: string | null,
-    endpointType: string,
-  ): Promise<{ endpoint: Record<string, unknown> }> {
-    let config: Record<string, unknown>;
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      config = raw ? JSON.parse(raw) : {};
-    } catch {
-      config = {};
-    }
-
-    const name = String(endpoint.name || "");
-    const epList: any[] = (config[endpointType] as any[] || []);
-    const existing = epList.find((e: any) => e.name === name);
-
-    let envVar = "";
-    if (apiKey) {
-      envVar = existing?.api_key_env || (endpoint.api_key_env as string) || allocateUniqueEnvVar(endpoint, config);
-      if (IS_TAURI && currentWorkspaceId) {
-        await invoke("workspace_update_env", {
-          workspaceId: currentWorkspaceId,
-          entries: [{ key: envVar, value: apiKey }],
-        });
-      }
-      setEnvDraft((e) => envSet(e, envVar, apiKey));
-    } else {
-      envVar = existing?.api_key_env || (endpoint.api_key_env as string) || "";
-    }
-    endpoint.api_key_env = envVar;
-
-    if (existing) {
-      const idx = epList.indexOf(existing);
-      epList[idx] = { ...existing, ...endpoint };
-    } else {
-      epList.push(endpoint);
-    }
-    config[endpointType] = epList;
-
-    await writeWorkspaceFile("data/llm_endpoints.json", JSON.stringify(config, null, 2));
-    return { endpoint: { ...endpoint, api_key_env: envVar } };
-  }
-
-  async function deleteEndpointLocal(name: string, endpointType: string): Promise<void> {
-    let config: Record<string, unknown>;
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      config = raw ? JSON.parse(raw) : {};
-    } catch {
-      config = {};
-    }
-    const epList: any[] = (config[endpointType] as any[] || []);
-    config[endpointType] = epList.filter((e: any) => e.name !== name);
-    await writeWorkspaceFile("data/llm_endpoints.json", JSON.stringify(config, null, 2));
-  }
-
-  async function readEndpointsJson(): Promise<{ endpoints: any[]; settings: any }> {
-    if (!currentWorkspaceId && !shouldUseHttpApi()) return { endpoints: [], settings: {} };
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      const parsed = raw ? JSON.parse(raw) : { endpoints: [], settings: {} };
-      const eps = Array.isArray(parsed?.endpoints) ? parsed.endpoints : [];
-      const settings = parsed?.settings && typeof parsed.settings === "object" ? parsed.settings : {};
-      return { endpoints: eps, settings };
-    } catch {
-      return { endpoints: [], settings: {} };
-    }
-  }
-
-  async function writeEndpointsJson(endpoints: any[], settings: any) {
-    let existing: any = {};
-    try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      existing = raw ? JSON.parse(raw) : {};
-    } catch { /* ignore */ }
-    const base = { ...existing, endpoints, settings: settings || {} };
-    const next = JSON.stringify(base, null, 2) + "\n";
-    await writeWorkspaceFile("data/llm_endpoints.json", next);
-  }
-
   async function doFetchCompilerModels() {
     const compilerSelectedProvider = providers.find((p) => p.slug === compilerProviderSlug) || null;
     const isCompilerLocal = isLocalProvider(compilerSelectedProvider);
@@ -627,26 +526,22 @@ export function LLMView(props: LLMViewProps) {
         capabilities: ["text"],
       };
 
-      if (shouldUseHttpApi()) {
-        const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            endpoint,
-            api_key: effectiveCompApiKeyValue || null,
-            endpoint_type: "compiler_endpoints",
-          }),
-        });
-        const data = await res.json();
-        if (data.status === "error" || data.status === "conflict") {
-          notifyError(data.error || "保存失败");
-          return false;
-        }
-        if (effectiveCompApiKeyValue && data.endpoint?.api_key_env) {
-          setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveCompApiKeyValue));
-        }
-      } else {
-        await saveEndpointLocal(endpoint, effectiveCompApiKeyValue || null, "compiler_endpoints");
+      const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint,
+          api_key: effectiveCompApiKeyValue || null,
+          endpoint_type: "compiler_endpoints",
+        }),
+      });
+      const data = await res.json();
+      if (data.status === "error" || data.status === "conflict") {
+        notifyError(data.error || "保存失败");
+        return false;
+      }
+      if (effectiveCompApiKeyValue && data.endpoint?.api_key_env) {
+        setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveCompApiKeyValue));
       }
 
       setCompilerModel("");
@@ -668,14 +563,10 @@ export function LLMView(props: LLMViewProps) {
     if (!currentWorkspaceId && dataMode !== "remote") return;
     const _busyId = notifyLoading("删除编译端点...");
     try {
-      if (shouldUseHttpApi()) {
-        await safeFetch(
-          `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(epName)}?endpoint_type=compiler_endpoints`,
-          { method: "DELETE" },
-        );
-      } else {
-        await deleteEndpointLocal(epName, "compiler_endpoints");
-      }
+      await safeFetch(
+        `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(epName)}?endpoint_type=compiler_endpoints`,
+        { method: "DELETE" },
+      );
       setSavedCompilerEndpoints((prev) => prev.filter((e) => e.name !== epName));
       notifySuccess(`编译端点 ${epName} 已删除`);
       loadSavedEndpoints().catch(() => {});
@@ -726,26 +617,22 @@ export function LLMView(props: LLMViewProps) {
         capabilities: ["text"],
       };
 
-      if (shouldUseHttpApi()) {
-        const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            endpoint,
-            api_key: effectiveSttApiKeyValue || null,
-            endpoint_type: "stt_endpoints",
-          }),
-        });
-        const data = await res.json();
-        if (data.status === "error" || data.status === "conflict") {
-          notifyError(data.error || "保存失败");
-          return false;
-        }
-        if (effectiveSttApiKeyValue && data.endpoint?.api_key_env) {
-          setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveSttApiKeyValue));
-        }
-      } else {
-        await saveEndpointLocal(endpoint, effectiveSttApiKeyValue || null, "stt_endpoints");
+      const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint,
+          api_key: effectiveSttApiKeyValue || null,
+          endpoint_type: "stt_endpoints",
+        }),
+      });
+      const data = await res.json();
+      if (data.status === "error" || data.status === "conflict") {
+        notifyError(data.error || "保存失败");
+        return false;
+      }
+      if (effectiveSttApiKeyValue && data.endpoint?.api_key_env) {
+        setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveSttApiKeyValue));
       }
 
       setSttModel("");
@@ -768,14 +655,10 @@ export function LLMView(props: LLMViewProps) {
     if (!currentWorkspaceId && dataMode !== "remote") return;
     const _busyId = notifyLoading("删除 STT 端点...");
     try {
-      if (shouldUseHttpApi()) {
-        await safeFetch(
-          `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(epName)}?endpoint_type=stt_endpoints`,
-          { method: "DELETE" },
-        );
-      } else {
-        await deleteEndpointLocal(epName, "stt_endpoints");
-      }
+      await safeFetch(
+        `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(epName)}?endpoint_type=stt_endpoints`,
+        { method: "DELETE" },
+      );
       setSavedSttEndpoints((prev) => prev.filter((e) => e.name !== epName));
       notifySuccess(`STT 端点 ${epName} 已删除`);
       loadSavedEndpoints().catch(() => {});
@@ -790,32 +673,13 @@ export function LLMView(props: LLMViewProps) {
     if (!currentWorkspaceId && dataMode !== "remote") return;
     const _busyId = notifyLoading("保存排序...");
     try {
-      const { endpoints, settings } = await readEndpointsJson();
-      const map = new Map<string, any>();
-      for (const e of endpoints) {
-        const name = String(e?.name || "");
-        if (name) map.set(name, e);
-      }
-      const nextEndpoints: any[] = [];
-      let p = 1;
-      for (const name of orderedNames) {
-        const e = map.get(name);
-        if (!e) continue;
-        e.priority = p++;
-        nextEndpoints.push(e);
-        map.delete(name);
-      }
-      for (const e of endpoints) {
-        const name = String(e?.name || "");
-        if (!name) continue;
-        if (map.has(name)) {
-          const ee = map.get(name);
-          ee.priority = p++;
-          nextEndpoints.push(ee);
-          map.delete(name);
-        }
-      }
-      await writeEndpointsJson(nextEndpoints, settings);
+      const res = await safeFetch(`${httpApiBase()}/api/config/reorder-endpoints`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ordered_names: orderedNames, endpoint_type: "endpoints" }),
+      });
+      const json = await res.json();
+      if (json.status !== "ok") throw new Error(json.error || "reorder failed");
       notifySuccess("已保存端点顺序（priority 已更新）");
       await loadSavedEndpoints();
     } catch (e) {
@@ -965,41 +829,33 @@ export function LLMView(props: LLMViewProps) {
       }
       if (editDraft.streamOnly) endpoint.stream_only = true;
 
-      if (shouldUseHttpApi()) {
-        if (nameChanged) {
-          await safeFetch(
-            `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(editingOriginalName)}?endpoint_type=endpoints`,
-            { method: "DELETE" },
-          );
-        }
-        // Only send the API key when the user actually edited the input
-        // (apiKeyDirty). Otherwise the prefilled masked value (sk-d****ab53)
-        // would be echoed back and overwrite the real key on disk.
-        // See v1.26.x commit 8ab550fa.
-        const keyToSave = editDraft.apiKeyDirty ? (editDraft.apiKeyValue.trim() || null) : null;
-        const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            endpoint,
-            api_key: keyToSave,
-            endpoint_type: "endpoints",
-          }),
-        });
-        const data = await res.json();
-        if (data.status === "conflict" || data.status === "error") {
-          notifyError(data.error || "保存失败");
-          return;
-        }
-        if (keyToSave && data.endpoint?.api_key_env) {
-          setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, keyToSave));
-        }
-      } else {
-        if (nameChanged) {
-          await deleteEndpointLocal(editingOriginalName, "endpoints");
-        }
-        const effectiveKeyLocal = editDraft.apiKeyDirty ? (editDraft.apiKeyValue.trim() || null) : null;
-        await saveEndpointLocal(endpoint, effectiveKeyLocal, "endpoints");
+      if (nameChanged) {
+        await safeFetch(
+          `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(editingOriginalName)}?endpoint_type=endpoints`,
+          { method: "DELETE" },
+        );
+      }
+      // Only send the API key when the user actually edited the input
+      // (apiKeyDirty). Otherwise the prefilled masked value (sk-d****ab53)
+      // would be echoed back and overwrite the real key on disk.
+      // See v1.26.x commit 8ab550fa.
+      const keyToSave = editDraft.apiKeyDirty ? (editDraft.apiKeyValue.trim() || null) : null;
+      const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint,
+          api_key: keyToSave,
+          endpoint_type: "endpoints",
+        }),
+      });
+      const data = await res.json();
+      if (data.status === "conflict" || data.status === "error") {
+        notifyError(data.error || "保存失败");
+        return;
+      }
+      if (keyToSave && data.endpoint?.api_key_env) {
+        setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, keyToSave));
       }
 
       notifySuccess("端点已更新");
@@ -1059,30 +915,26 @@ export function LLMView(props: LLMViewProps) {
         endpoint.extra_params = { enable_thinking: true };
       }
 
-      if (shouldUseHttpApi()) {
-        const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            endpoint,
-            api_key: effectiveApiKeyValue || null,
-            endpoint_type: "endpoints",
-          }),
-        });
-        const data = await res.json();
-        if (data.status === "conflict") {
-          notifyError(data.error || t("llm.configConflict"));
-          return false;
-        }
-        if (data.status === "error") {
-          notifyError(data.error || "保存失败");
-          return false;
-        }
-        if (effectiveApiKeyValue && data.endpoint?.api_key_env) {
-          setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveApiKeyValue));
-        }
-      } else {
-        await saveEndpointLocal(endpoint, effectiveApiKeyValue || null, "endpoints");
+      const res = await safeFetch(`${httpApiBase()}/api/config/save-endpoint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint,
+          api_key: effectiveApiKeyValue || null,
+          endpoint_type: "endpoints",
+        }),
+      });
+      const data = await res.json();
+      if (data.status === "conflict") {
+        notifyError(data.error || t("llm.configConflict"));
+        return false;
+      }
+      if (data.status === "error") {
+        notifyError(data.error || "保存失败");
+        return false;
+      }
+      if (effectiveApiKeyValue && data.endpoint?.api_key_env) {
+        setEnvDraft((e) => envSet(e, data.endpoint.api_key_env, effectiveApiKeyValue));
       }
 
       notifySuccess(
@@ -1105,14 +957,10 @@ export function LLMView(props: LLMViewProps) {
     if (!currentWorkspaceId && dataMode !== "remote") return;
     const _busyId = notifyLoading("删除端点...");
     try {
-      if (shouldUseHttpApi()) {
-        await safeFetch(
-          `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(name)}?endpoint_type=endpoints`,
-          { method: "DELETE" },
-        );
-      } else {
-        await deleteEndpointLocal(name, "endpoints");
-      }
+      await safeFetch(
+        `${httpApiBase()}/api/config/endpoint/${encodeURIComponent(name)}?endpoint_type=endpoints`,
+        { method: "DELETE" },
+      );
       setSavedEndpoints((prev) => prev.filter((e) => e.name !== name));
       notifySuccess(`已删除端点：${name}`);
       loadSavedEndpoints().catch(() => {});
@@ -1126,17 +974,13 @@ export function LLMView(props: LLMViewProps) {
   async function doToggleEndpointEnabled(name: string, endpointType: "endpoints" | "compiler_endpoints" | "stt_endpoints" = "endpoints") {
     if (!currentWorkspaceId && dataMode !== "remote") return;
     try {
-      const raw = await readWorkspaceFile("data/llm_endpoints.json");
-      const base = raw ? JSON.parse(raw) : { endpoints: [], settings: {} };
-      const eps = Array.isArray(base[endpointType]) ? base[endpointType] : [];
-      for (const ep of eps) {
-        if (String(ep?.name || "") === name) {
-          ep.enabled = ep.enabled === false ? true : false;
-          break;
-        }
-      }
-      base[endpointType] = eps;
-      await writeWorkspaceFile("data/llm_endpoints.json", JSON.stringify(base, null, 2) + "\n");
+      const res = await safeFetch(`${httpApiBase()}/api/config/toggle-endpoint`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, endpoint_type: endpointType }),
+      });
+      const json = await res.json();
+      if (json.status !== "ok") throw new Error(json.error || "toggle failed");
       loadSavedEndpoints().catch(() => {});
     } catch (e) {
       notifyError(String(e));

--- a/apps/setup-center/src/views/LLMView.tsx
+++ b/apps/setup-center/src/views/LLMView.tsx
@@ -82,6 +82,7 @@ export function LLMView(props: LLMViewProps) {
     [providers, providerSlug],
   );
   const [apiType, setApiType] = useState<"openai" | "openai_responses" | "anthropic">("openai");
+  const [streamOnly, setStreamOnly] = useState(false);
   const [baseUrl, setBaseUrl] = useState<string>("");
   const [apiKeyValue, setApiKeyValue] = useState<string>("");
   const [models, setModels] = useState<ListedModel[]>([]);
@@ -128,6 +129,7 @@ export function LLMView(props: LLMViewProps) {
   const [editDraft, setEditDraft] = useState<{
     name: string; priority: number; providerSlug: string;
     apiType: "openai" | "openai_responses" | "anthropic";
+    streamOnly: boolean;
     baseUrl: string; apiKeyEnv: string; apiKeyValue: string;
     apiKeyDirty: boolean;
     modelId: string; caps: string[]; maxTokens: number;
@@ -845,6 +847,7 @@ export function LLMView(props: LLMViewProps) {
       priority: normalizePriority(ep.priority, 1),
       providerSlug: ep.provider || "",
       apiType: (ep.api_type as any) || "openai",
+      streamOnly: !!(ep as any).stream_only,
       baseUrl: ep.base_url || "",
       apiKeyEnv: ep.api_key_env || "",
       apiKeyValue: envDraft[ep.api_key_env || ""] || "",
@@ -960,6 +963,7 @@ export function LLMView(props: LLMViewProps) {
       if (validTiers.length > 0) {
         endpoint.pricing_tiers = validTiers;
       }
+      if (editDraft.streamOnly) endpoint.stream_only = true;
 
       if (shouldUseHttpApi()) {
         if (nameChanged) {
@@ -1050,6 +1054,7 @@ export function LLMView(props: LLMViewProps) {
         rpm_limit: addEpRpmLimit,
         capabilities: capList,
       };
+      if (streamOnly) endpoint.stream_only = true;
       if (capList.includes("thinking") && (providerSlug || selectedProvider?.slug) === "dashscope") {
         endpoint.extra_params = { enable_thinking: true };
       }
@@ -1143,6 +1148,7 @@ export function LLMView(props: LLMViewProps) {
     setConnTestResult(null);
     setProviderSlug(providers.find(p => p.slug === "openai")?.slug ?? providers[0]?.slug ?? "");
     setApiType("openai");
+    setStreamOnly(false);
     setBaseUrl("");
     setBaseUrlTouched(false);
     setApiKeyValue("");
@@ -1436,6 +1442,10 @@ export function LLMView(props: LLMViewProps) {
                     <Input type="number" value={String(endpointPriority)} onChange={(e) => setEndpointPriority(Number(e.target.value))} />
                   </div>
                 </div>
+                <div className="flex items-center justify-between">
+                  <Label className="flex items-center gap-1.5">Stream Only <span className="text-[11px] font-normal text-muted-foreground/70">强制使用流式传输</span></Label>
+                  <Switch checked={streamOnly} onCheckedChange={setStreamOnly} />
+                </div>
                 <div className="space-y-1.5">
                   <Label>{t("llm.advMaxTokens")} <span className="text-[11px] font-normal text-muted-foreground/70">{t("llm.advMaxTokensHint")}</span></Label>
                   <Input type="number" min={0} value={addEpMaxTokens} onChange={(e) => setAddEpMaxTokens(Math.max(0, parseInt(e.target.value) || 0))} />
@@ -1625,6 +1635,10 @@ export function LLMView(props: LLMViewProps) {
                     <Label>{t("llm.advPriority")}</Label>
                     <Input type="number" value={editDraft.priority} onChange={(e) => setEditDraft({ ...editDraft, priority: Number(e.target.value) || 1 })} />
                   </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label className="flex items-center gap-1.5">Stream Only <span className="text-[11px] font-normal text-muted-foreground/70">强制使用流式传输</span></Label>
+                  <Switch checked={editDraft.streamOnly} onCheckedChange={(v) => setEditDraft({ ...editDraft, streamOnly: v })} />
                 </div>
                 <div className="space-y-1.5">
                   <Label>{t("llm.advMaxTokens")} <span className="text-[11px] font-normal text-muted-foreground/70">{t("llm.advMaxTokensHint")}</span></Label>

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -288,7 +288,7 @@ def _schedule_background_save(
                     meta["artifacts"] = bg_artifacts
                 session.add_message("assistant", bg_reply, **meta)
                 if session_manager:
-                    session_manager.mark_dirty()
+                    session_manager.persist()
                 logger.info(
                     "[Chat API] Background save: %d chars (conv=%s)",
                     len(bg_reply),
@@ -710,7 +710,7 @@ async def _stream_chat(
                     _msg_meta["ask_user"] = _ask_user_data
                 session.add_message("assistant", assistant_text_to_save, **_msg_meta)
                 if session_manager:
-                    session_manager.mark_dirty()
+                    session_manager.persist()
             except Exception as e:
                 logger.error(
                     f"[Chat API] Failed to save assistant message to session: {e}", exc_info=True
@@ -818,7 +818,7 @@ async def _stream_chat(
                         _deferred_meta["artifacts"] = _collected_artifacts
                     session.add_message("assistant", _deferred_text, **_deferred_meta)
                     if session_manager:
-                        session_manager.mark_dirty()
+                        session_manager.persist()
                     logger.info(
                         f"[Chat API] Deferred save: {len(_deferred_text)} chars "
                         f"(client_disconnected={_client_disconnected})"

--- a/src/openakita/api/routes/config.py
+++ b/src/openakita/api/routes/config.py
@@ -44,8 +44,8 @@ def _read_endpoints_safe(ep_path: Path) -> dict | None:
 def _endpoints_config_path() -> Path:
     """Return the canonical llm_endpoints.json path.
 
-    Uses the same resolution logic as LLMClient so the Config API
-    reads/writes the SAME file that the LLM runtime actually loads.
+    Delegates to ``get_default_config_path()`` — the single source of truth
+    for config path resolution across LLMClient, EndpointManager, and this API.
     """
     try:
         from openakita.llm.config import get_default_config_path
@@ -411,7 +411,7 @@ def _get_endpoint_manager():
     root = _project_root()
     _mgr = getattr(_get_endpoint_manager, "_instance", None)
     if _mgr is None or _mgr._ws_dir != root:
-        _mgr = EndpointManager(root)
+        _mgr = EndpointManager(root, config_path=_endpoints_config_path())
         _get_endpoint_manager._instance = _mgr
     return _mgr
 
@@ -566,6 +566,9 @@ def _trigger_reload(request: Request) -> bool:
     if llm_client is None:
         return False
     try:
+        canonical = _endpoints_config_path()
+        if llm_client._config_path is not None and llm_client._config_path != canonical:
+            llm_client._config_path = canonical
         llm_client.reload()
         if brain and hasattr(brain, "reload_compiler_client"):
             brain.reload_compiler_client()

--- a/src/openakita/api/routes/config.py
+++ b/src/openakita/api/routes/config.py
@@ -35,6 +35,12 @@ def _project_root() -> Path:
         return Path.cwd()
 
 
+def _read_endpoints_safe(ep_path: Path) -> dict | None:
+    """Read llm_endpoints.json with .bak fallback."""
+    from openakita.utils.atomic_io import read_json_safe
+    return read_json_safe(ep_path)
+
+
 def _endpoints_config_path() -> Path:
     """Return the canonical llm_endpoints.json path.
 
@@ -157,10 +163,6 @@ def _update_env_content(
 class EnvUpdateRequest(BaseModel):
     entries: dict[str, str]
     delete_keys: list[str] = []
-
-
-class EndpointsWriteRequest(BaseModel):
-    content: dict  # Full JSON content of llm_endpoints.json
 
 
 class SkillsWriteRequest(BaseModel):
@@ -307,7 +309,10 @@ async def write_env(body: EnvUpdateRequest):
     - Non-empty values are upserted.
     - Empty string values are ignored (original value preserved).
     - Keys listed in ``delete_keys`` are explicitly removed.
+    - Uses atomic write with .bak backup to prevent corruption on crash.
     """
+    from openakita.utils.atomic_io import safe_write
+
     env_path = _project_root() / ".env"
     existing = ""
     if env_path.exists():
@@ -334,7 +339,7 @@ async def write_env(body: EnvUpdateRequest):
     new_content = _update_env_content(
         existing, safe_entries, delete_keys=set(body.delete_keys)
     )
-    env_path.write_text(new_content, encoding="utf-8")
+    safe_write(env_path, new_content)
     for key, value in safe_entries.items():
         if value:
             os.environ[key] = value
@@ -391,28 +396,12 @@ async def write_env(body: EnvUpdateRequest):
 
 @router.get("/api/config/endpoints")
 async def read_endpoints():
-    """Read data/llm_endpoints.json."""
+    """Read data/llm_endpoints.json, falling back to .bak if primary is corrupt."""
     ep_path = _endpoints_config_path()
-    if not ep_path.exists():
+    data = _read_endpoints_safe(ep_path)
+    if data is None:
         return {"endpoints": [], "raw": {}}
-    try:
-        data = json.loads(ep_path.read_text(encoding="utf-8"))
-        return {"endpoints": data.get("endpoints", []), "raw": data}
-    except Exception as e:
-        return {"error": str(e), "endpoints": [], "raw": {}}
-
-
-@router.post("/api/config/endpoints")
-async def write_endpoints(body: EndpointsWriteRequest):
-    """Write data/llm_endpoints.json."""
-    ep_path = _endpoints_config_path()
-    ep_path.parent.mkdir(parents=True, exist_ok=True)
-    ep_path.write_text(
-        json.dumps(body.content, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    logger.info("[Config API] Updated llm_endpoints.json (%s)", ep_path)
-    return {"status": "ok"}
+    return {"endpoints": data.get("endpoints", []), "raw": data}
 
 
 def _get_endpoint_manager():
@@ -506,6 +495,61 @@ async def endpoint_status():
     """Return key presence status for all configured endpoints."""
     mgr = _get_endpoint_manager()
     return {"endpoints": mgr.get_endpoint_status()}
+
+
+class ToggleEndpointRequest(BaseModel):
+    name: str
+    endpoint_type: str = "endpoints"
+
+
+class ReorderEndpointsRequest(BaseModel):
+    ordered_names: list[str]
+    endpoint_type: str = "endpoints"
+
+
+class UpdateSettingsRequest(BaseModel):
+    settings: dict
+
+
+@router.post("/api/config/toggle-endpoint")
+async def toggle_endpoint(body: ToggleEndpointRequest, request: Request):
+    """Toggle an endpoint's enabled/disabled state via EndpointManager."""
+    mgr = _get_endpoint_manager()
+    try:
+        updated = mgr.toggle_endpoint(body.name, endpoint_type=body.endpoint_type)
+    except (ValueError, Exception) as e:
+        logger.error("[Config API] toggle-endpoint failed: %s", e, exc_info=True)
+        return {"status": "error", "error": str(e)}
+    _trigger_reload(request)
+    return {"status": "ok", "endpoint": updated, "version": mgr.get_version()}
+
+
+@router.post("/api/config/reorder-endpoints")
+async def reorder_endpoints(body: ReorderEndpointsRequest, request: Request):
+    """Reorder endpoints by name list via EndpointManager."""
+    mgr = _get_endpoint_manager()
+    try:
+        result = mgr.reorder_endpoints(
+            body.ordered_names, endpoint_type=body.endpoint_type,
+        )
+    except (ValueError, Exception) as e:
+        logger.error("[Config API] reorder-endpoints failed: %s", e, exc_info=True)
+        return {"status": "error", "error": str(e)}
+    _trigger_reload(request)
+    return {"status": "ok", "endpoints": result, "version": mgr.get_version()}
+
+
+@router.post("/api/config/update-settings")
+async def update_endpoint_settings(body: UpdateSettingsRequest, request: Request):
+    """Merge settings into llm_endpoints.json via EndpointManager."""
+    mgr = _get_endpoint_manager()
+    try:
+        updated = mgr.update_settings(body.settings)
+    except Exception as e:
+        logger.error("[Config API] update-settings failed: %s", e, exc_info=True)
+        return {"status": "error", "error": str(e)}
+    _trigger_reload(request)
+    return {"status": "ok", "settings": updated, "version": mgr.get_version()}
 
 
 def _trigger_reload(request: Request) -> bool:

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -66,8 +66,8 @@ async def list_sessions(request: Request, channel: str = "desktop"):
     sessions = [s for s in sessions if not s.chat_id.startswith("org_")]
     sessions.sort(key=lambda s: s.last_active, reverse=True)
 
-    # Backward compatibility: old truncate_history injected synthetic system
-    # summaries into sessions. Hide them from the conversation list.
+    # 向后兼容：旧版 _truncate_history 会在 session 中插入 system 摘要消息，
+    # 新版已不再产生（改用 metadata trim），但已有 session 中可能残留这些消息。
     truncation_prefixes = ("[用户规则（必须遵守）]", "[历史背景，非当前任务]")
 
     result = []
@@ -142,6 +142,7 @@ async def get_session_history(
         return {"messages": []}
 
     _STRIP_MARKERS = ["\n\n[子Agent工作总结]", "\n\n[执行摘要]"]
+    # 向后兼容：过滤旧版 _truncate_history 插入的 system 摘要（新版已不再产生）
     truncation_prefixes = ("[用户规则（必须遵守）]", "[历史背景，非当前任务]")
 
     result = []

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -3020,8 +3020,7 @@ class MessageGateway:
             if _tool_summary:
                 _msg_meta["tool_summary"] = _tool_summary
             session.add_message(role="assistant", content=response_text, **_msg_meta)
-            self.session_manager.mark_dirty()
-            self.session_manager.flush()
+            self.session_manager.persist()
             _notify_im_event(
                 "im:new_message",
                 {

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -374,7 +374,7 @@ class Settings(BaseSettings):
 
     # === 会话配置 ===
     session_timeout_minutes: int = Field(default=30, description="会话超时时间（分钟）")
-    session_max_history: int = Field(default=50, description="会话最大历史消息数")
+    session_max_history: int = Field(default=2000, description="会话消息硬上限（日常由 metadata trim 控制体积）")
     session_storage_path: str = Field(default="data/sessions", description="会话存储路径")
 
     # === 多 Agent 模式 (Beta) ===

--- a/src/openakita/core/brain.py
+++ b/src/openakita/core/brain.py
@@ -1093,7 +1093,7 @@ class Brain:
         }
         stop_reason = stop_reason_map.get(response.stop_reason, "end_turn")
 
-        return AnthropicMessage(
+        msg = AnthropicMessage(
             id=response.id,
             type="message",
             role="assistant",
@@ -1106,6 +1106,14 @@ class Brain:
                 output_tokens=response.usage.output_tokens,
             ),
         )
+        # 透传端点信息供 reasoning_engine 检测 failover / thinking 降级
+        if hasattr(response, 'endpoint_name'):
+            msg.endpoint_name = response.endpoint_name  # type: ignore[attr-defined]
+        if hasattr(response, '_failover_from'):
+            msg._failover_from = response._failover_from  # type: ignore[attr-defined]
+        if hasattr(response, '_thinking_fallback'):
+            msg._thinking_fallback = response._thinking_fallback  # type: ignore[attr-defined]
+        return msg
 
     # ========================================================================
     # 高级方法：think（向后兼容）

--- a/src/openakita/core/brain.py
+++ b/src/openakita/core/brain.py
@@ -423,13 +423,14 @@ class Brain:
             if isinstance(block, TextBlock):
                 text_parts.append(block.text)
             elif isinstance(block, ToolUseBlock):
-                tool_calls.append(
-                    {
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
-                    }
-                )
+                d: dict = {
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
+                }
+                if block.provider_extra:
+                    d["provider_extra"] = block.provider_extra
+                tool_calls.append(d)
         return Response(
             content="\n".join(text_parts),
             tool_calls=tool_calls,
@@ -789,6 +790,7 @@ class Brain:
                                     id=part.get("id", ""),
                                     name=part.get("name", ""),
                                     input=part.get("input", {}),
+                                    provider_extra=part.get("provider_extra"),
                                 )
                             )
 
@@ -1415,14 +1417,15 @@ class Brain:
                     if isinstance(tc.input, dict)
                     else str(tc.input)
                 )
-                blocks.append(
-                    {
-                        "type": "tool_use",
-                        "id": tc.id,
-                        "name": tc.name,
-                        "input": input_str,
-                    }
-                )
+                d: dict = {
+                    "type": "tool_use",
+                    "id": tc.id,
+                    "name": tc.name,
+                    "input": input_str,
+                }
+                if getattr(tc, "provider_extra", None):
+                    d["provider_extra"] = tc.provider_extra
+                blocks.append(d)
             return blocks
 
         # Anthropic Message 格式
@@ -1458,14 +1461,19 @@ class Brain:
                     if isinstance(inp, dict)
                     else str(inp)
                 )
-                blocks.append(
-                    {
-                        "type": "tool_use",
-                        "id": bid,
-                        "name": name,
-                        "input": input_str,
-                    }
+                d2: dict = {
+                    "type": "tool_use",
+                    "id": bid,
+                    "name": name,
+                    "input": input_str,
+                }
+                extra = (
+                    block.get("provider_extra") if isinstance(block, dict)
+                    else getattr(block, "provider_extra", None)
                 )
+                if extra:
+                    d2["provider_extra"] = extra
+                blocks.append(d2)
             else:
                 blocks.append({"type": str(block_type), "raw": str(block)})
 

--- a/src/openakita/core/brain.py
+++ b/src/openakita/core/brain.py
@@ -612,10 +612,21 @@ class Brain:
             )
             _choices = getattr(response, "choices", None) or []
             _content = getattr(response, "content", None) or []
+            _out_tokens = response.usage.output_tokens if hasattr(response, "usage") else 0
+            _reasoning = bool(getattr(response, "reasoning_content", None))
+            _ = _choices  # reserved for upcoming choice-level diagnostics
             logger.info(
                 f"[Brain] messages_create_async success: "
-                f"choices={len(_choices)}, content_blocks={len(_content)}"
+                f"content_blocks={len(_content)}, tokens_out={_out_tokens}, "
+                f"has_reasoning={_reasoning}, endpoint={getattr(response, 'endpoint_name', '?')}"
             )
+            if not _content and _out_tokens > 0:
+                logger.warning(
+                    f"[Brain] ⚠️ EMPTY CONTENT with {_out_tokens} output tokens! "
+                    f"enable_thinking={use_thinking}, model={getattr(response, 'model', '?')}, "
+                    f"reasoning_content_len={len(response.reasoning_content) if response.reasoning_content else 0}, "
+                    f"stop_reason={getattr(response, 'stop_reason', '?')}"
+                )
         except Exception as e:
             logger.error(f"[Brain] messages_create_async FAILED: {type(e).__name__}: {e}")
             raise

--- a/src/openakita/core/brain.py
+++ b/src/openakita/core/brain.py
@@ -1363,6 +1363,10 @@ class Brain:
             }
             if self._trace_context:
                 debug_data["context"] = dict(self._trace_context)
+            # 原始响应诊断（CONTENT LOST 时由 provider 附加）
+            _raw_diag = getattr(response, "_raw_diagnostic", None)
+            if _raw_diag:
+                debug_data["raw_diagnostic"] = _raw_diag
 
             with open(debug_file, "w", encoding="utf-8") as f:
                 json.dump(debug_data, f, ensure_ascii=False, indent=2, default=str)

--- a/src/openakita/core/reasoning_engine.py
+++ b/src/openakita/core/reasoning_engine.py
@@ -4838,21 +4838,15 @@ class ReasoningEngine:
                 text_content += display_text
                 assistant_content.append({"type": "text", "text": raw_text})
             elif block.type == "tool_use":
-                tool_calls.append(
-                    {
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
-                    }
-                )
-                assistant_content.append(
-                    {
-                        "type": "tool_use",
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
-                    }
-                )
+                tc_dict: dict = {
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
+                }
+                if getattr(block, "provider_extra", None):
+                    tc_dict["provider_extra"] = block.provider_extra
+                tool_calls.append(tc_dict)
+                assistant_content.append({"type": "tool_use", **tc_dict})
 
         # 防御层：如果 provider 层未能从 thinking 内容中提取嵌入的工具调用，
         # 在此做最后一次检查（MiniMax-M2.5 已知会将 <minimax:tool_call> 嵌入 thinking 块）
@@ -4864,21 +4858,15 @@ class ReasoningEngine:
                     _, embedded_tool_calls = parse_text_tool_calls(thinking_content)
                     if embedded_tool_calls:
                         for tc in embedded_tool_calls:
-                            tool_calls.append(
-                                {
-                                    "id": tc.id,
-                                    "name": tc.name,
-                                    "input": tc.input,
-                                }
-                            )
-                            assistant_content.append(
-                                {
-                                    "type": "tool_use",
-                                    "id": tc.id,
-                                    "name": tc.name,
-                                    "input": tc.input,
-                                }
-                            )
+                            tc_dict = {
+                                "id": tc.id,
+                                "name": tc.name,
+                                "input": tc.input,
+                            }
+                            if getattr(tc, "provider_extra", None):
+                                tc_dict["provider_extra"] = tc.provider_extra
+                            tool_calls.append(tc_dict)
+                            assistant_content.append({"type": "tool_use", **tc_dict})
                         logger.warning(
                             f"[_parse_decision] Recovered {len(embedded_tool_calls)} tool calls "
                             f"from thinking content (provider-level extraction missed)"
@@ -4898,21 +4886,15 @@ class ReasoningEngine:
                     if embedded_tool_calls:
                         text_content = _clean
                         for tc in embedded_tool_calls:
-                            tool_calls.append(
-                                {
-                                    "id": tc.id,
-                                    "name": tc.name,
-                                    "input": tc.input,
-                                }
-                            )
-                            assistant_content.append(
-                                {
-                                    "type": "tool_use",
-                                    "id": tc.id,
-                                    "name": tc.name,
-                                    "input": tc.input,
-                                }
-                            )
+                            tc_dict = {
+                                "id": tc.id,
+                                "name": tc.name,
+                                "input": tc.input,
+                            }
+                            if getattr(tc, "provider_extra", None):
+                                tc_dict["provider_extra"] = tc.provider_extra
+                            tool_calls.append(tc_dict)
+                            assistant_content.append({"type": "tool_use", **tc_dict})
                         logger.warning(
                             f"[_parse_decision] Recovered {len(embedded_tool_calls)} tool calls "
                             f"from text content: {[tc.name for tc in embedded_tool_calls]}"

--- a/src/openakita/core/reasoning_engine.py
+++ b/src/openakita/core/reasoning_engine.py
@@ -2349,6 +2349,9 @@ class ReasoningEngine:
                 param_hash = hashlib.md5(param_str.encode()).hexdigest()[:8]
                 return f"{name}({param_hash})"
 
+            # --- Thinking 静默失败降级通知节流 (#415 #416 #403) ---
+            _thinking_notice_emitted = False
+
             # --- 恢复的 Todo：补发 SSE 事件让前端重建 FloatingPlanBar ---
             if conversation_id:
                 try:
@@ -2589,6 +2592,18 @@ class ReasoningEngine:
                             _raw_streamed_text = stream_event.get("raw_streamed_text", "")
                     if decision is None:
                         raise RuntimeError("_reason_stream returned no decision")
+
+                    # --- Thinking 降级通知 ---
+                    if not _thinking_notice_emitted and decision:
+                        _resp = getattr(decision, 'raw_response', None)
+                        if _resp and getattr(_resp, '_thinking_fallback', False):
+                            _thinking_notice_emitted = True
+                            yield {
+                                "type": "endpoint_notice",
+                                "notice_type": "degraded",
+                                "endpoint": getattr(_resp, 'endpoint_name', ''),
+                                "reason_code": "thinking_degraded",
+                            }
 
                     if task_monitor:
                         task_monitor.reset_retry_count()

--- a/src/openakita/llm/adapter.py
+++ b/src/openakita/llm/adapter.py
@@ -155,6 +155,7 @@ class LLMAdapter:
                                     id=part.get("id", ""),
                                     name=part.get("name", ""),
                                     input=part.get("input", {}),
+                                    provider_extra=part.get("provider_extra"),
                                 )
                             )
                         elif part_type == "tool_result":
@@ -194,14 +195,15 @@ class LLMAdapter:
         # 提取工具调用
         tool_calls = []
         for tc in response.tool_calls:
-            tool_calls.append(
-                {
-                    "type": "tool_use",
-                    "id": tc.id,
-                    "name": tc.name,
-                    "input": tc.input,
-                }
-            )
+            d = {
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.name,
+                "input": tc.input,
+            }
+            if getattr(tc, "provider_extra", None):
+                d["provider_extra"] = tc.provider_extra
+            tool_calls.append(d)
 
         return LegacyResponse(
             content=content,

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -40,6 +40,7 @@ from .types import (
     LLMRequest,
     LLMResponse,
     Message,
+    RateLimitError,
     TextBlock,
     ThinkingBlock,
     Tool,
@@ -89,7 +90,16 @@ def _friendly_error_hint(failed_providers: list | None = None, last_error: str =
     if FailoverReason.AUTH in categories:
         hints.append("🔑 检测到 API 认证失败，请检查 API Key 是否正确、是否过期。")
     if FailoverReason.TRANSIENT in categories:
-        hints.append("🌐 检测到网络超时/连接失败，请检查网络连接和代理设置。")
+        _has_rate_limit = failed_providers and any(
+            any(kw in (getattr(p, "_last_error", "") or "").lower()
+                for kw in ["rate limit", "rate_limit", "too many requests"])
+            for p in failed_providers
+            if getattr(p, "error_category", "") == FailoverReason.TRANSIENT
+        )
+        if _has_rate_limit:
+            hints.append("⏱️ 检测到 API 请求频率超限（限速），请稍后重试或降低请求频率。")
+        else:
+            hints.append("🌐 检测到网络超时/连接失败，请检查网络连接和代理设置。")
     if FailoverReason.STRUCTURAL in categories:
         hints.append("⚙️ 检测到请求格式错误，这通常是模型兼容性问题，请尝试切换其他模型。")
 
@@ -1481,6 +1491,19 @@ class LLMClient:
 
             except (UserCancelledError, asyncio.CancelledError):
                 raise
+
+            except RateLimitError as e:
+                # 429 限速：短冷静期，立即切换到下一端点（重试同一端点无意义）#324
+                # 所有端点都限速时 _resolve 的 transient 等待路径会处理
+                error_str = str(e)
+                logger.warning(
+                    f"[LLM] endpoint={provider.name} rate_limited, "
+                    f"switching to next endpoint. Error: {error_str[:200]}"
+                )
+                errors.append(f"{provider.name}: {e}")
+                provider.mark_unhealthy(error_str, category="transient")
+                failed_providers.append(provider)
+                continue
 
             except AuthenticationError as e:
                 error_str = str(e)

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -887,10 +887,10 @@ class LLMClient:
                     and (not require_vision or p.config.has_capability("vision"))
                 ]
 
-        # 如果降级了 thinking，更新 request
+        # thinking 降级标记 — 不立即修改 request，等确认确实需要降级时再改 (#327)
+        _thinking_downgraded = False
         if require_thinking:
-            request.enable_thinking = False
-            logger.info("[LLM] All endpoints in cooldown. Disabling thinking for fallback attempt.")
+            logger.info("[LLM] All endpoints in cooldown, attempting recovery before disabling thinking.")
 
         if base_capability_matched:
             unhealthy = [p for p in base_capability_matched if not p.is_healthy]
@@ -932,7 +932,26 @@ class LLMClient:
                                 pass
                         else:
                             await asyncio.sleep(wait_seconds)
-                        # 等待后重新筛选
+                        # 等待后重新筛选 — 先尝试保留 thinking (#327)
+                        if require_thinking:
+                            eligible = self._filter_eligible_endpoints(
+                                require_tools=require_tools,
+                                require_vision=require_vision,
+                                require_video=require_video,
+                                require_thinking=True,
+                                require_audio=require_audio,
+                                require_pdf=require_pdf,
+                                conversation_id=conversation_id,
+                                prefer_endpoint=prefer_endpoint,
+                            )
+                            if eligible:
+                                logger.info(
+                                    f"[LLM] Recovery detected: "
+                                    f"{len(eligible)} endpoints available after wait "
+                                    f"(thinking preserved)"
+                                )
+                                return eligible
+                        # 降级 thinking 再试
                         eligible = self._filter_eligible_endpoints(
                             require_tools=require_tools,
                             require_vision=require_vision,
@@ -944,9 +963,13 @@ class LLMClient:
                             prefer_endpoint=prefer_endpoint,
                         )
                         if eligible:
+                            if require_thinking:
+                                request.enable_thinking = False
+                                _thinking_downgraded = True
                             logger.info(
                                 f"[LLM] Recovery detected: "
                                 f"{len(eligible)} endpoints available after wait"
+                                + (" (thinking disabled)" if _thinking_downgraded else "")
                             )
                             return eligible
 

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -1371,7 +1371,9 @@ class LLMClient:
                     self._last_success_endpoint = provider.name
                 response.endpoint_name = provider.name
 
-                # ── 诊断: 非 thinking 场景下的空内容检测（CONTENT LOST 早期信号） ──
+                # ── 结构性失败: 有 token 但无内容 → 切换端点 (#418) ──
+                # 部分代理返回 content:null 但 output_tokens>0，
+                # 应视为端点异常而非成功，触发 failover
                 if not response.content and response.usage.output_tokens > 0:
                     logger.error(
                         f"[LLM] ⚠️ CONTENT LOST: endpoint={provider.name} "
@@ -1380,6 +1382,25 @@ class LLMClient:
                         f"stream_only={getattr(provider, '_stream_only', False)}, "
                         f"reasoning={bool(getattr(response, 'reasoning_content', None))})"
                     )
+                    provider._content_error = True
+                    errors.append(
+                        f"{provider.name}: Content lost "
+                        f"({response.usage.output_tokens} output tokens, 0 content)"
+                    )
+                    # 如果还有其他端点，切换过去尝试
+                    if i < len(providers) - 1:
+                        logger.info(
+                            f"[LLM] Content lost on {provider.name}, "
+                            f"trying next endpoint"
+                        )
+                        failed_providers.append(provider)
+                        continue
+                    # 最后一个端点也失败了，返回空响应（让上层处理兜底文案）
+                    logger.warning(
+                        f"[LLM] Content lost on ALL endpoints, "
+                        f"returning empty response from {provider.name}"
+                    )
+                    return response
 
                 return response
 

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -1370,6 +1370,58 @@ class LLMClient:
                 async with self._endpoint_lock:
                     self._last_success_endpoint = provider.name
                 response.endpoint_name = provider.name
+                # 标记 failover 信息供上层（reasoning_engine）发送通知
+                if i > 0 and providers:
+                    response._failover_from = providers[0].name  # type: ignore[attr-defined]
+
+                # ── 自愈: thinking 模式静默失败（HTTP 200 但内容为空） ──
+                # 部分 API 代理/中转接受 thinking 参数但在响应中剥离推理内容，
+                # 导致 output_tokens > 0 但 content 为空。
+                # 策略：仅对当前请求降级重试一次，不永久禁用 thinking。
+                # 必须在 content lost failover 块之前执行，否则 endpoint 会被切换掉。
+                if (
+                    not response.content
+                    and response.usage.output_tokens > 0
+                    and request.enable_thinking
+                    and not getattr(request, '_thinking_silent_retried', False)
+                ):
+                    logger.warning(
+                        f"[LLM] endpoint={provider.name}: thinking mode produced "
+                        f"{response.usage.output_tokens} output tokens but 0 visible content "
+                        f"(proxy may strip reasoning_content). "
+                        f"Retrying once with thinking disabled."
+                    )
+                    request._thinking_silent_retried = True  # type: ignore[attr-defined]
+                    _saved_thinking = request.enable_thinking
+                    _saved_depth = request.thinking_depth
+                    request.enable_thinking = False
+                    request.thinking_depth = None
+                    try:
+                        response = await self._try_with_retry(
+                            lambda p=provider: p.chat(request),
+                            cancel_event=cancel_event,
+                            max_attempts=max_attempts,
+                            request=request,
+                            provider_name=provider.name,
+                        )
+                        response.endpoint_name = provider.name
+                        if i > 0 and providers:
+                            response._failover_from = providers[0].name  # type: ignore[attr-defined]
+                        response._thinking_fallback = True  # type: ignore[attr-defined]
+                        logger.info(
+                            f"[LLM] endpoint={provider.name}: thinking fallback succeeded, "
+                            f"tokens_out={response.usage.output_tokens} "
+                            f"content_blocks={len(response.content)}"
+                        )
+                        return response
+                    except Exception as retry_err:
+                        logger.warning(
+                            f"[LLM] endpoint={provider.name}: thinking fallback retry "
+                            f"also failed: {retry_err}"
+                        )
+                        request.enable_thinking = _saved_thinking
+                        request.thinking_depth = _saved_depth
+                        # 落到下面 content lost failover 兜底
 
                 # ── 结构性失败: 有 token 但无内容 → 切换端点 (#418) ──
                 # 部分代理返回 content:null 但 output_tokens>0，

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -1771,6 +1771,7 @@ class LLMClient:
                         id=block.get("id", ""),
                         name=block.get("name", ""),
                         input=block.get("input", {}),
+                        provider_extra=block.get("provider_extra"),
                     )
                 )
             elif btype == "tool_result":

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -2239,11 +2239,14 @@ class LLMClient:
             return
 
         name_to_priority = {ep.name: ep.priority for ep in self._endpoints}
-        for ep_data in config_data.get("endpoints", []):
+        ep_list = config_data.get("endpoints", [])
+        for ep_data in ep_list:
             name = ep_data.get("name")
             if name in name_to_priority:
                 ep_data["priority"] = name_to_priority[name]
 
+        ep_list.sort(key=lambda e: (int(e.get("priority", 999)), e.get("name", "")))
+        config_data["endpoints"] = ep_list
         safe_json_write(self._config_path, config_data)
 
     async def close(self):

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -1370,6 +1370,17 @@ class LLMClient:
                 async with self._endpoint_lock:
                     self._last_success_endpoint = provider.name
                 response.endpoint_name = provider.name
+
+                # ── 诊断: 非 thinking 场景下的空内容检测（CONTENT LOST 早期信号） ──
+                if not response.content and response.usage.output_tokens > 0:
+                    logger.error(
+                        f"[LLM] ⚠️ CONTENT LOST: endpoint={provider.name} "
+                        f"tokens_out={response.usage.output_tokens} but content is empty "
+                        f"(enable_thinking={request.enable_thinking}, "
+                        f"stream_only={getattr(provider, '_stream_only', False)}, "
+                        f"reasoning={bool(getattr(response, 'reasoning_content', None))})"
+                    )
+
                 return response
 
             except (UserCancelledError, asyncio.CancelledError):

--- a/src/openakita/llm/config.py
+++ b/src/openakita/llm/config.py
@@ -220,20 +220,34 @@ def _ensure_workspace_env_loaded(config_path: Path) -> None:
 
 
 def get_default_config_path() -> Path:
-    """获取默认配置文件路径
+    """获取默认配置文件路径（唯一权威入口）
 
-    搜索顺序：
-    1. 环境变量 LLM_ENDPOINTS_CONFIG
-    2. CWD 及其父级（最多 3 层）下的 data/llm_endpoints.json
-    3. 包文件所在目录向上（最多 5 层）下的 data/llm_endpoints.json
-    4. 兜底返回 CWD/data/llm_endpoints.json（即使不存在）
+    v1.25.x 单工作区架构下，所有配置读写都应通过此函数获取路径，
+    确保 LLMClient / EndpointManager / Config API 操作同一文件。
+
+    解析顺序：
+    1. 环境变量 LLM_ENDPOINTS_CONFIG（Tauri 桌面端设置）
+    2. settings.project_root / data / llm_endpoints.json（运行时权威路径）
+    3. CWD 向上搜索（settings 不可用时的降级，如 CLI 早期初始化）
+    4. 包目录向上搜索（editable install 开发场景）
+    5. 兜底 CWD/data/llm_endpoints.json
     """
-    # 1) 环境变量优先
+    # 1) 环境变量优先（Tauri 桌面端通过此变量指定工作区配置）
     env_path = os.environ.get("LLM_ENDPOINTS_CONFIG")
     if env_path:
         return Path(env_path)
 
-    # 2) 从 CWD 向上搜索（pip install 场景：openakita init 在 CWD 创建 data/）
+    # 2) settings.project_root — 运行时唯一权威路径
+    #    无条件返回（不做 exists() 探测），因为单工作区下文件就应该在这里
+    try:
+        from openakita.config import settings
+        return Path(settings.project_root) / "data" / "llm_endpoints.json"
+    except Exception:
+        pass
+
+    # ── 以下仅在 settings 不可用时执行（CLI 早期 / 模块级初始化）──
+
+    # 3) 从 CWD 向上搜索（pip install 场景：openakita init 在 CWD 创建 data/）
     cwd = Path.cwd()
     current = cwd
     for _ in range(3):
@@ -245,7 +259,7 @@ def get_default_config_path() -> Path:
             break
         current = parent
 
-    # 3) 从包文件向上搜索（开发 / editable install 场景）
+    # 4) 从包文件向上搜索（开发 / editable install 场景）
     current = Path(__file__).parent
     for _ in range(5):
         config_path = current / "data" / "llm_endpoints.json"
@@ -253,7 +267,7 @@ def get_default_config_path() -> Path:
             return config_path
         current = current.parent
 
-    # 4) 兜底：返回 CWD 下的默认位置（让调用方统一处理不存在的情况）
+    # 5) 兜底
     return cwd / "data" / "llm_endpoints.json"
 
 

--- a/src/openakita/llm/config.py
+++ b/src/openakita/llm/config.py
@@ -132,9 +132,61 @@ def _safe_load_dotenv(env_path: Path) -> None:
         logger.error("Unexpected error loading %s: %s", env_path, e)
 
 
+def _try_recover_env_from_backup(env_path: Path) -> bool:
+    """If .env is missing or suspiciously small, try to restore from .env.bak.
+
+    Returns True if a backup was restored.
+    """
+    import shutil
+
+    bak = env_path.with_suffix(env_path.suffix + ".bak")
+    if not bak.exists():
+        return False
+
+    env_missing = not env_path.exists()
+    env_empty = False
+    bak_bigger = False
+
+    if not env_missing:
+        try:
+            env_size = env_path.stat().st_size
+            bak_size = bak.stat().st_size
+            env_empty = env_size < 10
+            bak_bigger = bak_size > env_size + 20
+        except OSError:
+            pass
+
+    if env_missing or (env_empty and bak.stat().st_size > 10):
+        reason = "missing" if env_missing else "empty/truncated"
+        logger.warning(
+            "[env recovery] .env is %s, restoring from .env.bak (%s)",
+            reason, bak,
+        )
+        try:
+            shutil.copy2(bak, env_path)
+            return True
+        except OSError as e:
+            logger.error("[env recovery] Failed to restore .env from backup: %s", e)
+
+    if bak_bigger:
+        logger.info(
+            "[env recovery] .env.bak is significantly larger than .env — "
+            "possible data loss. Backup preserved at %s",
+            bak,
+        )
+
+    return False
+
+
 def ensure_env_loaded(config_path: Path | None = None) -> Path | None:
-    """Load the workspace .env associated with the given config path."""
+    """Load the workspace .env associated with the given config path.
+
+    Checks for corruption/truncation first and restores from .bak if needed.
+    """
     env_path = get_workspace_env_path(config_path)
+
+    _try_recover_env_from_backup(env_path)
+
     if env_path.exists():
         _safe_load_dotenv(env_path)
         logger.info("Loaded .env from %s", env_path)
@@ -295,7 +347,10 @@ def save_endpoints_config(
     stt_endpoints: list[EndpointConfig] | None = None,
 ):
     """
-    保存端点配置
+    保存端点配置（CLI / 离线场景专用，通过 safe_write 原子写入）
+
+    注意：当后端 API 服务运行中时，所有端点写入应通过 EndpointManager（HTTP API）。
+    此函数仅用于后端未运行的 CLI 交互 / 初始化场景。
 
     Args:
         endpoints: 主端点配置列表

--- a/src/openakita/llm/converters/tools.py
+++ b/src/openakita/llm/converters/tools.py
@@ -509,30 +509,67 @@ _GLM_KV_RE = re.compile(
     re.DOTALL,
 )
 
+# Llama / Meta 风格: <function=name> <parameter=key> val </parameter> </function>
+# 部分模型（如 nvidia/nemotron）会把这种格式嵌套在 <tool_call> 里
+_LLAMA_FUNC_RE = re.compile(
+    r"<function=(\w[\w.-]*)>\s*(.*?)\s*</function>",
+    re.DOTALL | re.IGNORECASE,
+)
+_LLAMA_PARAM_RE = re.compile(
+    r"<parameter=(\w[\w.-]*)>\s*(.*?)\s*</parameter>",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 def _parse_glm(text: str) -> tuple[str, list[ToolUseBlock]]:
-    """解析 GLM 模型的 <tool_call> 格式。
+    """解析 <tool_call> 包裹的工具调用。
 
-    格式:
-    <tool_call>run_shell<arg_key>command</arg_key><arg_value>...</arg_value></tool_call>
+    支持两种内部格式:
+    1. GLM 原生:  <tool_call>run_shell<arg_key>cmd</arg_key><arg_value>ls</arg_value></tool_call>
+    2. Llama 风格: <tool_call><function=run_shell><parameter=cmd>ls</parameter></function></tool_call>
+
+    当 GLM 格式解析失败（内容以 '<' 开头而非工具名）时自动尝试 Llama 格式。
     """
     matches = _GLM_COMPLETE_RE.findall(text) or _GLM_INCOMPLETE_RE.findall(text)
 
     tool_calls: list[ToolUseBlock] = []
     for content in matches:
-        name_match = re.match(r"(\w[\w-]*)", content.strip())
-        if not name_match:
-            continue
-        tool_name = name_match.group(1)
+        stripped = content.strip()
+        name_match = re.match(r"(\w[\w-]*)", stripped)
 
-        params: dict = {}
-        for kv in _GLM_KV_RE.finditer(content):
-            key, val = kv.group(1).strip(), kv.group(2).strip()
+        if name_match:
+            tool_name = name_match.group(1)
+            params: dict = {}
+            for kv in _GLM_KV_RE.finditer(content):
+                key, val = kv.group(1).strip(), kv.group(2).strip()
+                try:
+                    params[key] = json.loads(val)
+                except json.JSONDecodeError:
+                    params[key] = val
+            tool_calls.append(ToolUseBlock(
+                id=f"glm_call_{uuid.uuid4().hex[:8]}",
+                name=tool_name,
+                input=params,
+            ))
+            logger.info(
+                "[GLM_TOOL_PARSE] Extracted tool call: %s with params: %s",
+                tool_name, list(params.keys()),
+            )
+            continue
+
+        # Fallback: Llama / Meta 风格 <function=name>...<parameter=key>val</parameter>...</function>
+        func_match = _LLAMA_FUNC_RE.search(stripped)
+        if not func_match:
+            continue
+        tool_name = func_match.group(1)
+        func_body = func_match.group(2)
+        params = {}
+        for pm in _LLAMA_PARAM_RE.finditer(func_body):
+            key, val = pm.group(1).strip(), pm.group(2).strip()
             try:
                 params[key] = json.loads(val)
             except json.JSONDecodeError:
                 params[key] = val
-
         tool_calls.append(
             ToolUseBlock(
                 id=f"glm_call_{uuid.uuid4().hex[:8]}",
@@ -541,7 +578,8 @@ def _parse_glm(text: str) -> tuple[str, list[ToolUseBlock]]:
             )
         )
         logger.info(
-            f"[GLM_TOOL_PARSE] Extracted tool call: {tool_name} with params: {list(params.keys())}"
+            f"[GLM_TOOL_PARSE] Extracted Llama-style tool call: {tool_name} "
+            f"with params: {list(params.keys())}"
         )
 
     # 即使未提取到工具也清理标签，防止原始标签泄漏到用户界面

--- a/src/openakita/llm/endpoint_manager.py
+++ b/src/openakita/llm/endpoint_manager.py
@@ -297,6 +297,88 @@ class EndpointManager:
         return result
 
     # ------------------------------------------------------------------
+    # Granular operations (toggle / reorder / settings)
+    # ------------------------------------------------------------------
+
+    def toggle_endpoint(
+        self,
+        name: str,
+        endpoint_type: str = "endpoints",
+    ) -> dict:
+        """Toggle the ``enabled`` flag for an endpoint. Returns the updated entry."""
+        if endpoint_type not in _ENDPOINT_LISTS:
+            raise ValueError(f"Invalid endpoint_type: {endpoint_type}")
+
+        with self._lock:
+            config = self._read_json()
+            ep_list = config.get(endpoint_type, [])
+
+            target = None
+            for ep in ep_list:
+                if ep.get("name") == name:
+                    target = ep
+                    break
+
+            if target is None:
+                raise ValueError(f"Endpoint '{name}' not found in {endpoint_type}")
+
+            target["enabled"] = not target.get("enabled", True)
+            config[endpoint_type] = ep_list
+            self._write_json(config)
+            return dict(target)
+
+    def reorder_endpoints(
+        self,
+        ordered_names: list[str],
+        endpoint_type: str = "endpoints",
+    ) -> list[dict]:
+        """Reorder endpoints by assigning incremental ``priority`` values.
+
+        Endpoints whose names are in *ordered_names* get priority 10, 20, ...
+        in the given order.  Any endpoints not listed keep their original
+        relative order and are appended after the listed ones.
+        """
+        if endpoint_type not in _ENDPOINT_LISTS:
+            raise ValueError(f"Invalid endpoint_type: {endpoint_type}")
+
+        with self._lock:
+            config = self._read_json()
+            ep_list = config.get(endpoint_type, [])
+
+            by_name: dict[str, dict] = {ep.get("name", ""): ep for ep in ep_list}
+            result: list[dict] = []
+            step = 10
+
+            for i, name in enumerate(ordered_names, 1):
+                if name in by_name:
+                    ep = by_name.pop(name)
+                    ep["priority"] = i * step
+                    result.append(ep)
+
+            for ep in ep_list:
+                name = ep.get("name", "")
+                if name in by_name:
+                    ep["priority"] = (len(ordered_names) + len(result) + 1) * step
+                    result.append(ep)
+                    by_name.pop(name, None)
+
+            config[endpoint_type] = result
+            self._write_json(config)
+            return result
+
+    def update_settings(self, settings: dict) -> dict:
+        """Merge *settings* into the top-level ``settings`` key of the config."""
+        with self._lock:
+            config = self._read_json()
+            existing = config.get("settings", {})
+            if not isinstance(existing, dict):
+                existing = {}
+            existing.update(settings)
+            config["settings"] = existing
+            self._write_json(config)
+            return existing
+
+    # ------------------------------------------------------------------
     # File I/O with atomic write + backup
     # ------------------------------------------------------------------
 

--- a/src/openakita/llm/endpoint_manager.py
+++ b/src/openakita/llm/endpoint_manager.py
@@ -135,9 +135,9 @@ class EndpointManager:
     所有对 .env 和 llm_endpoints.json 的写操作都必须经过这里。
     """
 
-    def __init__(self, workspace_dir: Path):
+    def __init__(self, workspace_dir: Path, *, config_path: Path | None = None):
         self._ws_dir = Path(workspace_dir)
-        self._json_path = self._ws_dir / "data" / "llm_endpoints.json"
+        self._json_path = Path(config_path) if config_path else (self._ws_dir / "data" / "llm_endpoints.json")
         self._env_path = self._ws_dir / ".env"
         self._lock = threading.Lock()
 

--- a/src/openakita/llm/providers/base.py
+++ b/src/openakita/llm/providers/base.py
@@ -335,10 +335,11 @@ class LLMProvider(ABC):
     def _classify_error(error: str) -> str:
         """根据错误信息自动分类。
 
-        分类优先级: content_safety > quota > auth > structural > transient > unknown
+        分类优先级: content_safety > quota > auth > rate_limit(→transient) > structural > transient > unknown
         content_safety 必须最优先检测，否则 "data_inspection_failed" 中的
         "(400)" 或其他子串会被错误分到 STRUCTURAL，导致换端点重试浪费配额。
         quota 必须在 auth 之前检测，因为 403 配额耗尽也包含 "403" 关键字。
+        rate_limit 必须在 structural 之前检测，因为某些提供商 429 响应体含 "invalid_request"。
 
         返回 ``FailoverReason`` 枚举成员 (StrEnum, 与字符串互兼容)。
         """
@@ -386,6 +387,21 @@ class LLMProvider(ABC):
         ):
             return FailoverReason.AUTH
 
+        # 限速类（必须在 structural 之前，某些提供商 429 响应体含 "invalid_request"）#324
+        if any(
+            kw in err_lower
+            for kw in [
+                "rate limit",
+                "rate_limit",
+                "too many requests",
+                "rate reaches maximum",
+                "request rate",
+                "(429)",
+            ]
+        ):
+            return FailoverReason.TRANSIENT
+
+        # 结构性/格式类
         # 注意: 用 "(400)" 而非 "400"，避免匹配 HTML 中的 CSS 类名等内容
         if any(
             kw in err_lower

--- a/src/openakita/llm/providers/base.py
+++ b/src/openakita/llm/providers/base.py
@@ -128,10 +128,12 @@ class LLMProvider(ABC):
             self._error_category = ""
             if self._is_extended_cooldown:
                 self._is_extended_cooldown = False
-                # 渐进退避冷静期结束后重置连续计数，给端点重新证明自己的机会
-                self._consecutive_cooldowns = 0
+                # 不重置 _consecutive_cooldowns：只有 record_success() 才重置。
+                # 这样持续失败的端点在冷却到期后如果再次失败，会直接进入
+                # 上一次的退避阶级（而非从 0 重新开始），避免 5s→10s→reset 循环。
                 logger.info(
-                    f"[LLM] endpoint={self.name} progressive cooldown expired, reset to healthy"
+                    f"[LLM] endpoint={self.name} progressive cooldown expired, "
+                    f"reset to healthy (consecutive_cooldowns={self._consecutive_cooldowns} preserved)"
                 )
 
         return self._healthy
@@ -175,14 +177,14 @@ class LLMProvider(ABC):
                 - "structural": 结构性/格式错误 (10s)
                 - "transient": 超时/连接错误 (5s)
                 - "": 默认 (30s)
-            is_local: 是否为本地端点（Ollama 等），本地端点 transient
-                错误不参与渐进升级（超时是资源不足，非远程故障）
+            is_local: 是否为本地端点（Ollama 等），影响 transient 错误的退避策略
 
         渐进式冷静期退避：
             连续非结构性错误进入冷静期（中间没有成功请求），冷静期从
-            COOLDOWN_ESCALATION_STEPS 按次数递增，上限 5 分钟。
+            COOLDOWN_ESCALATION_STEPS 按次数递增，上限 60 秒。
             - 结构性错误不计入连续次数（重试不会改变结果）
-            - 本地端点 transient 错误不触发渐进升级（超时是正常行为）
+            - 本地端点 Timeout 不触发渐进升级（超时是推理资源不足）
+            - 本地端点 ConnectError 正常参与渐进升级（服务未启动，持续重试无意义）
         """
         was_already_unhealthy = not self._healthy
         self._healthy = False
@@ -192,9 +194,10 @@ class LLMProvider(ABC):
         # 累计连续冷静期次数
         # - 只在从健康 → 不健康时递增（同一轮重试中多次 mark_unhealthy 不重复计数）
         # - 结构性错误不累计：每次重试结果相同
-        # - 本地端点 transient 错误不累计：超时是资源不足，惩罚无意义
+        # - 本地端点 Timeout 不累计：超时是推理资源不足，惩罚无意义
+        #   但 ConnectError（服务未启动）应参与渐进退避，否则 5s 冷却循环浪费资源
         skip_escalation = self._error_category == "structural" or (
-            is_local and self._error_category == "transient"
+            is_local and self._error_category == "transient" and self._is_timeout_error(error)
         )
         if not skip_escalation and not was_already_unhealthy:
             self._consecutive_cooldowns += 1
@@ -219,8 +222,9 @@ class LLMProvider(ABC):
         elif self._error_category == "structural":
             cooldown = COOLDOWN_STRUCTURAL
         elif self._error_category == "transient":
-            if is_local:
-                # 本地端点超时固定短冷静期，不升级
+            _local_timeout = is_local and self._is_timeout_error(error)
+            if _local_timeout:
+                # 本地端点超时固定短冷静期，不升级（服务在跑但慢）
                 cooldown = COOLDOWN_TRANSIENT
             elif self._consecutive_cooldowns >= 2:
                 # 远程端点连续失败 → 渐进退避
@@ -320,6 +324,12 @@ class LLMProvider(ABC):
             if self._is_extended_cooldown:
                 self._is_extended_cooldown = False
             self._cooldown_until = new_until
+
+    @staticmethod
+    def _is_timeout_error(error: str) -> bool:
+        """判断是否为超时错误（区别于连接拒绝等其他 transient 错误）"""
+        err = error.lower()
+        return any(kw in err for kw in ["timeout", "timed out"])
 
     @staticmethod
     def _classify_error(error: str) -> str:

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -273,14 +273,14 @@ class OpenAIProvider(LLMProvider):
         )
 
     async def chat(self, request: LLMRequest) -> LLMResponse:
-        """发送聊天请求（支持 stream-only 端点自动检测）"""
+        """发送聊天请求（支持 stream-only 端点自动检测 + 空响应流式回退）"""
         await self.acquire_rate_limit()
 
         if self._stream_only:
             return await self._chat_via_stream(request)
 
         try:
-            return await self._chat_non_stream(request)
+            response = await self._chat_non_stream(request)
         except (AuthenticationError, RateLimitError):
             raise
         except LLMError as e:
@@ -292,6 +292,37 @@ class OpenAIProvider(LLMProvider):
                 self._stream_only = True
                 return await self._chat_via_stream(request)
             raise
+
+        # 同步响应空内容 + 有 token 消耗 → 流式回退重试（单次）
+        # 部分中转代理在同步模式下丢失内容但流式模式正常
+        if (
+            not response.content
+            and response.usage.output_tokens > 0
+            and not getattr(request, '_stream_fallback_tried', False)
+        ):
+            logger.warning(
+                f"[OpenAI] '{self.name}': sync response empty with "
+                f"{response.usage.output_tokens} output tokens, "
+                f"retrying via stream transport"
+            )
+            request._stream_fallback_tried = True  # type: ignore[attr-defined]
+            try:
+                stream_response = await self._chat_via_stream(request)
+                if stream_response.content:
+                    logger.info(
+                        f"[OpenAI] '{self.name}': stream fallback recovered content "
+                        f"({len(stream_response.content)} blocks)"
+                    )
+                    return stream_response
+                logger.warning(
+                    f"[OpenAI] '{self.name}': stream fallback also returned empty content"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[OpenAI] '{self.name}': stream fallback failed: {e}"
+                )
+
+        return response
 
     async def _chat_non_stream(self, request: LLMRequest) -> LLMResponse:
         """非流式请求实现（原始路径，逻辑完全不变）。调用方须已获取 rate limit。"""
@@ -356,9 +387,13 @@ class OpenAIProvider(LLMProvider):
                 )
                 raise LLMError(f"API error in response body: {err_msg}")
 
-            # HTTP 200 但 choices 为空 —— 某些中转/兼容 API 的异常行为
+            # HTTP 200 但 choices 为空 —— 尝试 Responses API 解析
             choices = data.get("choices")
             if not choices:
+                _output = data.get("output")
+                if isinstance(_output, list) and _output:
+                    self.mark_healthy()
+                    return self._parse_responses_api(data, _output)
                 body_preview = json.dumps(data, ensure_ascii=False)[:500]
                 logger.warning(
                     f"[OpenAI] '{self.name}': API returned 200 but choices is empty. "
@@ -921,10 +956,63 @@ class OpenAIProvider(LLMProvider):
 
         return body
 
+    @staticmethod
+    def _extract_from_responses_output(output: list) -> str:
+        """从 OpenAI Responses API 的 output 数组中提取文本内容。"""
+        texts: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            itype = item.get("type", "")
+            if itype == "message":
+                for part in item.get("content", []):
+                    if isinstance(part, dict):
+                        ptype = part.get("type", "")
+                        if ptype in ("output_text", "text"):
+                            texts.append(part.get("text", ""))
+                    elif isinstance(part, str):
+                        texts.append(part)
+            elif itype in ("text", "output_text"):
+                texts.append(item.get("text", ""))
+        return "".join(texts)
+
+    def _parse_responses_api(self, data: dict, output: list) -> LLMResponse:
+        """解析 OpenAI Responses API 格式的响应。"""
+        text = self._extract_from_responses_output(output)
+        content_blocks = [TextBlock(text=text)] if text else []
+
+        usage_data = data.get("usage", {})
+        usage = Usage(
+            input_tokens=usage_data.get("input_tokens") or usage_data.get("prompt_tokens", 0),
+            output_tokens=usage_data.get("output_tokens") or usage_data.get("completion_tokens", 0),
+        )
+
+        if content_blocks:
+            logger.info(
+                f"[PARSE] Parsed Responses API format: {len(text)} chars from {self.name}"
+            )
+        else:
+            logger.warning(
+                f"[PARSE] Responses API format detected but no text extracted from {self.name}, "
+                f"output_items={len(output)}"
+            )
+
+        return LLMResponse(
+            id=data.get("id", ""),
+            content=content_blocks,
+            stop_reason=StopReason.END_TURN,
+            usage=usage,
+            model=data.get("model", self.config.model),
+        )
+
     def _parse_response(self, data: dict) -> LLMResponse:
         """解析响应"""
         choices = data.get("choices", [])
         if not choices:
+            # Responses API 兼容：部分中转代理使用 output 字段返回内容
+            _output = data.get("output")
+            if isinstance(_output, list) and _output:
+                return self._parse_responses_api(data, _output)
             return LLMResponse(
                 id=data.get("id", ""),
                 content=[],
@@ -1024,6 +1112,14 @@ class OpenAIProvider(LLMProvider):
                     f"from {'reasoning_content' if _tool_calls_from_reasoning else 'text'}"
                 )
 
+        # ── pull usage early so empty-content fallbacks below can reference token counts ──
+        usage_data = data.get("usage", {})
+        _out_tokens = int(
+            usage_data.get("output_tokens")
+            or usage_data.get("completion_tokens")
+            or 0
+        )
+
         # Reasoning 模型容错：content 为空但 reasoning 有内容
         # 当 reasoning 模型被 max_tokens 截断时，所有输出可能都在 reasoning 字段，
         # content 为空。此时尝试从 reasoning 中提取结构化内容作为兜底。
@@ -1042,14 +1138,79 @@ class OpenAIProvider(LLMProvider):
                     f"({len(text_content)} chars extracted from {len(reasoning_content)} chars reasoning)"
                 )
             else:
+                # 1. 把 reasoning 全文作为 visible text fallback (优于直接放弃)
+                text_content = reasoning_content
+                reasoning_content = ""
+                content_blocks.insert(0, TextBlock(text=text_content))
                 logger.warning(
-                    f"[PARSE] content is empty, reasoning has {len(reasoning_content)} chars "
-                    f"but no extractable structured content. Response may be truncated "
-                    f"(model exhausted max_tokens on reasoning before producing content)."
+                    f"[PARSE] content is empty; using reasoning_content "
+                    f"({len(text_content)} chars) as visible text fallback from {self.name}"
+                )
+
+            # 2. 检查 message 中其他可能的文本字段
+            if not content_blocks and _out_tokens > 0:
+                for alt_key in ("reasoning", "output", "text", "thinking", "refusal"):
+                    alt_val = message.get(alt_key)
+                    if alt_val and isinstance(alt_val, str) and alt_val.strip():
+                        logger.warning(
+                            f"[PARSE] Recovered {len(alt_val)} chars from message.{alt_key} "
+                            f"(content was empty, {_out_tokens} output tokens) from {self.name}"
+                        )
+                        text_content = alt_val.strip()
+                        content_blocks.insert(0, TextBlock(text=text_content))
+                        break
+
+            # 3. Responses API 兼容 — 部分代理将内容放在 data.output 中
+            if not content_blocks and _out_tokens > 0:
+                _output = data.get("output")
+                if isinstance(_output, list) and _output:
+                    _recovered = self._extract_from_responses_output(_output)
+                    if _recovered:
+                        content_blocks.insert(0, TextBlock(text=_recovered))
+                        logger.info(
+                            f"[PARSE] Recovered {len(_recovered)} chars from data.output "
+                            f"(Responses API format) from {self.name}"
+                        )
+
+            # 4. choice.text 兼容（旧式 Completions API 格式）
+            if not content_blocks and _out_tokens > 0:
+                _choice_text = choice.get("text")
+                if _choice_text and isinstance(_choice_text, str) and _choice_text.strip():
+                    content_blocks.insert(0, TextBlock(text=_choice_text.strip()))
+                    logger.info(
+                        f"[PARSE] Recovered {len(_choice_text)} chars from choice.text "
+                        f"(legacy Completions format) from {self.name}"
+                    )
+
+            # 5. 仍然为空 → 记录详细诊断信息（帮助定位代理格式变化）
+            if not content_blocks and _out_tokens > 0:
+                msg_keys = sorted(k for k in message.keys() if k != "role")
+                msg_preview = {
+                    k: (str(v)[:200] if isinstance(v, str)
+                        else f"[{type(v).__name__}, len={len(v)}]" if isinstance(v, (list, dict))
+                        else str(v)[:100])
+                    for k, v in message.items() if k != "role"
+                }
+                _extra_keys = sorted(
+                    k for k in data.keys()
+                    if k not in ("id", "object", "created", "model", "choices", "usage", "system_fingerprint")
+                )
+                _choice_keys = sorted(
+                    k for k in choice.keys() if k not in ("message", "index", "finish_reason", "logprobs")
+                )
+                _token_details = usage_data.get("completion_tokens_details")
+                logger.error(
+                    f"[PARSE] ⚠️ CONTENT LOST: {_out_tokens} output tokens but content_blocks "
+                    f"is empty from {self.name}. message keys={msg_keys}, "
+                    f"preview={msg_preview}, "
+                    f"extra_data_keys={_extra_keys}, extra_choice_keys={_choice_keys}, "
+                    f"token_details={_token_details}"
                 )
 
         # 添加文本内容
-        if text_content:
+        if text_content and not any(
+            isinstance(b, TextBlock) and b.text == text_content for b in content_blocks
+        ):
             content_blocks.insert(0, TextBlock(text=text_content))
 
         # 解析停止原因
@@ -1068,8 +1229,7 @@ class OpenAIProvider(LLMProvider):
             }
             stop_reason = stop_reason_map.get(finish_reason, StopReason.END_TURN)
 
-        # 解析使用统计
-        usage_data = data.get("usage", {})
+        # 解析使用统计（usage_data 已在前面 empty-content fallback 链中提取）
         # OpenAI 兼容协议（DashScope/OpenAI/部分 OpenAI 兼容网关）通过
         # prompt_tokens_details.cached_tokens 暴露 prompt cache 命中数。
         # 部分模型（如 DashScope 新加坡区 / qwen3-vl-*）直接放在 usage.cached_tokens。

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -675,6 +675,7 @@ class OpenAIProvider(LLMProvider):
             stop_reason=stop_reason,
             usage=_usage,
             model=response_model,
+            reasoning_content=_reasoning_text or None,
         )
 
     async def chat_stream(self, request: LLMRequest) -> AsyncIterator[dict]:
@@ -1068,14 +1069,23 @@ class OpenAIProvider(LLMProvider):
         # 部分 OpenAI 兼容 API (如 Google Gemini OpenAI-compat) 返回 content 为数组:
         #   [{"type": "text", "text": "..."}, ...]
         raw_content = message.get("content")
+        _thinking_from_content: list[str] = []
         if isinstance(raw_content, list):
             text_content = ""
             for part in raw_content:
-                if isinstance(part, dict) and part.get("type") == "text":
-                    text_content += part.get("text", "")
+                if isinstance(part, dict):
+                    ptype = part.get("type", "")
+                    if ptype == "text" or ptype == "output_text":
+                        text_content += part.get("text", "")
+                    elif ptype == "thinking":
+                        _tval = part.get("thinking", "") or part.get("text", "")
+                        if _tval:
+                            _thinking_from_content.append(_tval)
+                    elif "text" in part and ptype not in ("tool_use", "image"):
+                        text_content += part.get("text", "")
                 elif isinstance(part, str):
                     text_content += part
-            if not text_content and raw_content:
+            if not text_content and raw_content and not _thinking_from_content:
                 logger.warning(
                     f"[PARSE] content is list but no text parts extracted: "
                     f"types={[p.get('type') if isinstance(p, dict) else type(p).__name__ for p in raw_content[:3]]}"
@@ -1121,6 +1131,17 @@ class OpenAIProvider(LLMProvider):
                 reasoning_content = _or_reasoning
             elif isinstance(_or_reasoning, dict):
                 reasoning_content = _or_reasoning.get("content", "") or ""
+        # 收集 content 数组中的 thinking 块到 reasoning_content (#415)
+        if _thinking_from_content:
+            _joined = "\n".join(_thinking_from_content)
+            if reasoning_content:
+                reasoning_content = reasoning_content + "\n" + _joined
+            else:
+                reasoning_content = _joined
+            logger.info(
+                f"[PARSE] Extracted {len(_thinking_from_content)} thinking block(s) "
+                f"({len(_joined)} chars) from content array into reasoning_content"
+            )
         if not has_tool_calls and not text_content and reasoning_content:
             if has_text_tool_calls(reasoning_content):
                 combined_for_check = reasoning_content

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -410,7 +410,13 @@ class OpenAIProvider(LLMProvider):
                 )
 
             self.mark_healthy()
-            return self._parse_response(data)
+            self._last_raw_diagnostic = None
+            result = self._parse_response(data)
+            # 附加原始响应诊断（content lost 时由 _parse_response 设置）
+            _diag = self._last_raw_diagnostic
+            if _diag and not result.content:
+                result._raw_diagnostic = _diag  # type: ignore[attr-defined]
+            return result
 
         except httpx.TimeoutException as e:
             detail = f"{type(e).__name__}: {e}"
@@ -1206,6 +1212,18 @@ class OpenAIProvider(LLMProvider):
                     f"extra_data_keys={_extra_keys}, extra_choice_keys={_choice_keys}, "
                     f"token_details={_token_details}"
                 )
+                # 附加原始响应摘要供 llm_debug 保存
+                self._last_raw_diagnostic = {
+                    "endpoint": self.name,
+                    "data_keys": sorted(data.keys()),
+                    "choice_keys": sorted(choice.keys()),
+                    "message_keys": msg_keys,
+                    "message_preview": msg_preview,
+                    "extra_data_keys": _extra_keys,
+                    "extra_choice_keys": _choice_keys,
+                    "token_details": _token_details,
+                    "usage": usage_data,
+                }
 
         # 添加文本内容
         if text_content and not any(

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -605,6 +605,9 @@ class OpenAIProvider(LLMProvider):
                         elif delta.get("name") and not tool_calls[call_id]["name"]:
                             tool_calls[call_id]["name"] = delta["name"]
                         current_tool_id = call_id
+                        extra = delta.get("extra_content")
+                        if extra and "extra_content" not in tool_calls[call_id]:
+                            tool_calls[call_id]["extra_content"] = extra
                     target_id = call_id or current_tool_id
                     if target_id and target_id in tool_calls:
                         tool_calls[target_id]["arguments"] += delta.get("arguments") or ""
@@ -637,6 +640,7 @@ class OpenAIProvider(LLMProvider):
                     id=call_id,
                     name=tc["name"],
                     input=args,
+                    provider_extra=tc.get("extra_content"),
                 )
             )
 
@@ -1394,15 +1398,19 @@ class OpenAIProvider(LLMProvider):
             tool_calls = delta["tool_calls"]
             if tool_calls:
                 tc = tool_calls[0]
+                d = {
+                    "type": "tool_use",
+                    "id": tc.get("id"),
+                    "name": tc.get("function", {}).get("name"),
+                    "arguments": tc.get("function", {}).get("arguments"),
+                }
+                extra = tc.get("extra_content")
+                if extra:
+                    d["extra_content"] = extra
                 events.append(
                     {
                         "type": "content_block_delta",
-                        "delta": {
-                            "type": "tool_use",
-                            "id": tc.get("id"),
-                            "name": tc.get("function", {}).get("name"),
-                            "arguments": tc.get("function", {}).get("arguments"),
-                        },
+                        "delta": d,
                     }
                 )
 

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -56,6 +56,22 @@ def _is_stream_only_error(error: str) -> bool:
     )
 
 
+def _is_empty_response_error(error: str) -> bool:
+    """检测错误是否为非流式空响应（可能流式模式能正常返回内容）。
+
+    仅匹配 _chat_non_stream 产生的 "choices/output 为空" 错误，
+    不匹配流式路径的空响应错误。
+    """
+    err_lower = error.lower()
+    if "stream" in err_lower:
+        return False
+    return (
+        "empty response" in err_lower
+        or "no choices" in err_lower
+        or "no output" in err_lower
+    )
+
+
 def _humanize_upstream_error(status: int, body: str) -> str:
     """把云端 LLM 的英文错误转成对小白用户更友好的中文摘要。
 
@@ -273,17 +289,27 @@ class OpenAIProvider(LLMProvider):
         )
 
     async def chat(self, request: LLMRequest) -> LLMResponse:
-        """发送聊天请求（支持 stream-only 端点自动检测 + 空响应流式回退）"""
+        """发送聊天请求（统一的非流式 → 流式自动回退）
+
+        回退策略（按优先级）：
+        1. 配置 stream_only → 直接走流式
+        2. 代理明确要求 stream → 永久切换流式
+        3. 非流式空响应异常 / 非流式成功但内容空+token>0 → 尝试流式，成功则记忆
+        """
         await self.acquire_rate_limit()
 
         if self._stream_only:
             return await self._chat_via_stream(request)
+
+        response: LLMResponse | None = None
+        non_stream_error: LLMError | None = None
 
         try:
             response = await self._chat_non_stream(request)
         except (AuthenticationError, RateLimitError):
             raise
         except LLMError as e:
+            non_stream_error = e
             if _is_stream_only_error(str(e)):
                 logger.info(
                     f"[OpenAI] '{self.name}': detected stream-only endpoint, "
@@ -291,38 +317,44 @@ class OpenAIProvider(LLMProvider):
                 )
                 self._stream_only = True
                 return await self._chat_via_stream(request)
-            raise
 
-        # 同步响应空内容 + 有 token 消耗 → 流式回退重试（单次）
-        # 部分中转代理在同步模式下丢失内容但流式模式正常
-        if (
-            not response.content
-            and response.usage.output_tokens > 0
-            and not getattr(request, '_stream_fallback_tried', False)
-        ):
-            logger.warning(
-                f"[OpenAI] '{self.name}': sync response empty with "
-                f"{response.usage.output_tokens} output tokens, "
-                f"retrying via stream transport"
+        # 统一判断：非流式未能产出内容 → 尝试流式回退
+        _should_fallback = (
+            (non_stream_error is not None and _is_empty_response_error(str(non_stream_error)))
+            or (response is not None and not response.content
+                and response.usage.output_tokens > 0)
+        )
+
+        if _should_fallback:
+            _reason = (
+                f"non-stream error: {non_stream_error}"
+                if non_stream_error
+                else f"empty content with {response.usage.output_tokens} output tokens"  # type: ignore[union-attr]
             )
-            request._stream_fallback_tried = True  # type: ignore[attr-defined]
+            logger.warning(
+                f"[OpenAI] '{self.name}': {_reason}, attempting stream fallback"
+            )
             try:
                 stream_response = await self._chat_via_stream(request)
                 if stream_response.content:
                     logger.info(
                         f"[OpenAI] '{self.name}': stream fallback recovered content "
-                        f"({len(stream_response.content)} blocks)"
+                        f"({len(stream_response.content)} blocks), "
+                        f"switching to stream-only for this endpoint"
                     )
+                    self._stream_only = True
                     return stream_response
                 logger.warning(
                     f"[OpenAI] '{self.name}': stream fallback also returned empty content"
                 )
-            except Exception as e:
+            except Exception as stream_err:
                 logger.warning(
-                    f"[OpenAI] '{self.name}': stream fallback failed: {e}"
+                    f"[OpenAI] '{self.name}': stream fallback failed: {stream_err}"
                 )
 
-        return response
+        if non_stream_error is not None:
+            raise non_stream_error
+        return response  # type: ignore[return-value]
 
     async def _chat_non_stream(self, request: LLMRequest) -> LLMResponse:
         """非流式请求实现（原始路径，逻辑完全不变）。调用方须已获取 rate limit。"""

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -499,20 +499,28 @@ class OpenAIProvider(LLMProvider):
         body["stream"] = True
 
         text_parts: list[str] = []
+        reasoning_parts: list[str] = []
         tool_calls: dict[str, dict] = {}
         current_tool_id: str | None = None
         stop_reason = StopReason.END_TURN
         response_model = self.config.model
+        stream_usage: dict | None = None
 
         async for event in self._iter_sse_events(body):
             event_type = event.get("type")
+
+            if event_type == "usage":
+                stream_usage = event.get("usage")
+                continue
 
             if event_type == "content_block_delta":
                 delta = event.get("delta", {})
                 delta_type = delta.get("type")
 
                 if delta_type == "text":
-                    text_parts.append(delta.get("text", ""))
+                    text_parts.append(delta.get("text") or "")
+                elif delta_type == "reasoning":
+                    reasoning_parts.append(delta.get("text") or "")
                 elif delta_type == "tool_use":
                     call_id = delta.get("id")
                     if call_id:
@@ -562,11 +570,37 @@ class OpenAIProvider(LLMProvider):
         if tool_calls and stop_reason != StopReason.MAX_TOKENS:
             stop_reason = StopReason.TOOL_USE
 
+        _reasoning_text = "".join(reasoning_parts)
+        has_any_tool_calls = bool(tool_calls)
+
+        # 防御层：与 _parse_response 对齐 — reasoning 作为可见文本 fallback
+        if not content_blocks and not has_any_tool_calls and _reasoning_text:
+            logger.warning(
+                f"[STREAM] content empty but reasoning has {len(_reasoning_text)} chars "
+                f"from {self.name} — using reasoning as visible text fallback"
+            )
+            content_blocks.append(TextBlock(text=_reasoning_text))
+            _reasoning_text = ""
+
+        # 从流尾部 usage chunk 获取 token 统计（不再始终为零）
+        _usage = Usage()
+        if stream_usage:
+            _usage = Usage(
+                input_tokens=stream_usage.get("prompt_tokens", 0),
+                output_tokens=stream_usage.get("completion_tokens", 0),
+            )
+
+        if not content_blocks and _usage.output_tokens > 0:
+            logger.error(
+                f"[STREAM] ⚠️ CONTENT LOST: {_usage.output_tokens} output tokens "
+                f"but content is empty from {self.name} (stream_only adapter)"
+            )
+
         return LLMResponse(
             id="",
             content=content_blocks,
             stop_reason=stop_reason,
-            usage=Usage(),
+            usage=_usage,
             model=response_model,
         )
 

--- a/src/openakita/llm/types.py
+++ b/src/openakita/llm/types.py
@@ -240,12 +240,15 @@ class ToolUseBlock(ContentBlock):
             self.input = normalize_tool_input(self.name, self.input)
 
     def to_dict(self) -> dict:
-        return {
+        d: dict = {
             "type": "tool_use",
             "id": self.id,
             "name": self.name,
             "input": self.input,
         }
+        if self.provider_extra:
+            d["provider_extra"] = self.provider_extra
+        return d
 
 
 @dataclass

--- a/src/openakita/main.py
+++ b/src/openakita/main.py
@@ -631,7 +631,7 @@ def _setup_session_backfill(agent_or_master):
         _mm = _actual_agent.memory_manager
         if hasattr(_mm, "store") and _session_manager is not None:
             _session_manager.set_turn_loader(
-                lambda safe_id: _mm.store.get_recent_turns(safe_id, limit=50)
+                lambda safe_id: _mm.store.get_recent_turns(safe_id, limit=200)
             )
             backfilled = _session_manager.backfill_sessions_from_store()
             if backfilled:

--- a/src/openakita/sessions/manager.py
+++ b/src/openakita/sessions/manager.py
@@ -95,8 +95,21 @@ class SessionManager:
         logger.info("SessionManager started")
 
     def mark_dirty(self) -> None:
-        """标记会话数据已修改，需要保存"""
+        """标记会话数据已修改，等待防抖保存（最多 _save_delay_seconds）。
+
+        适用于非关键状态变更（元数据、配置切换等）。
+        关键消息（对话内容）应使用 persist()。
+        """
         self._dirty = True
+
+    def persist(self) -> None:
+        """标记脏 + 立即持久化（用于对话消息等关键数据）。#374
+
+        统一的"确保写盘"语义，供所有通道（Desktop / IM）在
+        assistant 回复完成后调用。调用方无需关心 mark_dirty + flush 细节。
+        """
+        self._dirty = False
+        self._save_sessions()
 
     def _dispatch_hook_fire_and_forget(self, hook_name: str, **kwargs) -> None:
         """Dispatch a plugin hook from sync context (best-effort, non-blocking)."""
@@ -122,7 +135,10 @@ class SessionManager:
             logger.warning("Plugin hook task failed: %s", exc)
 
     def flush(self) -> None:
-        """立即保存所有待写入的会话（绕过防抖延迟）"""
+        """立即保存所有待写入的会话（绕过防抖延迟）。
+
+        低级 API，优先使用 persist()。
+        """
         if self._dirty:
             self._dirty = False
             self._save_sessions()
@@ -133,6 +149,10 @@ class SessionManager:
 
     def backfill_sessions_from_store(self) -> int:
         """用 turn_loader 回填所有 session 中可能缺失的消息（崩溃恢复）。
+
+        对比 sessions.json 和 SQLite conversation_turns 表，
+        将 SQLite 中比 sessions.json 更新的消息回填到 session 上下文中。
+        保留原始时间戳以保证消息顺序正确。
 
         Returns:
             回填的总 turn 数
@@ -156,10 +176,15 @@ class SessionManager:
                 if not newer and not session.context.messages and db_turns:
                     newer = db_turns
                 for t in newer:
-                    session.context.add_message(
-                        role=t["role"],
-                        content=t.get("content", ""),
-                    )
+                    ts = t.get("timestamp", "")
+                    msg = {"role": t["role"], "content": t.get("content", "")}
+                    if ts:
+                        msg["timestamp"] = ts
+                    with session.context._msg_lock:
+                        last = session.context.messages[-1] if session.context.messages else None
+                        if last and last.get("role") == msg["role"] and last.get("content") == msg["content"]:
+                            continue
+                        session.context.messages.append(msg)
                 if newer:
                     total_backfilled += len(newer)
                     logger.info(
@@ -485,11 +510,28 @@ class SessionManager:
                 logger.error(f"Error in save loop: {e}")
 
     def _load_sessions(self) -> None:
-        """从文件加载会话，主文件失败时自动回退到 .bak 备份。"""
+        """从文件加载会话，主文件失败时自动回退到 .tmp / .bak 备份。"""
         sessions_file = self.storage_path / "sessions.json"
         backup_file = self.storage_path / "sessions.json.bak"
+        temp_file = self.storage_path / "sessions.json.tmp"
 
         data = self._try_load_sessions_file(sessions_file)
+
+        if data is None and temp_file.exists():
+            logger.warning(
+                "Main sessions.json failed or missing, recovering from .tmp "
+                "(likely crash during atomic save)"
+            )
+            data = self._try_load_sessions_file(temp_file)
+            if data is not None:
+                try:
+                    if sessions_file.exists():
+                        sessions_file.unlink()
+                    temp_file.rename(sessions_file)
+                    logger.info("Recovered sessions.json from .tmp successfully")
+                except Exception as e:
+                    logger.warning(f"Failed to promote .tmp to sessions.json: {e}")
+
         if data is None and backup_file.exists():
             logger.warning("Main sessions.json failed or missing, trying .bak backup")
             data = self._try_load_sessions_file(backup_file)

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -36,7 +36,7 @@ class SessionConfig:
     可覆盖全局配置，实现会话级别的定制
     """
 
-    max_history: int = 100  # 最大历史消息数
+    max_history: int = 2000  # 硬安全上限（日常由 _trim_old_metadata 控制体积，此值仅为极端兜底）
     timeout_minutes: int = 30  # 超时时间（分钟）
     language: str = "zh"  # 语言
     model: str | None = None  # 覆盖默认模型
@@ -366,13 +366,37 @@ class Session:
             key += f":{self.thread_id}"
         return key
 
+    # 重型元数据键（思考链、工具摘要、代码产物），对旧消息裁剪以控制体积
+    _HEAVY_METADATA_KEYS = ("chain_summary", "tool_summary", "artifacts")
+    # 保留最近 N 条消息的完整元数据（前端展示思考链等），更早的仅保留 base content
+    _METADATA_PRESERVE_WINDOW = 50
+
     def add_message(self, role: str, content: str, **metadata) -> bool:
         """添加消息并更新活跃时间。返回 True 表示消息被添加，False 表示被去重跳过。"""
         added = self.context.add_message(role, content, **metadata)
         self.touch()
-        if added and len(self.context.messages) > self.config.max_history:
-            self._truncate_history()
+
+        if added:
+            self._trim_old_metadata()
+            if len(self.context.messages) > self.config.max_history:
+                self._truncate_history()
         return added
+
+    def _trim_old_metadata(self) -> None:
+        """裁剪旧消息的重型元数据以控制内存与序列化体积。
+
+        保留所有消息的 base content（role, content, timestamp），仅移除
+        chain_summary / tool_summary / artifacts 等重型字段。
+        这是日常的体积控制机制，不会删除任何消息——用户永远不会丢失聊天记录。
+        """
+        with self.context._msg_lock:
+            messages = self.context.messages
+            trim_end = len(messages) - self._METADATA_PRESERVE_WINDOW
+            if trim_end <= 0:
+                return
+            for msg in messages[:trim_end]:
+                for key in self._HEAVY_METADATA_KEYS:
+                    msg.pop(key, None)
 
     _RULE_SIGNAL_WORDS = (
         "不要",
@@ -390,15 +414,22 @@ class Session:
     )
 
     def _truncate_history(self) -> None:
-        """截断历史消息，保留 75%，对丢弃部分生成简要摘要插入头部。
+        """硬安全网：仅当消息数超过 max_history（默认 2000）时触发。
 
-        优先保留用户设定的行为规则类消息。
+        日常体积控制由 _trim_old_metadata 负责（不删消息），本方法仅在极端情况
+        下删除最老 5% 的消息。正常使用几乎不会触发。
         """
         with self.context._msg_lock:
-            keep_count = int(self.config.max_history * 3 / 4)
+            keep_count = int(self.config.max_history * 95 / 100)
             messages = self.context.messages
             dropped = messages[:-keep_count]
             kept = messages[-keep_count:]
+
+            logger.warning(
+                f"Session {self.id}: HARD CAP truncation — "
+                f"total {len(messages)}, dropping {len(dropped)}, "
+                f"keeping {len(kept)} (max_history={self.config.max_history})"
+            )
 
             self._mark_dropped_for_extraction(dropped)
 
@@ -454,8 +485,8 @@ class Session:
                 kept.insert(0, {"role": "system", "content": "\n\n".join(header_parts)})
 
             self.context.messages = kept
-            logger.debug(
-                f"Session {self.id}: truncated history — "
+            logger.info(
+                f"Session {self.id}: truncated — "
                 f"dropped {len(dropped)}, kept {len(kept)} messages, "
                 f"preserved {len(rule_snippets)} rule snippets"
             )
@@ -548,7 +579,7 @@ class Session:
             last_active=datetime.fromisoformat(data["last_active"]),
             context=SessionContext.from_dict(data.get("context") or {}),
             config=SessionConfig(
-                max_history=config_data.get("max_history", 100),
+                max_history=max(config_data.get("max_history", 2000), 500),
                 timeout_minutes=config_data.get("timeout_minutes", 30),
                 language=config_data.get("language", "zh"),
                 model=config_data.get("model"),

--- a/src/openakita/setup/wizard.py
+++ b/src/openakita/setup/wizard.py
@@ -756,23 +756,20 @@ OpenAkita 按「现状」(AS IS) 提供，不附带任何形式的明示或暗�
 
     def _write_llm_endpoints(self):
         """将 LLM 端点和 Compiler 端点写入 data/llm_endpoints.json"""
-        endpoints_path = self.project_dir / "data" / "llm_endpoints.json"
+        from openakita.llm.endpoint_manager import EndpointManager
 
-        existing_data: dict = {}
-        if endpoints_path.exists():
-            try:
-                existing_data = json.loads(endpoints_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                pass
+        mgr = EndpointManager(self.project_dir)
+        mgr._json_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Use wizard-collected endpoints if available; otherwise fall back to legacy config
+        # Build the list of main endpoints
+        endpoints_to_save: list[dict] = []
         if self._llm_endpoints:
             max_tokens = int(self.config.get("MAX_TOKENS", "0"))
             for ep in self._llm_endpoints:
                 if ep.get("max_tokens", 0) == 0:
                     ep["max_tokens"] = max_tokens
-            existing_data["endpoints"] = self._llm_endpoints
-        elif not existing_data.get("endpoints"):
+            endpoints_to_save = self._llm_endpoints
+        elif not mgr.list_endpoints("endpoints"):
             api_key_env = "ANTHROPIC_API_KEY"
             base_url = self.config.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
             model = self.config.get("DEFAULT_MODEL", "claude-sonnet-4-20250514")
@@ -790,7 +787,7 @@ OpenAkita 按「现状」(AS IS) 提供，不附带任何形式的明示或暗�
             if not capabilities:
                 capabilities = ["text", "tools"]
 
-            existing_data["endpoints"] = [
+            endpoints_to_save = [
                 {
                     "name": "primary",
                     "provider": provider,
@@ -805,9 +802,11 @@ OpenAkita 按「现状」(AS IS) 提供，不附带任何形式的明示或暗�
                 }
             ]
 
+        for ep in endpoints_to_save:
+            mgr.save_endpoint(endpoint=ep, endpoint_type="endpoints")
+
         # Compiler endpoints
         compiler_endpoints = []
-
         primary_cfg = self.config.get("_compiler_primary")
         if primary_cfg:
             compiler_endpoints.append(
@@ -844,23 +843,19 @@ OpenAkita 按「现状」(AS IS) 提供，不附带任何形式的明示或暗�
                 }
             )
 
-        if compiler_endpoints:
-            existing_data["compiler_endpoints"] = compiler_endpoints
+        for ep in compiler_endpoints:
+            mgr.save_endpoint(endpoint=ep, endpoint_type="compiler_endpoints")
 
-        if not existing_data.get("settings"):
-            existing_data["settings"] = {
+        # Default settings
+        existing_settings = mgr.get_all_config().get("settings", {})
+        if not existing_settings:
+            mgr.update_settings({
                 "retry_count": 2,
                 "retry_delay_seconds": 2,
                 "health_check_interval": 60,
                 "fallback_on_error": True,
-            }
+            })
 
-        from openakita.llm.endpoint_manager import EndpointManager
-
-        mgr = EndpointManager(self.project_dir)
-        # Use EndpointManager's atomic write for safety
-        mgr._json_path.parent.mkdir(parents=True, exist_ok=True)
-        mgr._write_json(existing_data)
         console.print(f"  [green]✓[/green] LLM endpoints saved to {mgr.json_path}")
 
     def _configure_im_channels(self):

--- a/src/openakita/tools/handlers/config.py
+++ b/src/openakita/tools/handlers/config.py
@@ -656,9 +656,10 @@ class ConfigHandler:
             ep_dict["api_key_env"] = endpoint_data["api_key_env"]
 
         from ...config import settings
+        from ...llm.config import get_default_config_path
         from ...llm.endpoint_manager import EndpointManager
 
-        mgr = EndpointManager(Path(settings.project_root))
+        mgr = EndpointManager(Path(settings.project_root), config_path=get_default_config_path())
         try:
             result = mgr.save_endpoint(
                 endpoint=ep_dict,
@@ -697,9 +698,10 @@ class ConfigHandler:
         endpoint_type = endpoint_type_map.get(target, "endpoints")
 
         from ...config import settings
+        from ...llm.config import get_default_config_path
         from ...llm.endpoint_manager import EndpointManager
 
-        mgr = EndpointManager(Path(settings.project_root))
+        mgr = EndpointManager(Path(settings.project_root), config_path=get_default_config_path())
         removed = mgr.delete_endpoint(endpoint_name, endpoint_type=endpoint_type)
 
         if removed is None:

--- a/src/openakita/tools/handlers/config.py
+++ b/src/openakita/tools/handlers/config.py
@@ -496,12 +496,14 @@ class ConfigHandler:
             if not changes:
                 return f"❌ 所有修改都被拒绝:\n{error_lines}"
 
+        # 写入 .env（原子写入 + 备份）
         if env_entries:
+            from openakita.utils.atomic_io import safe_write
             existing = ""
             if env_path.exists():
                 existing = env_path.read_text(encoding="utf-8", errors="replace")
             new_content = _update_env_content(existing, env_entries)
-            env_path.write_text(new_content, encoding="utf-8")
+            safe_write(env_path, new_content)
 
             for key, value in env_entries.items():
                 if value:

--- a/tests/llm/unit/test_provider_extra_roundtrip.py
+++ b/tests/llm/unit/test_provider_extra_roundtrip.py
@@ -1,0 +1,107 @@
+"""Verify provider_extra (thought_signature) survives the full message pipeline."""
+
+from openakita.llm.converters.messages import (
+    convert_messages_from_openai,
+    convert_messages_to_openai,
+)
+from openakita.llm.converters.tools import convert_tool_calls_from_openai
+from openakita.llm.types import Message, TextBlock, ToolUseBlock
+
+SAMPLE_EXTRA = {"google": {"thought_signature": "abc123"}}
+
+
+def test_to_dict_includes_provider_extra():
+    tb = ToolUseBlock(
+        id="call_1", name="check", input={"x": 1}, provider_extra=SAMPLE_EXTRA,
+    )
+    d = tb.to_dict()
+    assert d["provider_extra"] == SAMPLE_EXTRA
+
+
+def test_to_dict_omits_none_provider_extra():
+    tb = ToolUseBlock(id="call_1", name="check", input={"x": 1})
+    d = tb.to_dict()
+    assert "provider_extra" not in d
+
+
+def test_convert_tool_calls_from_openai_captures_extra_content():
+    tc_list = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "check", "arguments": '{"x": 1}'},
+            "extra_content": SAMPLE_EXTRA,
+        }
+    ]
+    blocks = convert_tool_calls_from_openai(tc_list)
+    assert len(blocks) == 1
+    assert blocks[0].provider_extra == SAMPLE_EXTRA
+
+
+def test_convert_messages_to_openai_emits_extra_content():
+    msg = Message(
+        role="assistant",
+        content=[
+            TextBlock(text="thinking..."),
+            ToolUseBlock(
+                id="call_1", name="check", input={"x": 1},
+                provider_extra=SAMPLE_EXTRA,
+            ),
+        ],
+    )
+    openai_msgs = convert_messages_to_openai([msg])
+    assistant_msg = [m for m in openai_msgs if m.get("role") == "assistant"][0]
+    tc = assistant_msg["tool_calls"][0]
+    assert tc["extra_content"] == SAMPLE_EXTRA
+
+
+def test_full_openai_roundtrip():
+    """extra_content survives: OpenAI response → internal Message → OpenAI request."""
+    openai_history = [
+        {
+            "role": "assistant",
+            "content": "Let me check.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "check", "arguments": '{"x": 1}'},
+                    "extra_content": SAMPLE_EXTRA,
+                }
+            ],
+        }
+    ]
+    internal_msgs, _ = convert_messages_from_openai(openai_history)
+    assert internal_msgs[0].content[1].provider_extra == SAMPLE_EXTRA
+
+    openai_out = convert_messages_to_openai(internal_msgs)
+    out_tc = openai_out[0]["tool_calls"][0]
+    assert out_tc["extra_content"] == SAMPLE_EXTRA
+
+
+def test_decision_dict_roundtrip():
+    """Simulate _parse_decision dict construction → brain reconstruction."""
+    block = ToolUseBlock(
+        id="call_1", name="check", input={"x": 1}, provider_extra=SAMPLE_EXTRA,
+    )
+
+    # _parse_decision constructs these dicts
+    tc_dict = {"id": block.id, "name": block.name, "input": block.input}
+    if getattr(block, "provider_extra", None):
+        tc_dict["provider_extra"] = block.provider_extra
+    assistant_content_item = {"type": "tool_use", **tc_dict}
+
+    # brain._convert_messages_to_llm reconstructs ToolUseBlock from dict
+    reconstructed = ToolUseBlock(
+        id=assistant_content_item["id"],
+        name=assistant_content_item["name"],
+        input=assistant_content_item["input"],
+        provider_extra=assistant_content_item.get("provider_extra"),
+    )
+    assert reconstructed.provider_extra == SAMPLE_EXTRA
+
+    # Then convert_messages_to_openai emits extra_content
+    msg = Message(role="assistant", content=[reconstructed])
+    openai_out = convert_messages_to_openai([msg])
+    out_tc = openai_out[0]["tool_calls"][0]
+    assert out_tc["extra_content"] == SAMPLE_EXTRA

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -70,6 +70,134 @@ class TestSessionConfig:
         assert isinstance(config, SessionConfig)
 
 
+class TestMetadataTrimming:
+    """_trim_old_metadata: 日常体积控制，裁剪重型元数据但不删消息 (#309)."""
+
+    def _make_session(self, max_history: int = 2000) -> Session:
+        return Session(
+            id="s1", channel="desktop", chat_id="c1", user_id="u1",
+            config=SessionConfig(max_history=max_history),
+        )
+
+    def test_default_max_history_is_2000(self):
+        config = SessionConfig()
+        assert config.max_history == 2000
+
+    def test_from_dict_no_config_defaults_to_2000(self):
+        s = Session.from_dict({
+            "id": "s1", "channel": "desktop", "chat_id": "c1", "user_id": "u1",
+            "state": "active", "created_at": "2026-01-01T00:00:00",
+            "last_active": "2026-01-01T00:00:00",
+        })
+        assert s.config.max_history == 2000
+
+    def test_from_dict_upgrades_old_small_values(self):
+        """旧 session 序列化值 100/500 应被迁移至 >= 500."""
+        s = Session.from_dict({
+            "id": "s1", "channel": "desktop", "chat_id": "c1", "user_id": "u1",
+            "state": "active", "created_at": "2026-01-01T00:00:00",
+            "last_active": "2026-01-01T00:00:00",
+            "config": {"max_history": 100},
+        })
+        assert s.config.max_history >= 500
+
+    def test_messages_never_deleted_below_hard_cap(self):
+        """低于 hard cap 时，add_message 只 trim 元数据，不删除消息。"""
+        s = self._make_session(max_history=2000)
+        for i in range(200):
+            s.add_message(
+                "user" if i % 2 == 0 else "assistant",
+                f"msg-{i}",
+                chain_summary=f"chain-{i}",
+                tool_summary=f"tool-{i}",
+            )
+        assert len(s.context.messages) == 200
+
+    def test_trim_strips_heavy_metadata_from_old_messages(self):
+        """超过 preserve window 的旧消息应丢失 chain_summary 等重型字段。"""
+        s = self._make_session()
+        for i in range(80):
+            s.add_message(
+                "user" if i % 2 == 0 else "assistant",
+                f"msg-{i}",
+                chain_summary=f"chain-{i}",
+                tool_summary=f"tool-{i}",
+                artifacts=[f"artifact-{i}"],
+            )
+        window = Session._METADATA_PRESERVE_WINDOW
+        old_msg = s.context.messages[0]
+        assert "chain_summary" not in old_msg
+        assert "tool_summary" not in old_msg
+        assert "artifacts" not in old_msg
+        recent_msg = s.context.messages[-1]
+        assert recent_msg.get("chain_summary") == f"chain-{80 - 1}"
+
+    def test_trim_preserves_base_content(self):
+        """trim 后旧消息的 role/content/timestamp 必须完好。"""
+        s = self._make_session()
+        for i in range(80):
+            s.add_message(
+                "user" if i % 2 == 0 else "assistant",
+                f"msg-{i}",
+                chain_summary="big data",
+            )
+        for i, msg in enumerate(s.context.messages):
+            assert "content" in msg
+            assert "role" in msg
+
+    def test_recent_messages_keep_full_metadata(self):
+        """最近 _METADATA_PRESERVE_WINDOW 条消息保留全部元数据。"""
+        s = self._make_session()
+        window = Session._METADATA_PRESERVE_WINDOW
+        for i in range(window + 20):
+            s.add_message(
+                "user" if i % 2 == 0 else "assistant",
+                f"msg-{i}",
+                chain_summary=f"chain-{i}",
+            )
+        for msg in s.context.messages[-window:]:
+            assert "chain_summary" in msg
+
+
+class TestHardCapTruncation:
+    """_truncate_history: 仅 hard cap (2000) 极端兜底 (#309)."""
+
+    def _make_session(self, max_history: int = 100) -> Session:
+        return Session(
+            id="s1", channel="desktop", chat_id="c1", user_id="u1",
+            config=SessionConfig(max_history=max_history),
+        )
+
+    def test_hard_cap_triggers_above_max_history(self):
+        s = self._make_session(max_history=100)
+        for i in range(101):
+            s.add_message("user" if i % 2 == 0 else "assistant", f"msg-{i}")
+        assert len(s.context.messages) <= 100
+
+    def test_hard_cap_keeps_95_percent(self):
+        s = self._make_session(max_history=200)
+        for i in range(201):
+            s.add_message("user" if i % 2 == 0 else "assistant", f"msg-{i}")
+        # 95% of 200 = 190, plus possible system summary = 191
+        assert len(s.context.messages) >= 190
+        assert len(s.context.messages) <= 192
+
+    def test_hard_cap_preserves_recent_messages(self):
+        s = self._make_session(max_history=100)
+        for i in range(120):
+            s.add_message("user" if i % 2 == 0 else "assistant", f"msg-{i}")
+        contents = [m.get("content", "") for m in s.context.messages]
+        assert "msg-119" in contents
+
+    def test_hard_cap_produces_summary_on_truncation(self):
+        s = self._make_session(max_history=100)
+        for i in range(101):
+            s.add_message("user" if i % 2 == 0 else "assistant", f"msg-{i}")
+        system_msgs = [m for m in s.context.messages if m.get("role") == "system"]
+        assert len(system_msgs) >= 1
+        assert "[历史背景" in system_msgs[0].get("content", "")
+
+
 class TestSessionTimestamps:
     def test_created_at_set(self):
         before = datetime.now()


### PR DESCRIPTION
# PR-5 / 5（合并体）：v1.26.x → main LLM/session/endpoint 综合修复

> ⚠️ **本 PR 是回填系列的最后一个，按用户决策合并了原计划的 PR-5 ~ PR-10 共 6 个独立 PR 的 15 个 commit**，覆盖 LLM #418 系列、thinking 静默失败 / cooldown 升级、单端点 thinking 永久禁用、provider 解析三合一、endpoint 配置统一、session 持久化 / metadata trim。

依赖已合并的 PR-1 (#482) + PR-2 (#483) + PR-3 (#484) + PR-4 (#485)。

## Commits（不 squash，请用 Rebase merge —— 这里强烈建议保留 15 commit 历史，方便日后单独回滚某个 fix）

| # | Commit | 主题 | 主题分组 |
|---|---|---|---|
| 1 | `3c75233b` | `fix(llm): stream-only 端点 usage 丢失 + reasoning fallback + 空响应诊断增强` | **PR-5: LLM #418 系列** |
| 2 | `c167cb3f` | `fix(llm): 兼容 Responses API + 同步空响应流式回退 + 增强诊断 (#418)` | |
| 3 | `5290282d` | `fix(llm): content lost 视为结构性失败触发 failover + 原始响应诊断 (#418)` | |
| 4 | `99b670d9` | `fix(llm): unify non-stream to stream fallback in chat() + expose stream_only in UI` | |
| 5 | `16a54fb9` | `fix(llm): fix progressive cooldown never reaching higher steps for persistently failing endpoints` | **PR-6: thinking 静默 + cooldown** |
| 6 | `54a3dcd5` | `fix(llm): 修复 thinking 模式静默失败导致空响应的问题 (#415 #416 #403)` | |
| 7 | `c52e1377` | `fix(llm): defer thinking downgrade to preserve capability after cooldown recovery (#327)` | **PR-7: thinking 永久禁用拆分** |
| 8 | `b6aeb65e` | `fix(llm): _parse_glm 增加 Llama 风格 tool_call 解析 fallback，修复 #296` | **PR-8: provider 解析三合一** |
| 9 | `1094c1d8` | `fix(llm): 修复 429 限速被误判为结构性错误导致无法重试，修复 #324` | |
| 10 | `c2a99286` | `fix(llm): backport ea0eda11 — propagate provider_extra (Gemini thought_signature) end-to-end (#294)` | |
| 11 | `5d3f60bd` | `fix(llm): 统一 LLM 端点配置写入架构，消除 7 条并行写入路径导致的数据丢失` | **PR-9: endpoint 配置统一** |
| 12 | `a0e58b37` | `fix(llm): 删除 v1.26.x onboarding 中残留的 Tauri 直写 llm_endpoints.json 旁路` | |
| 13 | `728ce687` | `fix(llm): 统一配置路径解析，修复 Priority 设置不生效问题 (#371)` | |
| 14 | `9a07e38f` | `fix(session): 重构消息历史管理，用 metadata trim 替代破坏性截断，修复 #309` | **PR-10: session 持久化** |
| 15 | `d202cfc8` | `fix(session): 统一 Desktop/IM 会话持久化策略，强化崩溃恢复，修复 #374` | |

## 修复主题（5 大组）

### A. LLM #418 系列 —— 空响应、流式回退、stream-only 端点 usage 丢失（commits 1-4）
- **`stream-only` 端点**：v1.26 引入但未在 main 出现的端点能力，stream chunk 解析时丢 usage / reasoning，本 PR 补全
- **content lost failover**：`response.content==""` 但 `output_tokens > 0` 的情况现在被识别为结构性失败 → 自动切到下一个端点
- **Responses API 兼容**：兼容 OpenAI 新版 `data.get("output")` 结构、`choice.get("text")` fallback
- **统一 stream fallback**：把非流式空响应自动转流式重试统一到 `chat()` 中央决策（之前散落在多处）
- **诊断增强**：`_raw_diagnostic` 附加到 `LLMResponse`，可从 brain 一路传到 UI；UI 加 `Stream Only` 开关

### B. thinking 模式静默失败 + cooldown 升级（commits 5-6）
- **thinking 静默失败自愈（#415 #416 #403）**：thinking 模式有时返回空 content + 正 output_tokens，以前直接当成失败。本 PR 检测到此情况会**当场重试一次禁用 thinking**，给 response 打 `_thinking_fallback` 标记，UI 显示 `degraded` notice
- **progressive cooldown 不升级 fix**：本地 ConnectError 之前直接走快速 cooldown，导致后端没起的端点反复刷请求；现在它也参与渐进式升级；同时移除 `_consecutive_cooldowns` 在 cooldown 到期时被错误重置

### C. 单端点 thinking 永久禁用 (#327) —— 仅取 client.py 31 行（commit 7）
- **问题**：cooldown 后再回归时，原代码会在 `_resolve_providers_with_fallback` 中**直接禁用 thinking**，导致单端点用户失去 thinking 能力
- **修复**：先尝试只过滤 `require_thinking=True` 的端点；只有当没有任何 thinking-capable 端点时才降级
- 原 v1.26 commit `0e5cd3be` 还包含 supervisor / reasoning_engine 重写部分，**舍弃**（现在 main 上的 supervisor 架构与 v1.26 已差异过大，回填会引入新 bug）

### D. provider 解析三合一（commits 8-10）
- **`_parse_glm` 增加 Llama 风格 fallback (#296)**：nvidia/nemotron 等模型把工具调用嵌套在 `<tool_call>` 内但内部用 `<function=name><parameter=key>val</parameter></function>` 风格；GLM 解析失败时自动 fallback
- **429 不再被误判为 structural (#324)**：之前 429 走 structural error 路径直接被当作 fatal，永不重试；本 PR 加 `rate_limit` 分类，按 transient 处理（mark unhealthy + 切下一端点 + cooldown）
- **Gemini `thought_signature` 端到端传递 (#294)**：在 `ToolUseBlock` 加 `provider_extra` 字段，从 raw stream → `_chat_via_stream` → `_convert_stream_event` → `brain` → `reasoning_engine` → `_dict_to_message` 全链路携带，避免 Gemini 在多轮 tool use 中丢 signature 触发签名校验失败
- 新增完整 roundtrip 测试 `tests/llm/unit/test_provider_extra_roundtrip.py`

### E. endpoint 配置统一（commits 11-13）
- **消除 7 条并行写入路径**：v1.26 之前有 7 处不同代码可以写 `llm_endpoints.json`（前端 Tauri 直写、CLI、wizard、tools handler、HTTP API ……），相互覆盖导致数据丢失
- **本 PR 统一走 `EndpointManager.save_endpoint()` HTTP API**：删除前端 LLMView Tauri 旁路、删除 onboarding Tauri 旁路、CLI/wizard 转用 HTTP API
- **`/api/config/env` 切到 `safe_write`**：原子写入 .env 防止断电损坏
- **统一配置路径解析 (#371)**：之前 priority 设置在 `llm_endpoints.json` 中 `Priority` 字段不生效，因为用了不同的 `_endpoints_config_path` 解析路径；本 PR 统一用 `get_default_config_path()`

### F. session 持久化 + metadata trim（commits 14-15）
- **重构消息历史管理 (#309)**：之前用"硬截断"策略，超过 `max_history`（旧默认 50）就直接砍；用户感知为"对话历史丢失"
  - 改为 **metadata trim**：只清理超出 `_METADATA_PRESERVE_WINDOW` 之前消息的 heavy metadata（图片 base64、文件附件等），text 内容保留
  - `max_history` 默认 **50 → 2000**，`get_recent_turns` limit `50 → 200`
- **统一 Desktop/IM 会话持久化策略 (#374)**：Desktop 走 `mark_dirty` + `flush` 两步；IM 走 `_save_sessions` 一步；Desktop crash 时 mark_dirty 已置但 flush 未触发，会丢未持久化的对话
  - 本 PR 在 `SessionManager` 加 `persist()` 一站式 method（`_dirty=False` + `_save_sessions()`）
  - 把 `chat.py` 和 `gateway.py` 中所有 `mark_dirty()+flush()` 替换成 `persist()`，统一语义"确保已落盘"

## 与 v1.26.x 的差异（手工 patch 摘要）

由于 main 与 v1.26.x 在 LLM provider / brain / reasoning_engine 架构上有较大差异，下列 commit **不能直接 cherry-pick**，已在本 PR 中手工 patch 适配：

| 原 v1.26 commit | 本 PR commit | 适配要点 |
|---|---|---|
| `cfb3f0bb` `0ddf1892` `e54012d6` `cbbb01c6` | 1-4 | 保留 main 的 `_chat_via_stream` 重构，集成 v1.26 的 reasoning_parts / content lost 诊断 |
| `8afd4fe5` `a82f59d1` | 5-6 | 抛弃 v1.26 `a82f59d1` 的格式化冲突全量，只手工应用 3 个核心功能改动 |
| `0e5cd3be` | 7 | **仅取 client.py 31 行**，舍弃 supervisor / reasoning_engine 重写 |
| `d5b01b5e` `d2dddced` | 8-9 | Llama parse 与 GLM parse 合并；rate_limit 分类整合到 main 现有 `_classify_error` |
| `ea0eda11` | 10 | provider_extra 端到端补全到 brain / reasoning_engine / adapter 三个 main 上独有路径 |
| `3cb9b39d` `166adf58` | 11-13 | endpoint 统一时保留 main 的 try/except 防御代码 + apiKeyDirty 仅改时上传逻辑 |
| `46e29193` `7183d931` | 14-15 | session metadata trim 适配到 main 的 `add_message bool` 返回；persist() 加在 `_dispatch_hook_fire_and_forget` 旁边 |

## 影响面

| 类型 | 数量 |
|---|---|
| commit | **15** |
| 文件 | **24** |
| 净行数 | **+1401 / -594** |
| 新增测试 | 2 个新文件（provider_extra roundtrip + session trim） |
| 改动最大文件 | `LLMView.tsx` (-380 行)，`openai.py` (+317)，`App.tsx` (-162)，`brain.py` (-79)，`config.py routes` (-103) |

## Test Plan

### 必跑（阻塞 merge）
- [ ] `pytest tests/unit tests/llm --ignore=tests/unit/test_delegation_preamble.py --ignore=tests/unit/test_plugins/test_avatar_speaker_providers.py -q`
  - 本地实测：1256 passed
  - `test_delegation_preamble.py` 与 `test_avatar_speaker_providers.py` 是 main 上**预先存在的失败**，与本 PR 无关
- [ ] `ruff check src/openakita`
- [ ] `mypy src/openakita`（新加的 typing 不应该有问题）

### 建议手工回归（按主题）
- [ ] **A. #418**：用一个 stream-only 端点（如某些 free Gemini proxy）→ 应正常显示 usage、reasoning、空响应自动切到下一端点
- [ ] **B. thinking 静默**：DeepSeek-R1 或 Qwen-thinking 模式 → 偶发空响应应自动重试一次禁用 thinking，UI 应有 "thinking degraded" notice
- [ ] **C. cooldown**：故意让一个本地端点起不来 → cooldown 时间应渐进式上升（5s → 30s → 5min），不应一直 5s
- [ ] **D. provider_extra**：Gemini 多轮 tool use（连续 3 个 tool 调用）→ 不应出现签名校验失败
- [ ] **D. 429**：cursor / openrouter 这种容易 429 的端点 → 应识别为 rate_limit 切下一端点而非永久 failover
- [ ] **E. endpoint 配置**：在 LLMView 编辑端点 → 保存 → 看 `llm_endpoints.json` 写入应通过 HTTP API（DevTools Network 应能看到 `/api/llm/endpoints` PUT 请求），且**只在 API key 真改时才上传**
- [ ] **F. session 持久化**：聊一会儿（>20 条消息）→ kill 后端进程（不要优雅关闭）→ 重启 → 历史消息应完整保留；超过 50 条的旧消息 metadata 应被 trim 但 text 保留

## 已知风险

1. **commit 7 的范围裁剪**：v1.26 `0e5cd3be` 原本同时改了 supervisor 和 reasoning_engine，本 PR 故意只取 client.py 31 行；如果将来发现 supervisor 在 thinking-recovery 路径还有其他问题，需要单独处理
2. **commit 11 endpoint 统一**：删了前端 LLMView 中"HTTP 不可达时回落到 Tauri 直写"的旁路，**纯 Tauri 离线启动**（HTTP 服务彻底起不来）的 corner case 下不能编辑端点。本 PR 认为这是可接受的——HTTP 服务起不来本身就是更严重的问题应当先处理
3. **session `max_history` 默认从 50 → 2000**：磁盘占用上升 40 倍。监测 `~/.openakita/sessions/*.json` 大小变化，如果某用户对话特别长（>2000 条），原来直接砍现在不砍

## 注意
- 这是 v1.26.x → main 回填系列的**最后一个 PR**
- 推荐 **Rebase merge**，保留全部 15 commit 历史
- 合并后 v1.26.x 与 main 的关键 fix 同步即完成
- 涉及范围广，建议至少**部署到 staging 一周**再放生产

## 来源
- v1.26.x 共 12 个 source commit：`cfb3f0bb` `0ddf1892` `e54012d6` `cbbb01c6` `8afd4fe5` `a82f59d1` `0e5cd3be`(部分) `d5b01b5e` `d2dddced` `ea0eda11` `3cb9b39d` `166adf58` `46e29193` `7183d931`
- 完整 backport 计划：`v126-to-main-backport_0ebdaaa9.plan.md`
