### PR TITLE
fix(shell): backport v1.26.x — Windows robustness fixes

### DIFF
--- a/src/openakita/core/agent.py
+++ b/src/openakita/core/agent.py
@@ -428,7 +428,8 @@ class Agent:
         )
 
         # 初始化基础工具
-        self.shell_tool = ShellTool()
+        # 显式传入 settings.project_root，确保 Windows 自启动场景不会落到 System32。
+        self.shell_tool = ShellTool(default_cwd=str(settings.project_root))
         self.file_tool = FileTool()
         self.web_tool = WebTool()
 

--- a/src/openakita/core/response_handler.py
+++ b/src/openakita/core/response_handler.py
@@ -565,6 +565,15 @@ class ResponseHandler:
 - 助手已实际尝试且遇不可绕过的 API/平台限制，并已向用户解释 → **COMPLETED**
 - 若仍有其他可行路径（换命令、换文件路径等）→ **INCOMPLETE**
 
+**E. 多路径同因失败（关键去抖规则）**
+- 如果助手已经在**两个或两个以上不同路径 / 命令 / 文件**上尝试同一件事，
+  并且**根本失败原因相同**（例如：同一权限错误 / 同一路径不存在 / 同一依赖缺失），
+  这是上游限制而非"换条路就能成"，必须判 **COMPLETED**（带说明），不要再继续 INCOMPLETE
+  让模型陷入"再换一个路径试试"的死循环。
+- 例：依次执行 `pip install foo`、`python -m pip install foo`、`pipx install foo` 三次都
+  报同样的 PermissionError → 这是**环境**问题，已超出 LLM 可解决范围，应判 COMPLETED 并
+  把诊断结果交还用户。
+
 ## 回答要求
 STATUS: COMPLETED 或 INCOMPLETE
 EVIDENCE: 完成的证据

--- a/src/openakita/tools/errors.py
+++ b/src/openakita/tools/errors.py
@@ -140,6 +140,18 @@ def classify_error(
             retry_suggestion="请确认文件路径是否正确",
         )
 
+    # IsADirectoryError 必须在 PermissionError 之前判断：Windows 下用 open() 读取
+    # 目录会抛 PermissionError [WinError 5]，导致 LLM 误认为是权限问题反复重试。
+    # 单独分类为 VALIDATION 并提示改用 list_directory。
+    if isinstance(error, IsADirectoryError):
+        return ToolError(
+            error_type=ErrorType.VALIDATION,
+            tool_name=tool_name,
+            message=f"目标路径是目录而非文件：{error_msg}",
+            retry_suggestion="如需查看目录内容，请改用 list_directory 工具",
+            alternative_tools=["list_directory"],
+        )
+
     if isinstance(error, PermissionError):
         return ToolError(
             error_type=ErrorType.PERMISSION,

--- a/src/openakita/tools/file.py
+++ b/src/openakita/tools/file.py
@@ -103,6 +103,12 @@ class FileTool:
         file_path = self._resolve_path(path)
         logger.debug(f"Reading file: {file_path}")
 
+        # Windows 下用 open() 打开目录会抛 PermissionError [WinError 5]，导致
+        # 错误分类为 PERMISSION 触发反复重试。提前显式检测目录并抛 IsADirectoryError，
+        # 让 classify_error 能正确建议 LLM 改用 list_directory。
+        if file_path.is_dir():
+            raise IsADirectoryError(f"路径是目录而非文件，无法读取文件内容: {file_path}")
+
         # 检查是否为二进制文件
         suffix = file_path.suffix.lower()
         if suffix in self.BINARY_EXTENSIONS:

--- a/src/openakita/tools/handlers/filesystem.py
+++ b/src/openakita/tools/handlers/filesystem.py
@@ -297,7 +297,9 @@ class FilesystemHandler:
                 timeout_s = int(timeout_s)
             except (ValueError, TypeError):
                 timeout_s = 60
-            timeout_s = max(10, min(timeout_s, 600))
+            # Cap shell timeout at 300s（v1.26.x 调整）。10 分钟以上的命令通常是
+            # LLM 误用（应改为后台进程或拆步），强制 cap 避免 reasoning 长时间阻塞。
+            timeout_s = max(10, min(timeout_s, 300))
             block_timeout_ms = timeout_s * 1000
 
         session_id = params.get("session_id", 1)

--- a/src/openakita/tools/shell.py
+++ b/src/openakita/tools/shell.py
@@ -187,7 +187,27 @@ class ShellTool:
         timeout: int = 60,
         shell: bool = True,
     ):
