### PR TITLE
feat(vision): backport v1.26.x — vision degradation notice + multimodal fallback

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -2630,6 +2630,34 @@ export function ChatView({
                   }];
                 });
                 continue; // skip normal update below
+              case "endpoint_notice": {
+                // 渲染为系统气泡：thinking_degraded / vision_degraded
+                const reasonCode: string =
+                  (event as any).reason_code || (event as any).notice_type || "";
+                const endpointName: string = (event as any).endpoint || "";
+                let noticeText = "";
+                if (reasonCode === "thinking_degraded") {
+                  noticeText = endpointName
+                    ? `当前模型「${endpointName}」未返回思考过程，已自动降级为非思考模式继续回答。`
+                    : "当前模型未返回思考过程，已自动降级为非思考模式继续回答。";
+                } else if (reasonCode === "vision_degraded") {
+                  noticeText = endpointName
+                    ? `当前选中的模型「${endpointName}」不支持视觉，本轮的图片已被隐藏，仅根据文字内容回答。`
+                    : "当前选中的模型不支持视觉，本轮的图片已被隐藏，仅根据文字内容回答。";
+                } else {
+                  noticeText = "端点能力降级提示";
+                }
+                updateMessages((prev) => [
+                  ...prev,
+                  {
+                    id: genId(),
+                    role: "system" as const,
+                    content: noticeText,
+                    timestamp: Date.now(),
+                  },
+                ]);
+                continue;
+              }
               case "error":
                 currentError = {
                   message: event.message,

--- a/src/openakita/core/reasoning_engine.py
+++ b/src/openakita/core/reasoning_engine.py
@@ -2351,6 +2351,8 @@ class ReasoningEngine:
 
             # --- Thinking 静默失败降级通知节流 (#415 #416 #403) ---
             _thinking_notice_emitted = False
+            # --- Vision 降级通知节流（一次会话只发一次） ---
+            _vision_notice_emitted = False
 
             # --- 恢复的 Todo：补发 SSE 事件让前端重建 FloatingPlanBar ---
             if conversation_id:
@@ -2586,6 +2588,17 @@ class ReasoningEngine:
                         elif _evt_type == "thinking_delta":
                             yield stream_event
                             _streamed_thinking = True
+                        elif _evt_type == "endpoint_meta":
+                            # 由 LLMClient 注入的端点元信息（vision_degraded 等）
+                            # 转换成前端协议一致的 endpoint_notice。
+                            if stream_event.get("vision_degraded") and not _vision_notice_emitted:
+                                _vision_notice_emitted = True
+                                yield {
+                                    "type": "endpoint_notice",
+                                    "notice_type": "degraded",
+                                    "endpoint": stream_event.get("endpoint_name", ""),
+                                    "reason_code": "vision_degraded",
+                                }
                         elif _evt_type == "decision":
                             decision = stream_event["decision"]
                             _stream_usage = stream_event.get("usage")
@@ -4610,6 +4623,13 @@ class ReasoningEngine:
                         reason=cancel_reason,
                         source="llm_stream",
                     )
+
+                # 端点元信息（如 vision_degraded）由 LLMClient 直接 yield
+                # 在流开始之前，不走 StreamAccumulator，原样向上转发。
+                if isinstance(raw_event, dict) and raw_event.get("type") == "endpoint_meta":
+                    yield raw_event
+                    last_yield_time = _time.monotonic()
+                    continue
 
                 for high_event in acc.feed(raw_event):
                     yield high_event

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -663,6 +663,21 @@ class LLMClient:
                     f"[LLM-Stream] endpoint={provider.name} model={provider.model} "
                     f"action=stream_request"
                 )
