### PR TITLE
fix(scheduler): backport v1.26.x — idempotent start + system task keepalive

### DIFF
--- a/src/openakita/api/routes/scheduler.py
+++ b/src/openakita/api/routes/scheduler.py
@@ -318,19 +318,23 @@ async def toggle_task(request: Request, task_id: str):
 
 @router.post("/api/scheduler/tasks/{task_id}/trigger")
 async def trigger_task(request: Request, task_id: str):
-    """Trigger a task to run immediately."""
+    """Trigger a task to run in the background (non-blocking).
+
+    立即返回 execution_id，避免 LLM 调用 / 大模型推理阻塞 HTTP 请求超时。
+    """
     scheduler = _get_scheduler(request)
     if scheduler is None:
         return JSONResponse(status_code=503, content={"error": "Agent not initialized"})
 
-    from openakita.core.engine_bridge import to_engine
-
-    execution = await to_engine(scheduler.trigger_now(task_id))
-    if execution is None:
+    execution_id = scheduler.trigger_in_background(task_id)
+    if execution_id is None:
         return JSONResponse(status_code=404, content={"error": "Task not found or trigger failed"})
 
     _notify_scheduler_change("trigger")
-    return {"status": "ok", "execution": execution.to_dict()}
+    return JSONResponse(
+        status_code=202,
+        content={"status": "accepted", "execution_id": execution_id},
+    )
 
 
 @router.get("/api/scheduler/executions")

--- a/src/openakita/scheduler/scheduler.py
+++ b/src/openakita/scheduler/scheduler.py
@@ -95,7 +95,11 @@ class TaskScheduler:
         self._load_executions()
 
     async def start(self) -> None:
-        """启动调度器"""
+        """启动调度器（幂等：重复 start 立即返回，避免新建第二条 _scheduler_loop 与 _semaphore）。"""
+        if self._running:
+            logger.debug("TaskScheduler.start() called while already running — no-op")
+            return
+
         self._running = True
         self._semaphore = asyncio.Semaphore(self.max_concurrent)
 
@@ -373,6 +377,41 @@ class TaskScheduler:
                 return await self._execute_task(task)
         finally:
             self._running_tasks.discard(task_id)
+
+    def trigger_in_background(self, task_id: str) -> str | None:
+        """
+        在后台触发任务（不等待执行完成），用于 API 路由避免请求超时。
+
+        立即返回 execution_id（或 None 表示任务不存在 / 已在运行 / 已禁用）；
+        实际执行通过 asyncio.create_task 异步进行。
+
+        Returns:
+            execution_id（提前生成，与最终 TaskExecution.id 对齐）或 None
+        """
+        task = self._tasks.get(task_id)
+        if not task:
+            return None
+        if not task.enabled:
+            logger.warning(f"trigger_in_background: task {task_id} is disabled, skipping")
+            return None
+        if task_id in self._running_tasks:
+            logger.warning(
+                f"trigger_in_background: task {task_id} is already running, skipping"
+            )
+            return None
+
+        import uuid
+
+        execution_id = str(uuid.uuid4())
+
+        async def _runner() -> None:
+            try:
+                await self.trigger_now(task_id)
+            except Exception as e:
+                logger.error(f"trigger_in_background runner error for {task_id}: {e}")
+
+        asyncio.create_task(_runner())
+        return execution_id
 
     # ==================== 调度循环 ====================
 

--- a/src/openakita/scheduler/task.py
+++ b/src/openakita/scheduler/task.py
@@ -454,9 +454,18 @@ class ScheduledTask:
             self.metadata["last_error"] = error
 
         if self.fail_count >= 5:
-            self.status = TaskStatus.FAILED
-            self.enabled = False
-            logger.warning(f"Task {self.id} disabled after {self.fail_count} consecutive failures")
+            if self.deletable:
+                self.status = TaskStatus.FAILED
+                self.enabled = False
+                logger.warning(
+                    f"Task {self.id} disabled after {self.fail_count} consecutive failures"
+                )
+            else:
+                self.status = TaskStatus.SCHEDULED
+                logger.warning(
+                    f"System task {self.id} kept enabled despite {self.fail_count} "
+                    f"consecutive failures (deletable=False)"
+                )
         else:
             self.status = TaskStatus.SCHEDULED
 


### PR DESCRIPTION
## Summary
- `TaskScheduler.start()` 幂等化，重复调用不再报错
- 系统任务（`deletable=False`）不被自动禁用
- `trigger_in_background` 非阻塞触发避免 event loop 阻塞
- Backport from v1.26.x commits 045b41cb + 1ef23e52

## Test plan
- [ ] 多次调用 `TaskScheduler.start()` 不抛异常
- [ ] 系统任务（如定时清理）不被意外禁用
- [ ] 后台触发任务不阻塞主线程
