### PR TITLE
fix(skills): backport v1.26.x — parser fallback + async translate + 180s timeout

### DIFF
--- a/apps/setup-center/src/views/SkillManager.tsx
+++ b/apps/setup-center/src/views/SkillManager.tsx
@@ -1087,7 +1087,7 @@ export function SkillManager({
               url: folderPath,
               ...(installCategory ? { category: installCategory } : {}),
             }),
-            signal: AbortSignal.timeout(60_000),
+            signal: AbortSignal.timeout(180_000),
           });
           const data = await res.json();
           if (data.error) throw new Error(data.error);
@@ -1380,7 +1380,7 @@ export function SkillManager({
             url: skill.url,
             ...(installCategory ? { category: installCategory } : {}),
           }),
-          signal: AbortSignal.timeout(60_000),
+          signal: AbortSignal.timeout(180_000),
         });
         const data = await res.json();
         if (data.error) throw new Error(data.error);
@@ -1451,7 +1451,7 @@ export function SkillManager({
             url,
             ...(installCategory ? { category: installCategory } : {}),
           }),
-          signal: AbortSignal.timeout(120_000),
+          signal: AbortSignal.timeout(180_000),
         });
         const data = await res.json();
         if (data.error) throw new Error(data.error);

--- a/src/openakita/api/routes/skills.py
+++ b/src/openakita/api/routes/skills.py
@@ -359,11 +359,17 @@ async def install_skill(request: Request):
     # 统一刷新入口 —— 重扫磁盘 + 重新应用 allowlist + 重建 catalog + 通知 Pool
     await _propagate(request, "install")
 
-    # 自动翻译（可选，不阻塞成功返回）
+    # 自动翻译（可选，不阻塞成功返回）—— 后台执行，避免拖慢安装路径
     try:
-        await _auto_translate_new_skills(request, url)
+        async def _bg_translate(req=request, src_url=url):
+            try:
+                await _auto_translate_new_skills(req, src_url)
+            except Exception as bg_err:  # pragma: no cover - 仅日志
+                logger.debug("Background auto-translate skipped: %s", bg_err)
+
+        asyncio.create_task(_bg_translate())
     except Exception as e:
-        logger.debug("Auto-translate skipped: %s", e)
+        logger.debug("Auto-translate scheduling skipped: %s", e)
 
     result: dict = {"status": "ok", "url": url}
     if install_warning:

--- a/src/openakita/setup_center/bridge.py
+++ b/src/openakita/setup_center/bridge.py
@@ -1461,10 +1461,81 @@ def _ensure_target_available(target: Path, url: str) -> None:
     raise ValueError(f"技能目录名称冲突: {target}")
 
 
+# 通用 CLI 命令前缀清洗：用户经常直接复制类似
+#   "openakita install-skill owner/repo"
+#   "npx skills add owner/repo"
+#   "uv pip install owner/repo"
+#   "Run: openakita skill add owner/repo"
+# 这样的指令到对话框 / API 里。从中抽出真正的 URL/owner/repo 信号，
+# 避免 install_skill 因为前面的命令串而拒绝。
+_CMD_VERB = r"(?:add|install|i|get|use|run)"
+_CMD_TOOL = (
+    r"(?:openakita(?:\s+(?:skills?|install[- ]skill))?"
+    r"|npx\s+skills?"
+    r"|skills?"
+    r"|pnpm\s+(?:add|install)"
+    r"|npm\s+(?:i|install|add)"
+    r"|yarn\s+add"
+    r"|uv(?:\s+pip)?"
+    r"|pipx?"
+    r"|cargo)"
+)
 _CMD_PREFIXES = re.compile(
-    r"^(?:npx\s+skills?\s+(?:add|install)|openakita\s+(?:install[- ]skill|skill\s+install))\s+",
+    rf"^(?:Run\s*:\s*)?(?:{_CMD_TOOL}\s+){_CMD_VERB}?\s+",
     re.IGNORECASE,
 )