-        self.default_cwd = default_cwd or os.getcwd()
+        # default_cwd 优先级：调用方指定 > settings.project_root > os.getcwd()。
+        # os.getcwd() 在 Windows 守护进程 / 自启动场景下经常落到 C:\Windows\System32，
+        # 导致 shell 命令找不到用户工程文件。
+        if default_cwd:
+            cwd_str = default_cwd
+        else:
+            try:
+                from ..config import settings as _settings
+
+                cwd_str = str(_settings.project_root)
+            except Exception:
+                cwd_str = os.getcwd()
+
+        if not os.path.isdir(cwd_str):
+            logger.warning(
+                f"[ShellTool] default_cwd does not exist or is not a directory: {cwd_str!r}, "
+                f"falling back to os.getcwd()"
+            )
+            cwd_str = os.getcwd()
+
+        self.default_cwd = cwd_str
         self.timeout = timeout
         self.shell = shell
         self._is_windows = sys.platform == "win32"
@@ -555,20 +575,42 @@ class ShellTool:
         return result.success
 
     async def pip_install(self, package: str) -> CommandResult:
-        """使用 pip 安装包（PyInstaller 兼容：使用 runtime_env 获取正确的 Python 解释器）"""
+        """使用 pip 安装包（PyInstaller 兼容：使用 runtime_env 获取正确的 Python 解释器）。
+
+        Windows 下若 site-packages 目录无写权限（系统 Python / 受保护安装目录），
+        自动追加 --user 重试，避免 LLM 看到 PermissionError 后陷入"反复加 sudo / 改路径"
+        的死循环。
+        """
         from openakita.runtime_env import IS_FROZEN, get_python_executable
 
         py = get_python_executable()
         if py:
-            return await self.run(f'"{py}" -m pip install {package}')
-        if IS_FROZEN:
-            return CommandResult(
-                returncode=-1,
-                stdout="",
-                stderr="未找到可用的 Python 解释器，无法执行 pip install。"
-                "请前往「设置中心 → Python 环境」使用「一键修复」。",
+            base_cmd = f'"{py}" -m pip install {package}'
+        else:
+            if IS_FROZEN:
+                return CommandResult(
+                    returncode=-1,
+                    stdout="",
+                    stderr="未找到可用的 Python 解释器，无法执行 pip install。"
+                    "请前往「设置中心 → Python 环境」使用「一键修复」。",
+                )
+            base_cmd = f"pip install {package}"
+
+        result = await self.run(base_cmd)
+        if (
+            self._is_windows
+            and not result.success
+            and any(
+                kw in (result.stderr or "").lower()
+                for kw in ("permission denied", "winerror 5", "access is denied", "errno 13")
             )
-        return await self.run(f"pip install {package}")
+        ):
+            logger.info(
+                f"[ShellTool.pip_install] PermissionError on Windows, retrying with --user: {package}"
+            )
+            return await self.run(f"{base_cmd} --user")
+
+        return result
 
     async def npm_install(self, package: str, global_: bool = False) -> CommandResult:
         """使用 npm 安装包"""


### PR DESCRIPTION
## Summary
- Windows 下 `IsADirectoryError` / `PermissionError` ([WinError 5]) 处理
- CWD 验证使用 `settings.project_root`
- PowerShell `EncodedCommand` 支持
- `pip install --user` fallback
- 命令超时处理
- "同因多路径失败"规则（multi-path same-cause failure）
- Backport from v1.26.x commits 4d910816 + 38d72c00

## Test plan
- [ ] Windows 下读取目录不报 PermissionError
- [ ] PowerShell 命令正确执行
- [ ] pip install 失败时自动重试 --user
- [ ] 命令超时后正确清理