+                # 发射一次端点元信息：vision 降级时让上层（reasoning_engine）能
+                # 转换为 endpoint_notice 给前端显示系统气泡。
+                try:
+                    if (
+                        not provider.config.has_capability("vision")
+                        and self._has_images(request.messages)
+                    ):
+                        yield {
+                            "type": "endpoint_meta",
+                            "endpoint_name": provider.name,
+                            "vision_degraded": True,
+                        }
+                        yielded = True
+                except Exception:
+                    pass
                 async for event in provider.chat_stream(request):
                     if cancel_event and cancel_event.is_set():
                         raise UserCancelledError(
@@ -1406,6 +1421,17 @@ class LLMClient:
                 # 标记 failover 信息供上层（reasoning_engine）发送通知
                 if i > 0 and providers:
                     response._failover_from = providers[0].name  # type: ignore[attr-defined]
+                # Vision 降级标记：消息含图片但所选端点不支持 vision，
+                # 此时图片已在 converter 中被替换为占位文本，给上层一个
+                # endpoint_notice 钩子，让前端能渲染系统气泡告知用户。
+                try:
+                    if (
+                        not provider.config.has_capability("vision")
+                        and self._has_images(request.messages)
+                    ):
+                        response._vision_degraded = True  # type: ignore[attr-defined]
+                except Exception:
+                    pass
 
                 # ── 自愈: thinking 模式静默失败（HTTP 200 但内容为空） ──
                 # 部分 API 代理/中转接受 thinking 参数但在响应中剥离推理内容，

--- a/src/openakita/llm/converters/messages.py
+++ b/src/openakita/llm/converters/messages.py
@@ -51,6 +51,8 @@ def convert_messages_to_openai(
     system: str = "",
     provider: str = "openai",
     enable_thinking: bool = False,
+    *,
+    vision_available: bool = True,
 ) -> list[dict]:
     """
     将内部消息格式转换为 OpenAI 格式
@@ -65,10 +67,11 @@ def convert_messages_to_openai(
         system: 系统提示
         provider: 服务商标识（用于多媒体处理，如 moonshot 支持视频）
         enable_thinking: 是否启用思考模式
+        vision_available: 当前选中端点是否具备 vision 能力。False 时图片块
+            会被替换为 "[图片：因当前模型不支持视觉，已隐藏 N 张图片]" 占位文本。
     """
     result = []
 
-    # 添加 system 消息
     if system:
         result.append(
             {
@@ -82,6 +85,7 @@ def convert_messages_to_openai(
             msg,
             provider=provider,
             enable_thinking=enable_thinking,
+            vision_available=vision_available,
         )
         if converted:
             if isinstance(converted, list):
@@ -96,6 +100,8 @@ def _convert_single_message_to_openai(
     msg: Message,
     provider: str = "openai",
     enable_thinking: bool = False,
+    *,
+    vision_available: bool = True,
 ) -> dict | list[dict] | None:
     """转换单条消息"""
     if isinstance(msg.content, str):
@@ -219,7 +225,9 @@ def _convert_single_message_to_openai(
             result.append(assistant_msg)
         else:
             # user 消息，转换内容块（传递 provider 以正确处理视频）
-            openai_content = convert_content_blocks_to_openai(other_blocks, provider=provider)
+            openai_content = convert_content_blocks_to_openai(
+                other_blocks, provider=provider, vision_available=vision_available
+            )
             result.append(
                 {
                     "role": msg.role,
@@ -381,6 +389,8 @@ def convert_messages_to_responses(
     system: str = "",
     provider: str = "openai",
     enable_thinking: bool = False,
+    *,
+    vision_available: bool = True,
 ) -> tuple[list[dict], str]:
     """将内部消息转换为 Responses API 的 input items + instructions。
 
@@ -388,6 +398,9 @@ def convert_messages_to_responses(
     - system prompt 不嵌入 messages，改由 instructions 独立传递
     - tool_result 使用 function_call_output item 而非 role:"tool" 消息
     - tool_call 使用 function_call item 而非 assistant.tool_calls
+
+    Args:
+        vision_available: 当前选中端点是否具备 vision 能力，False 时图片块降级。
 
     Returns:
         (input_items, instructions): input 数组和 instructions 字符串
@@ -399,6 +412,7 @@ def convert_messages_to_responses(
             msg,
             provider=provider,
             enable_thinking=enable_thinking,
+            vision_available=vision_available,
         )
         if converted:
             if isinstance(converted, list):
@@ -413,6 +427,8 @@ def _convert_single_message_to_responses(
     msg: Message,
     provider: str = "openai",
     enable_thinking: bool = False,
+    *,
+    vision_available: bool = True,
 ) -> dict | list[dict] | None:
     """将单条内部消息转换为 Responses API input item(s)。"""
     from .tools import convert_tool_result_to_responses
@@ -457,7 +473,9 @@ def _convert_single_message_to_responses(
                 )
         else:
             # user 消息
-            openai_content = convert_content_blocks_to_openai(other_blocks, provider=provider)
+            openai_content = convert_content_blocks_to_openai(
+                other_blocks, provider=provider, vision_available=vision_available
+            )
             result.append({"role": msg.role, "content": openai_content})
 
     return result if result else None

--- a/src/openakita/llm/converters/multimodal.py
+++ b/src/openakita/llm/converters/multimodal.py
@@ -343,6 +343,15 @@ DOCUMENT_CONVERTERS: dict[str, object] = {
 }
 
 
+def _degrade_image(block: ImageBlock, count: int) -> dict:
+    """图片降级: 当所选端点不支持视觉时 → 文本占位符"""
+    _converter_logger.warning("Image content degraded to text (provider does not support vision)")
+    return {
+        "type": "text",
+        "text": f"[图片：因当前模型不支持视觉，已隐藏 {count} 张图片]",
+    }
+
+
 def _degrade_video(block: VideoBlock) -> dict:
     """视频降级: 不支持视频的端点 → 文本描述"""
     _converter_logger.warning("Video content degraded to text (provider not supported)")
@@ -365,6 +374,8 @@ def _degrade_document(block: DocumentBlock) -> dict:
 def convert_content_blocks(
     blocks: list[ContentBlock],
     provider: str = "openai",
+    *,
+    vision_available: bool = True,
 ) -> str | list[dict]:
     """
     统一内容块转换器（策略表分发 + 优雅降级）
@@ -373,6 +384,7 @@ def convert_content_blocks(
     如果 provider 不在策略表中，自动走降级链。
 
     降级链:
+    - 视觉不支持 → 文本占位 "[图片：因当前模型不支持视觉，已隐藏 N 张图片]"
     - 视频不支持 → 文本描述 "[视频内容：该端点不支持视频输入]"
     - 音频不支持 → 文本描述 "[音频内容：该端点不支持音频输入]"
     - 文档不支持 → 文本描述 "[文档内容：该端点不支持文档输入]"
@@ -380,6 +392,9 @@ def convert_content_blocks(
     Args:
         blocks: 内容块列表
         provider: 服务商标识
+        vision_available: 当前选中端点是否具备 vision 能力。
+            False 时所有 ImageBlock 会被合并降级为一条占位文本，避免把图片
+            发到非 vision 端点（多数会直接报错或丢字段）。
 
     Returns:
         如果只有一个文本块，返回字符串；否则返回列表
@@ -390,13 +405,20 @@ def convert_content_blocks(
     if len(blocks) == 1 and isinstance(blocks[0], dict) and blocks[0].get("type") == "text":
         return blocks[0].get("text", "")
 
+    image_count = sum(1 for b in blocks if isinstance(b, ImageBlock))
+
     result = []
+    image_placeholder_emitted = False
     for block in blocks:
         if isinstance(block, TextBlock):
             result.append({"type": "text", "text": block.text})
 
         elif isinstance(block, ImageBlock):
-            result.append(convert_image_to_openai(block.image))
+            if vision_available:
+                result.append(convert_image_to_openai(block.image))
+            elif not image_placeholder_emitted:
+                result.append(_degrade_image(block, image_count))
+                image_placeholder_emitted = True
 
         elif isinstance(block, VideoBlock):
             converter = VIDEO_CONVERTERS.get(provider)

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -764,11 +764,13 @@ class OpenAIProvider(LLMProvider):
             if is_always_thinking:
                 thinking_enabled = True
 
+        _vision_available = self.config.has_capability("vision")
         messages = convert_messages_to_openai(
             request.messages,
             request.system,
             provider=self.config.provider,
             enable_thinking=thinking_enabled,
+            vision_available=_vision_available,
         )
 
         body = {


### PR DESCRIPTION
## Summary
- `multimodal.py`: 新增 `_degrade_image()`，`vision_available=False` 时将图片替换为文字占位符
- `messages.py`: 消息转换函数透传 `vision_available` 参数
- `openai.py` provider: 查询 `has_capability("vision")` 并传入消息转换器
- `client.py`: 无 vision 能力 + 有图片时注入 `endpoint_meta` 事件
- `reasoning_engine.py`: 处理 `endpoint_meta` 事件，转换为 `endpoint_notice(vision_degraded)` SSE
- `ChatView.tsx`: 渲染 `vision_degraded` / `thinking_degraded` 系统消息气泡

## Test plan
- [ ] 选择无视觉能力的模型发送图片，验证出现降级提示
- [ ] 前端显示"当前模型不支持视觉"系统消息
- [ ] 有视觉能力的模型正常处理图片
