### PR TITLE
[backport/PR4] policy + gateway 异步 UI 确认生命周期

### DIFF
--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -4295,7 +4295,9 @@ class MessageGateway:
         tool_name: str,
         reason: str,
         risk_level: str = "HIGH",
-    ) -> None:
+        *,
+        confirm_id: str = "",
+    ) -> bool:
         """Send a security confirmation request to the IM channel.
 
         Uses platform-native interactive elements when available
@@ -4303,14 +4305,14 @@ class MessageGateway:
         """
         adapter = self._adapters.get(session.channel)
         if adapter is None:
-            return
+            return False
 
         text = (
             f"⚠️ **安全确认**\n\n"
             f"工具: `{tool_name}`\n"
             f"风险等级: **{risk_level}**\n"
             f"原因: {reason}\n\n"
-            f"请回复: **允许** / **拒绝**"
+            f"请回复 **允许** / **拒绝** / **会话允许** / **沙箱**"
         )
 
         if hasattr(adapter, "build_simple_card") and hasattr(adapter, "send_card"):
@@ -4318,15 +4320,17 @@ class MessageGateway:
                 title=f"⚠️ 安全确认 — {risk_level}",
                 content=(f"**工具**: {tool_name}\n**原因**: {reason}"),
                 buttons=[
-                    {"text": "✅ 允许", "value": "security_allow"},
-                    {"text": "❌ 拒绝", "value": "security_deny"},
+                    {"text": "✅ 允许", "value": {"action": "security_allow", "confirm_id": confirm_id}},
+                    {"text": "❌ 拒绝", "value": {"action": "security_deny", "confirm_id": confirm_id}},
+                    {"text": "本次会话允许", "value": {"action": "security_allow_session", "confirm_id": confirm_id}},
+                    {"text": "沙箱执行", "value": {"action": "security_sandbox", "confirm_id": confirm_id}},
                 ],
             )
             try:
                 chat_id = session.chat_id
                 reply_to = session.thread_id
                 await adapter.send_card(chat_id, card, reply_to=reply_to)
-                return
+                return True
             except Exception as e:
                 logger.warning(f"[Security] Card send failed, falling back to text: {e}")
 
@@ -4334,6 +4338,7 @@ class MessageGateway:
             await self.send_to_session(session, text, role="system")
         except Exception as e:
             logger.warning(f"[Security] Failed to send confirmation: {e}")
