### PR TITLE
[backport/PR1] i18n 语言选择新增跟随系统选项

### DIFF
--- a/apps/setup-center/src/components/Topbar.tsx
+++ b/apps/setup-center/src/components/Topbar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { EnvMap, ViewId, WorkspaceSummary } from "../types";
 import type { Theme } from "../theme";
+import { setLanguage, getLanguagePref } from "../i18n";
 import {
   DotGreen, DotGray,
   IconX, IconLink, IconPower, IconRefresh,
@@ -422,7 +423,8 @@ export function Topbar({
             <DropdownMenuContent align="end" className="min-w-[140px]">
               <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{t("topbar.langLabel", "语言")}</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuRadioGroup value={i18n.language?.startsWith("zh") ? "zh" : "en"} onValueChange={(v) => i18n.changeLanguage(v)}>
+              <DropdownMenuRadioGroup value={getLanguagePref()} onValueChange={(v) => setLanguage(v as "auto" | "zh" | "en")}>
+                <DropdownMenuRadioItem value="auto">{t("topbar.langAuto", "跟随系统")}</DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="zh">中文</DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="en">English</DropdownMenuRadioItem>
               </DropdownMenuRadioGroup>

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -70,6 +70,7 @@
     "themeDark": "Dark",
     "themeLight": "Light",
     "langLabel": "Language",
+    "langAuto": "System Default",
     "webAccess": "Web Access",
     "remoteUrl": "Remote URL",
     "copyRemoteUrl": "Copy remote access URL",

--- a/apps/setup-center/src/i18n/index.ts
+++ b/apps/setup-center/src/i18n/index.ts
@@ -5,6 +5,20 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import zh from "./zh.json";
 import en from "./en.json";
 
+const LS_KEY = "openakita_lang";
+
+function getStoredLang(): string | null {
+  try { return localStorage.getItem(LS_KEY); } catch { return null; }
+}
+
+function detectSystemLang(): string {
+  const nav = navigator.language || "";
+  return nav.startsWith("zh") ? "zh" : "en";
+}
+
+const stored = getStoredLang();
+const initialLng = stored === "auto" || !stored ? detectSystemLang() : stored;
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
@@ -13,13 +27,31 @@ i18n
       zh: { translation: zh },
       en: { translation: en },
     },
+    lng: initialLng,
     fallbackLng: "zh",
     detection: {
       order: ["navigator"],
+      caches: [],
     },
     interpolation: {
       escapeValue: false,
     },
   });
+
+/**
+ * Switch language with persistence.
+ * "auto" = follow system; "zh" / "en" = explicit override.
+ */
+export function setLanguage(lang: "auto" | "zh" | "en"): void {
+  try { localStorage.setItem(LS_KEY, lang); } catch {}
+  const resolved = lang === "auto" ? detectSystemLang() : lang;
+  i18n.changeLanguage(resolved);
+}
+
+export function getLanguagePref(): "auto" | "zh" | "en" {
+  const v = getStoredLang();
+  if (v === "zh" || v === "en") return v;
+  return "auto";
+}
 
 export default i18n;

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -70,6 +70,7 @@
     "themeDark": "暗色",
     "themeLight": "亮色",
     "langLabel": "语言",
+    "langAuto": "跟随系统",
     "webAccess": "网页访问",
     "remoteUrl": "远程地址",
     "copyRemoteUrl": "复制远程访问地址",

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -4,6 +4,8 @@
 import { useEffect, useMemo, useRef, useState, useCallback, memo } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { setLanguage } from "../i18n";
+import { AgentIcon } from "../components/AgentIcon";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -2585,7 +2587,7 @@ export function ChatView({
               }
               case "ui_preference":
                 if (event.theme) setThemePref(event.theme as Theme);
-                if (event.language) i18n.changeLanguage(event.language);
+                if (event.language) setLanguage(event.language as "auto" | "zh" | "en");
                 break;
               case "artifact":
                 logger.debug("Chat", "Artifact SSE received", { name: event.name, file_url: event.file_url, artifact_type: event.artifact_type });


### PR DESCRIPTION
## 来源
cherry-pick 8614d98c

## 改动
- 新增 `apps/setup-center/src/i18n/index.ts` `setLanguage(lang)` 统一入口
- Topbar 语言下拉新增 `auto` 选项
- ChatView SSE `language` 事件改走 `setLanguage`
- 用 `openakita_lang` localStorage 持久化（禁用 i18next 自身缓存）

## Main 现状
4 个文件全缺；ChatView L2461 有 1 处 import 冲突，手动保留两行（`setLanguage` + `AgentIcon`）。

## 验证
- build 通过
- 浏览器切换 zh/en/auto 后刷新保持
- SSE 推送的 `language` 事件触发切换

## 回滚
`git revert <merge-commit>`

Made with [Cursor](https://cursor.com)