### PR TITLE
[backport/PR7] feishu/onebot 小修：非图片媒体上传 + 群聊类型映射

### DIFF
--- a/src/openakita/channels/adapters/feishu.py
+++ b/src/openakita/channels/adapters/feishu.py
@@ -2859,19 +2859,16 @@ class FeishuAdapter(ChannelAdapter):
     async def upload_media(self, path: Path, mime_type: str) -> MediaFile:
         """上传媒体文件"""
         if mime_type.startswith("image/"):
-            image_key = await self._upload_image(str(path))
-            media = MediaFile.create(
-                filename=path.name,
-                mime_type=mime_type,
-                file_id=image_key,
-            )
-            media.status = MediaStatus.READY
-            return media
-
-        return MediaFile.create(
+            file_key = await self._upload_image(str(path))
+        else:
+            file_key = await self._upload_file(str(path))
+        media = MediaFile.create(
             filename=path.name,
             mime_type=mime_type,
+            file_id=file_key,
         )
+        media.status = MediaStatus.READY
+        return media
 
     async def send_card(
         self,

--- a/src/openakita/channels/adapters/onebot.py
+++ b/src/openakita/channels/adapters/onebot.py
@@ -768,7 +768,9 @@ class OneBotAdapter(ChannelAdapter):
             raise FileNotFoundError(f"File not found: {file_path}")
 
         chat_id_int = int(chat_id)
-        _is_grp = is_group if is_group is not None else True  # 文件上传默认尝试群
+        _is_grp = is_group if is_group is not None else (
+            self._chat_type_map.get(chat_id, "group") == "group"
+        )
 
         if caption:
             text_msg = [{"type": "text", "data": {"text": caption}}]
@@ -806,7 +808,9 @@ class OneBotAdapter(ChannelAdapter):
             raise FileNotFoundError(f"Voice file not found: {voice_path}")
 
         chat_id_int = int(chat_id)
-        _is_grp = is_group if is_group is not None else True
+        _is_grp = is_group if is_group is not None else (
+            self._chat_type_map.get(chat_id, "group") == "group"
+        )
 
         normalized = str(path.resolve()).replace("\\", "/")
         msg_array = [{"type": "record", "data": {"file": f"file:///{normalized}"}}]


### PR DESCRIPTION
## 来源
cherry-pick aa8b3f62 + 定向修复

## 改动

### 飞书 (feishu.py)
- `_upload_to_feishu` 非图片 MIME 类型路由到 `_upload_file`（走 `/open-apis/im/v1/files`）
- 修复发送非图片类附件（视频/PDF/Excel）时 403 错误

### OneBot (onebot.py)
- `send_file` / `send_voice` 根据 `_chat_type_map` 判断群聊/私聊
- 原先误用 `user_id` 作为 `group_id` 参数发送到错误目标

## Main 现状
- `feishu.py` L443 `_upload_to_feishu` 现有 if-else 未分流非图片
- `onebot.py` L1060/L1105 `send_file/send_voice` 使用硬编码发送目标
- cherry-pick 零冲突

## 验证
- 飞书：发送 jpg、png、mp4、pdf、xlsx、docx 各种类型正常
- OneBot：群聊/私聊场景各发文件和语音均送达正确目标

## 回滚
`git revert <merge-commit>`
