### PR TITLE
[backport/PR2] 讯飞星辰 MaaS 平台 LLM provider

### DIFF
--- a/apps/setup-center/src/providers.ts
+++ b/apps/setup-center/src/providers.ts
@@ -98,6 +98,24 @@ export function isQianFanCodingPlanProvider(providerSlug: string | null, baseUrl
   return isQf && base.includes("coding");
 }
 
+export function isXfyunCodingPlanProvider(providerSlug: string | null, baseUrl: string): boolean {
+  const slug = (providerSlug || "").toLowerCase();
+  const base = (baseUrl || "").toLowerCase();
+  const isXfyun = slug === "xfyun" || base.includes("xf-yun.com");
+  return isXfyun && base.includes("maas-coding-api");
+}
+
+export function xfyunCodingPlanFallbackModels(providerSlug: string | null): ListedModel[] {
+  const ids = [
+    "astron-code-latest",
+  ];
+  return ids.map((id) => ({
+    id,
+    name: id,
+    capabilities: inferCapabilities(id, providerSlug),
+  }));
+}
+
 export function miniMaxFallbackModels(providerSlug: string | null): ListedModel[] {
   const ids = [
     "MiniMax-M2.7",
@@ -194,6 +212,9 @@ export async function fetchModelsDirectly(params: {
   }
   if (isQianFanCodingPlanProvider(providerSlug, baseUrl)) {
     return qianFanCodingPlanFallbackModels(providerSlug);
+  }
+  if (isXfyunCodingPlanProvider(providerSlug, baseUrl)) {
+    return xfyunCodingPlanFallbackModels(providerSlug);
   }
   if (isLongCatProvider(providerSlug, baseUrl)) {
     return longCatFallbackModels(providerSlug);

--- a/apps/setup-center/src/views/LLMView.tsx
+++ b/apps/setup-center/src/views/LLMView.tsx
@@ -5,10 +5,10 @@ import {
   isLocalProvider, localProviderPlaceholderKey, friendlyFetchError,
   fetchModelsDirectly, safeFetch,
   isMiniMaxProvider, isVolcCodingPlanProvider, isDashScopeCodingPlanProvider,
-  isQianFanCodingPlanProvider, isLongCatProvider,
+  isQianFanCodingPlanProvider, isLongCatProvider, isXfyunCodingPlanProvider,
   miniMaxFallbackModels, volcCodingPlanFallbackModels,
   dashScopeCodingPlanFallbackModels, qianFanCodingPlanFallbackModels,
-  longCatFallbackModels,
+  longCatFallbackModels, xfyunCodingPlanFallbackModels,
 } from "../providers";
 import {
   suggestEndpointName, envGet, envSet,
@@ -249,6 +249,10 @@ export function LLMView(props: LLMViewProps) {
     }
     if (isQianFanCodingPlanProvider(selectedProvider.slug, effectiveBaseUrl)) {
       setModels(qianFanCodingPlanFallbackModels(selectedProvider.slug));
+      return;
+    }
+    if (isXfyunCodingPlanProvider(selectedProvider.slug, effectiveBaseUrl)) {
+      setModels(xfyunCodingPlanFallbackModels(selectedProvider.slug));
       return;
     }
     if (isLongCatProvider(selectedProvider.slug, effectiveBaseUrl)) {

--- a/src/openakita/llm/registries/__init__.py
+++ b/src/openakita/llm/registries/__init__.py
@@ -63,6 +63,7 @@ _CLASS_MODULE_MAP: dict[str, str] = {
     "VolcEngineRegistry": ".volcengine",
     "ZhipuChinaRegistry": ".zhipu",
     "ZhipuInternationalRegistry": ".zhipu",
+    "XfyunRegistry": ".xfyun",
 }
 
 

--- a/src/openakita/llm/registries/providers.json
+++ b/src/openakita/llm/registries/providers.json
@@ -313,6 +313,18 @@
     "registry_class": "OpenAIRegistry"
   },
   {
+    "name": "讯飞星辰 MaaS (iFlytek Astron)",
+    "slug": "xfyun",
+    "api_type": "openai",
+    "default_base_url": "https://maas-api.cn-huabei-1.xf-yun.com/v2",
+    "coding_plan_base_url": "https://maas-coding-api.cn-huabei-1.xf-yun.com/v2",
+    "coding_plan_api_type": "openai",
+    "api_key_env_suggestion": "XFYUN_API_KEY",
+    "supports_model_list": true,
+    "supports_capability_api": false,
+    "registry_class": "XfyunRegistry"
+  },
+  {
     "name": "Ollama (本地)",
     "slug": "ollama",
     "api_type": "openai",

--- a/src/openakita/llm/registries/xfyun.py
+++ b/src/openakita/llm/registries/xfyun.py
@@ -1,0 +1,80 @@
+"""
+讯飞星辰 MaaS 服务商注册表（OpenAI 兼容）。
+
+讯飞星辰 MaaS 平台提供 OpenAI 兼容协议，同时支持 Coding Plan 订阅服务。
+常规推理: https://maas-api.cn-huabei-1.xf-yun.com/v2
+Coding Plan: https://maas-coding-api.cn-huabei-1.xf-yun.com/v2 (OpenAI)
+             https://maas-coding-api.cn-huabei-1.xf-yun.com/anthropic (Anthropic)
+
+Coding Plan 统一使用 model=astron-code-latest，底层模型在平台控制台切换。
+"""
+
+import httpx
+
+from ..capabilities import infer_capabilities
+from .base import ModelInfo, ProviderInfo, ProviderRegistry
+
+
+class XfyunRegistry(ProviderRegistry):
+    """讯飞星辰 MaaS 注册表"""
+
+    info = ProviderInfo(
+        name="讯飞星辰 MaaS (iFlytek Astron)",
+        slug="xfyun",
+        api_type="openai",
+        default_base_url="https://maas-api.cn-huabei-1.xf-yun.com/v2",
+        api_key_env_suggestion="XFYUN_API_KEY",
+        supports_model_list=True,
+        supports_capability_api=False,
+    )
+
+    async def list_models(self, api_key: str) -> list[ModelInfo]:
+        async with httpx.AsyncClient(timeout=30) as client:
+            try:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except httpx.HTTPError:
+                return self._get_preset_models()
+
+        models: list[ModelInfo] = []
+        seen: set[str] = set()
+        for m in data.get("data", []) or []:
+            if not isinstance(m, dict):
+                continue
+            mid = (m.get("id") or "").strip()
+            if not mid or mid in seen:
+                continue
+            seen.add(mid)
+            models.append(
+                ModelInfo(
+                    id=mid,
+                    name=mid,
+                    capabilities=infer_capabilities(mid, provider_slug="xfyun"),
+                )
+            )
+        return sorted(models, key=lambda x: x.id) if models else self._get_preset_models()
+
+    def _get_preset_models(self) -> list[ModelInfo]:
+        preset = [
+            "deepseek-v3.2",
+            "deepseek-v3.1",
+            "glm-5",
+            "glm-4.7-flash",
+            "qwen3-235b-a22b",
+            "qwen3.5-35b-a3b",
+            "minimax-m2.5",
+            "kimi-k2.5",
+            "astron-code-latest",
+        ]
+        return [
+            ModelInfo(
+                id=model_id,
+                name=model_id,
+                capabilities=infer_capabilities(model_id, provider_slug="xfyun"),
+            )
+            for model_id in preset
+        ]

--- a/src/openakita/setup_center/bridge.py
+++ b/src/openakita/setup_center/bridge.py
@@ -81,6 +81,25 @@ async def _list_models_openai(api_key: str, base_url: str, provider_slug: str | 
         is_qianfan = slug == "qianfan" or "qianfan.baidubce.com" in b
         return is_qianfan and "coding" in b
 
+    def _is_xfyun_coding_plan_provider() -> bool:
+        slug = (provider_slug or "").strip().lower()
+        b = (base_url or "").strip().lower()
+        is_xfyun = slug == "xfyun" or "xf-yun.com" in b
+        return is_xfyun and "maas-coding-api" in b
+
+    def _xfyun_coding_plan_fallback_models() -> list[dict]:
+        ids = [
+            "astron-code-latest",
+        ]
+        return [
+            {
+                "id": mid,
+                "name": mid,
+                "capabilities": infer_capabilities(mid, provider_slug="xfyun"),
+            }
+            for mid in ids
+        ]
+
     def _minimax_fallback_models() -> list[dict]:
         # MiniMax Anthropic/OpenAI 兼容文档仅列出固定模型，且未提供 /models 列表接口。
         ids = [
@@ -181,6 +200,8 @@ async def _list_models_openai(api_key: str, base_url: str, provider_slug: str | 
         return _dashscope_coding_plan_fallback_models()
     if _is_qianfan_coding_plan_provider():
         return _qianfan_coding_plan_fallback_models()
+    if _is_xfyun_coding_plan_provider():
+        return _xfyun_coding_plan_fallback_models()
     if _is_longcat_provider():
         return _longcat_fallback_models()
 
@@ -270,6 +291,25 @@ async def _list_models_anthropic(
         b = (base_url or "").strip().lower()
         is_qianfan = slug == "qianfan" or "qianfan.baidubce.com" in b
         return is_qianfan and "coding" in b
+
+    def _is_xfyun_coding_plan_provider() -> bool:
+        slug = (provider_slug or "").strip().lower()
+        b = (base_url or "").strip().lower()
+        is_xfyun = slug == "xfyun" or "xf-yun.com" in b
+        return is_xfyun and "maas-coding-api" in b
+
+    def _xfyun_coding_plan_fallback_models() -> list[dict]:
+        ids = [
+            "astron-code-latest",
+        ]
+        return [
+            {
+                "id": mid,
+                "name": mid,
+                "capabilities": infer_capabilities(mid, provider_slug="xfyun"),
+            }
+            for mid in ids
+        ]
 
     def _minimax_fallback_models() -> list[dict]:
         ids = [
@@ -364,6 +404,8 @@ async def _list_models_anthropic(
         return _dashscope_coding_plan_fallback_models()
     if _is_qianfan_coding_plan_provider():
         return _qianfan_coding_plan_fallback_models()
+    if _is_xfyun_coding_plan_provider():
+        return _xfyun_coding_plan_fallback_models()
     if _is_longcat_provider():
         return _longcat_fallback_models()
 


### PR DESCRIPTION
## 来源
cherry-pick 59909998

## 改动
- 新增 `src/openakita/llm/registries/xfyun.py` (XfyunRegistry)
- `llm/registries/providers.json` 注册 xfyun 条目
- `llm/registries/__init__.py` `_CLASS_MODULE_MAP` 加 xfyun
- `setup-center/src/views/LLMView.tsx` 加 apply URL
- `setup-center/src/providers.ts` 加类型
- `setup_center/bridge.py` 兼容

## Main 现状
全缺；cherry-pick 零冲突自动合并。

## 验证
- UI 选 xfyun → 添加端点 → 列模型 → 测连通
- 常规推理 + Coding Plan 两种模式

## 回滚
`git revert <merge-commit>`

Made with [Cursor](https://cursor.com)