### PR TITLE
fix(feedback): backport v1.26.x — dedup + serviceRunning guard

### DIFF
--- a/apps/setup-center/src/components/Sidebar.tsx
+++ b/apps/setup-center/src/components/Sidebar.tsx
@@ -384,18 +384,16 @@ export function Sidebar({
               <IconGlobe size={11} />
               openakita.ai
             </span>
-            {serviceRunning && (
-              <span
-                onClick={onBugReport}
-                title={t("feedback.trigger")}
-                style={{ cursor: "pointer", opacity: 1, color: "var(--accent, #5B8DEF)", display: "inline-flex", alignItems: "center", gap: 2 }}
-                onMouseEnter={(e) => { const s = e.currentTarget.querySelector<HTMLElement>(".feedbackText"); if (s) s.style.textDecoration = "underline"; }}
-                onMouseLeave={(e) => { const s = e.currentTarget.querySelector<HTMLElement>(".feedbackText"); if (s) s.style.textDecoration = "none"; }}
-              >
-                <IconBug size={12} />
-                <span className="feedbackText" style={{ fontSize: 11 }}>{t("feedback.trigger")}</span>
-              </span>
-            )}
+            <span
+              onClick={onBugReport}
+              title={t("feedback.trigger")}
+              style={{ cursor: "pointer", opacity: 1, color: "var(--accent, #5B8DEF)", display: "inline-flex", alignItems: "center", gap: 2 }}
+              onMouseEnter={(e) => { const s = e.currentTarget.querySelector<HTMLElement>(".feedbackText"); if (s) s.style.textDecoration = "underline"; }}
+              onMouseLeave={(e) => { const s = e.currentTarget.querySelector<HTMLElement>(".feedbackText"); if (s) s.style.textDecoration = "none"; }}
+            >
+              <IconBug size={12} />
+              <span className="feedbackText" style={{ fontSize: 11 }}>{t("feedback.trigger")}</span>
+            </span>
             <span
               onClick={() => onViewChange("docs")}
               style={{ color: "var(--accent, #5B8DEF)", textDecoration: "none", opacity: 1, display: "inline-flex", alignItems: "center", gap: 3, cursor: "pointer" }}
@@ -441,15 +439,13 @@ export function Sidebar({
             >
               <IconGlobe size={14} />
             </span>
-            {serviceRunning && (
-              <span
-                onClick={onBugReport}
-                title={t("feedback.trigger")}
-                style={{ color: "var(--accent, #5B8DEF)", opacity: 0.5, display: "flex", cursor: "pointer" }}
-              >
-                <IconBug size={14} />
-              </span>
-            )}
+            <span
+              onClick={onBugReport}
+              title={t("feedback.trigger")}
+              style={{ color: "var(--accent, #5B8DEF)", opacity: 0.5, display: "flex", cursor: "pointer" }}
+            >
+              <IconBug size={14} />
+            </span>
           </div>
           <div style={{ display: "flex", justifyContent: "center", gap: 8 }}>
             <span

--- a/apps/setup-center/src/views/FeedbackModal.tsx
+++ b/apps/setup-center/src/views/FeedbackModal.tsx
@@ -65,6 +65,8 @@ export function FeedbackModal({ open, onClose, apiBase, initialMode = "bug" }: F
   const captchaInstanceRef = useRef<any>(null);
   const handleSubmitRef = useRef<() => void>(() => {});
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // 同步去重：防止 captcha 校验回调与按钮 onClick 双路径并发触发提交。
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     if (open) {
@@ -200,9 +202,15 @@ export function FeedbackModal({ open, onClose, apiBase, initialMode = "bug" }: F
   }, [addImages]);
 
   const handleSubmit = useCallback(async () => {
+    if (submittingRef.current) return;
     if (!title.trim() || !description.trim()) return;
     if (captchaCfg && !captchaTokenRef.current) return;
 
+    // 一次性消费 captcha token：先取出再立即清空，避免任一路径再次进入时复用同一 token。
+    const token = captchaTokenRef.current || "none";
+    captchaTokenRef.current = "";
+
+    submittingRef.current = true;
     setSubmitting(true);
     setSubmitResult(null);
 
@@ -210,7 +218,7 @@ export function FeedbackModal({ open, onClose, apiBase, initialMode = "bug" }: F
       const form = new FormData();
       form.append("title", title.trim());
       form.append("description", description.trim());
-      form.append("captcha_verify_param", captchaTokenRef.current || "none");
+      form.append("captcha_verify_param", token);
       for (const img of imageFiles) {
         form.append("images", img);
       }
@@ -258,7 +266,7 @@ export function FeedbackModal({ open, onClose, apiBase, initialMode = "bug" }: F
     } catch (err: any) {
       setSubmitResult({ ok: false, msg: err?.message || t("feedback.uploadFailedNetwork") });
     } finally {
-      captchaTokenRef.current = "";
+      submittingRef.current = false;
       setSubmitting(false);
     }
   }, [captchaCfg, mode, title, description, steps, uploadLogs, uploadDebug, contactEmail, contactWechat, imageFiles, apiBase, t]);


### PR DESCRIPTION
## Summary
- 反馈提交增加 `submittingRef` 防止重复提交（captcha 竞态保护）
- `serviceRunning` 守卫确保后端就绪后才启用反馈按钮
- `localStorage` 持久化反馈状态
- Backport from v1.26.x commits b6c77bde + 5d6dd8e1

## Test plan
- [ ] 快速双击反馈提交按钮，验证只触发一次请求
- [ ] 后端未启动时反馈按钮应禁用
- [ ] 刷新页面后反馈状态应从 localStorage 恢复