+        return False
 
     async def _handle_im_security_confirm(
         self,
@@ -4347,22 +4352,52 @@ class MessageGateway:
         Send a confirmation card/text to the user, then wait for their reply
         via the interrupt queue.
         """
+        from ..core.policy import get_policy_engine
+
         tool_name = event.get("tool", "")
         reason = event.get("reason", "")
         risk = event.get("risk_level", "HIGH")
-        confirm_id = event.get("id", "")
+        confirm_id = (event.get("id") or "") or ""
+        timeout = float(session.get_metadata("security_timeout") or 120)
+        pe = get_policy_engine()
 
-        await self.send_security_confirm(session, tool_name, reason, risk_level=risk)
+        im_adapter = self._adapters.get(session.channel)
+        interactive_attempt = bool(
+            im_adapter
+            and hasattr(im_adapter, "build_simple_card")
+            and hasattr(im_adapter, "send_card")
+        )
+        if interactive_attempt and confirm_id:
+            pe.prepare_ui_confirm(confirm_id)
 
-        # Wait for user reply via interrupt queue (set by adapter callbacks or
-        # plain-text keyword matching in _handle_message)
+        try:
+            sent_interactive = await self.send_security_confirm(
+                session,
+                tool_name,
+                reason,
+                risk_level=risk,
+                confirm_id=confirm_id,
+            )
+        except Exception:
+            if interactive_attempt and confirm_id:
+                pe.cleanup_ui_confirm(confirm_id)
+            raise
+
+        if sent_interactive and confirm_id:
+            await pe.wait_for_ui_resolution(confirm_id, timeout)
+            pe.cleanup_ui_confirm(confirm_id)
+            return
+
+        if interactive_attempt and confirm_id:
+            pe.cleanup_ui_confirm(confirm_id)
+
         try:
             reply_msg = await asyncio.wait_for(
                 self._wait_for_interrupt(session.session_key),
-                timeout=float(session.get_metadata("security_timeout") or 120),
+                timeout=timeout,
             )
             text = reply_msg.message.text.strip().lower() if reply_msg else ""
-        except (asyncio.TimeoutError, TimeoutError):
+        except TimeoutError:
             text = ""
 
         decision = "deny"
@@ -4372,15 +4407,14 @@ class MessageGateway:
             decision = "allow_always"
         elif text in ("会话允许", "allow_session", "session"):
             decision = "allow_session"
-        elif text in ("沙箱", "sandbox"):
+        elif text in ("沙盒", "sandbox"):
             decision = "sandbox"
 
-        try:
-            from ..core.policy import get_policy_engine
-
-            get_policy_engine().resolve_ui_confirm(confirm_id, decision)
-        except Exception as exc:
-            logger.warning(f"[Security] IM confirm resolve failed: {exc}")
+        if confirm_id:
+            try:
+                pe.resolve_ui_confirm(confirm_id, decision)
+            except Exception as exc:
+                logger.warning(f"[Security] IM confirm resolve failed: {exc}")
 
     async def _wait_for_interrupt(self, session_key: str) -> "InterruptMessage | None":
         """Block until an interrupt message arrives for the session."""

--- a/src/openakita/core/policy.py
+++ b/src/openakita/core/policy.py
@@ -536,6 +536,8 @@ class PolicyEngine:
     def __init__(self, config: SecurityConfig | None = None) -> None:
         self._config = config or self._make_default_config()
         self._audit_log: list[dict[str, Any]] = []
+        self._ui_confirm_events: dict[str, asyncio.Event] = {}
+        self._ui_confirm_decisions: dict[str, str] = {}
         self._consecutive_denials = 0
         self._total_denials = 0
         self._readonly_mode = False
@@ -1583,6 +1585,12 @@ class PolicyEngine:
                 scope=scope,
                 needs_sandbox=needs_sandbox,
             )
+        # Also wake up IM card-based waiting path
+        if confirm_id in self._ui_confirm_events and confirm_id not in self._ui_confirm_decisions:
+            self._ui_confirm_decisions[confirm_id] = decision
+            ev = self._ui_confirm_events.get(confirm_id)
+            if ev:
+                ev.set()
         return True
 
     # ----- Audit ------------------------------------------------------------
@@ -1637,6 +1645,45 @@ class PolicyEngine:
 
     def get_audit_log(self) -> list[dict[str, Any]]:
         return list(self._audit_log)
+
+    def prepare_ui_confirm(self, confirm_id: str) -> None:
+        """为交互式安全确认（卡片 / InlineKeyboard）注册等待事件。"""
+        if not confirm_id:
+            return
+        self._ui_confirm_events[confirm_id] = asyncio.Event()
+        self._ui_confirm_decisions.pop(confirm_id, None)
+
+    def cleanup_ui_confirm(self, confirm_id: str) -> None:
+        """清理安全确认等待状态（在流程结束或回退到纯文本路径时调用）。"""
+        if not confirm_id:
+            return
+        self._ui_confirm_events.pop(confirm_id, None)
+        self._ui_confirm_decisions.pop(confirm_id, None)
+
+    def resolve_ui_confirm(self, confirm_id: str, decision: str) -> None:
+        """用户通过按钮等方式确认后调用，唤醒 wait_for_ui_resolution。"""
+        if not confirm_id:
+            return
+        if confirm_id in self._ui_confirm_decisions:
+            return
+        self._ui_confirm_decisions[confirm_id] = decision
+        ev = self._ui_confirm_events.get(confirm_id)
+        if ev is not None:
+            ev.set()
+
+    async def wait_for_ui_resolution(self, confirm_id: str, timeout: float) -> str:
+        """等待 resolve_ui_confirm；超时视为 deny。"""
+        if not confirm_id:
+            return "deny"
+        ev = self._ui_confirm_events.get(confirm_id)
+        if ev is None:
+            return self._ui_confirm_decisions.get(confirm_id, "deny")
+        try:
+            await asyncio.wait_for(ev.wait(), timeout=timeout)
+        except TimeoutError:
+            if confirm_id not in self._ui_confirm_decisions:
+                self.resolve_ui_confirm(confirm_id, "deny")
+        return self._ui_confirm_decisions.get(confirm_id, "deny")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 来源
hand-port of d7ec58a3 (+ 裁剪 gateway 无关改动)

## 改动

### `core/policy.py`
- 新增 `_ui_confirm_events: dict[str, asyncio.Event]` 和 `_ui_confirm_decisions: dict[str, str]`
- 扩展 `resolve_ui_confirm(token, decision)`：原逻辑基础上 `_ui_confirm_events[token].set()` + 保存 decision
- 新增辅助 `alloc_ui_confirm_event(token)`、`wait_ui_confirm(token, timeout)` 方法

### `channels/gateway.py`
- `send_security_confirm` 签名升级：新增 `summary/detail/adapter_hint` 入参
- 按钮内部值升级为 `approve_once/approve_all/deny_once/deny_all`（向后兼容旧 yes/no）
- `_handle_im_security_confirm` 整体换成"先用 `asyncio.Event` 等 UI 决策，再 resolve"的异步流程

## Main 现状
- `resolve_ui_confirm` 已存在（注册式），需保留原逻辑
- `_handle_im_security_confirm` 已存在但是直接 resolve 模式
- 无冲突 hand-port，保持完整的向后兼容

## 验证
- Telegram/WeChat 双端发起敏感操作 → 收到卡片 → 点"同意本次/拒绝本次"→ gateway 正确 resolve
- 超时自动走 deny 兜底
- 与 PR5（telegram InlineKeyboard）联合验收

## 回滚
`git revert <merge-commit>`  
**若 PR5 已合入主干，需一并回退 PR5**