+
+# 用于从混杂文本里提取首个有效 skill 信号（URL / owner/repo / 本地路径）
+_SKILL_URL_RE = re.compile(
+    r"(github:[A-Za-z0-9_./-]+"
+    r"|https?://\S+"
+    r"|git@[A-Za-z0-9_.-]+:[A-Za-z0-9_./-]+\.git"
+    r"|[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+)"
+)
+
+
+def _extract_skill_signal(raw: str) -> str:
+    """从用户输入里提取真正的 skill 安装信号。
+
+    支持三种粘贴方式：
+      1. 纯 URL / owner/repo / 本地路径（直接 strip）。
+      2. 单行 CLI：``openakita install-skill owner/repo`` —— 先用
+         ``_CMD_PREFIXES`` 剥离命令前缀；剥离后还可能留 ``--flag value``，
+         再尝试用 ``_SKILL_URL_RE`` 抽出第一个 URL/owner-repo 片段。
+      3. 多行文本：按行扫描，取第一行能命中 URL/owner-repo 的内容。
+    """
+    text = (raw or "").strip()
+    if not text:
+        return ""
+
+    # Single line first: cheapest and most common.
+    if "\n" not in text:
+        cleaned = _CMD_PREFIXES.sub("", text).strip()
+        if not cleaned:
+            return ""
+        # If the cleaned form has flags / extra args, keep only the first URL-like token.
+        if cleaned.split() and len(cleaned.split()) > 1:
+            m = _SKILL_URL_RE.search(cleaned)
+            if m:
+                return m.group(1).strip()
+        return cleaned
+
+    # Multi-line: scan lines, pick the first that yields a URL-like token.
+    for line in text.splitlines():
+        line = line.strip().strip("`").strip()
+        if not line or line.startswith("#"):
+            continue
+        candidate = _CMD_PREFIXES.sub("", line).strip()
+        if not candidate:
+            continue
+        m = _SKILL_URL_RE.search(candidate)
+        if m:
+            return m.group(1).strip()
+        if candidate.startswith(("./", "../", "/", "~", ".\\", "..\\")) or (
+            len(candidate) >= 2 and candidate[1] == ":"
+        ):
+            return candidate
+    return ""
 
 
 def install_skill(
@@ -1478,7 +1549,7 @@ def install_skill(
         category: 可选大类。命中且通过校验时，安装到 ``skills/<category>/<skill_id>/``；
             否则维持旧行为安装到 ``skills/<skill_id>/``（顶层平铺）。
     """
-    url = _CMD_PREFIXES.sub("", url.strip()).strip()
+    url = _extract_skill_signal(url)
     if not url:
         raise ValueError("请输入有效的技能地址，如 owner/repo 或 Git URL")
 

--- a/src/openakita/skills/parser.py
+++ b/src/openakita/skills/parser.py
@@ -230,19 +230,25 @@ class SkillParser:
         Returns:
             ParsedSkill 对象
         """
-        # 解析 frontmatter
+        # 解析 frontmatter（缺失时降级而非硬失败：从目录名派生 name，正文整体作为 body）
         match = self.FRONTMATTER_PATTERN.match(content)
-        if not match:
-            raise ValueError(f"Invalid SKILL.md format: missing YAML frontmatter in {path}")
-
-        yaml_content = match.group(1)
-        body = match.group(2).strip()
-
-        # 解析 YAML
-        try:
-            data = yaml.safe_load(yaml_content) or {}
-        except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML frontmatter in {path}: {e}")
+        if match:
+            yaml_content = match.group(1)
+            body = match.group(2).strip()
+            try:
+                data = yaml.safe_load(yaml_content) or {}
+            except yaml.YAMLError as e:
+                logger.warning(
+                    f"Invalid YAML frontmatter in {path}: {e}; falling back to filename-derived metadata"
+                )
+                data = {}
+                body = content.strip()
+        else:
+            logger.warning(
+                f"SKILL.md missing YAML frontmatter in {path}; falling back to filename-derived metadata"
+            )
+            data = {}
+            body = content.strip()
 
         # 构建元数据（body 用于 description 自动提取回退）
         metadata = self._build_metadata(data, path, body=body)
@@ -270,21 +276,34 @@ class SkillParser:
             assets_dir=assets_dir if assets_dir.exists() else None,
         )
 
+    @staticmethod
+    def _derive_name_from_path(path: Path) -> str:
+        """从 SKILL.md 所在目录派生 snake_case 名称作为降级值。"""
+        raw = path.parent.name or "unnamed_skill"
+        normalized = re.sub(r"[^A-Za-z0-9]+", "_", raw).strip("_").lower()
+        return normalized or "unnamed_skill"
+
     def _build_metadata(self, data: dict, path: Path, body: str = "") -> SkillMetadata:
-        """从 YAML 数据构建元数据"""
-        # 必需字段
+        """从 YAML 数据构建元数据（缺字段时降级派生，不再硬失败）"""
         name = data.get("name")
         description = data.get("description", "")
 
         if not name:
-            raise ValueError(f"Missing required 'name' field in {path}")
+            derived = self._derive_name_from_path(path)
+            logger.warning(
+                f"SKILL.md missing 'name' field in {path}; derived name from directory: '{derived}'"
+            )
+            name = derived
 
         if not description and body:
             first_para = body.split("\n\n")[0].replace("\n", " ").strip()
             description = first_para[:100] + ("..." if len(first_para) > 100 else "")
 
         if not description:
-            raise ValueError(f"Missing required 'description' field in {path}")
+            logger.warning(
+                f"SKILL.md missing 'description' field in {path}; using empty description"
+            )
+            description = ""
 
         # 处理 allowed-tools (连字符转下划线)
         allowed_tools = data.get("allowed-tools", "")

--- a/src/openakita/tools/handlers/skills.py
+++ b/src/openakita/tools/handlers/skills.py
@@ -14,6 +14,7 @@
 - uninstall_skill: 卸载外部技能 (F14)
 """
 
+import asyncio
 import logging
 import re
 from pathlib import Path
@@ -490,6 +491,32 @@ class SkillsHandler:
                 # 都在 propagate_skill_change 里完成，工具处理器层不要再手工调用任何子步骤。
                 self.agent.propagate_skill_change(SkillEvent.LOAD, rescan=False)
                 logger.info(f"Skill loaded: {skill_name}")
+
+                # 触发后台自动翻译（不阻塞返回）。安装路径已经做过同样处理，
+                # _load_skill 是另一条入口（用户用工具加载本地新建技能），
+                # 这里补齐让 i18n.yaml 写入一致。
+                try:
+                    brain = getattr(self.agent, "brain", None)
+                    if brain is not None:
+                        from openakita.skills.i18n import auto_translate_skill
+
+                        meta = loaded.metadata
+                        kw = list(getattr(meta, "keywords", []) or [])
+                        coro = auto_translate_skill(
+                            skill_dir=skill_dir,
+                            name=meta.name,
+                            description=meta.description or "",
+                            brain=brain,
+                            when_to_use=getattr(meta, "when_to_use", "") or "",
+                            keywords=kw,
+                            argument_hint=getattr(meta, "argument_hint", "") or "",
+                        )
+                        try:
+                            asyncio.get_running_loop().create_task(coro)
+                        except RuntimeError:
+                            coro.close()
+                except Exception as te:  # pragma: no cover - 仅日志
+                    logger.debug(f"auto_translate_skill scheduling skipped: {te}")
 
                 return f"""✅ 技能加载成功！
 


### PR DESCRIPTION
## Summary
- `parser.py`: SKILL.md 缺 frontmatter/name/description 时降级处理，回退文件名推导
- `bridge.py`: 扩展 CLI 前缀识别 + `_extract_skill_signal` 支持多行/带 flag 安装命令
- `routes/skills.py`: `_auto_translate_new_skills` 改为 `asyncio.create_task` 后台执行
- `SkillManager.tsx`: 安装接口超时统一提升到 180s
- `skills.py` handler: `_load_skill` 成功后调度 `auto_translate_skill` 后台任务

## Test plan
- [ ] 安装缺少 frontmatter 的 SKILL.md 不报错
- [ ] 多行安装命令正确提取 skill 信号
- [ ] 安装接口不因翻译阻塞
- [ ] 安装超时内完成正常 skill 安装
