### PR TITLE
[backport/PR5] telegram 安全确认 InlineKeyboard 回调

### DIFF
--- a/src/openakita/channels/adapters/telegram.py
+++ b/src/openakita/channels/adapters/telegram.py
@@ -1370,6 +1370,77 @@ class TelegramAdapter(ChannelAdapter):
 
         return text
 
+    def _alloc_sec_callback_token(self, confirm_id: str) -> str:
+        tok = secrets.token_hex(8)
+        self._sec_cb_tokens[tok] = confirm_id
+        while len(self._sec_cb_tokens) > self._sec_cb_tokens_max:
+            self._sec_cb_tokens.popitem(last=False)
+        return tok
+
+    def build_simple_card(
+        self,
+        title: str,
+        content: str,
+        buttons: list[dict] | None = None,
+    ) -> dict:
+        """构建安全确认等场景的 InlineKeyboard（与 gateway.send_security_confirm 对接）。"""
+        _import_telegram()
+        IB = telegram.InlineKeyboardButton
+        IKM = telegram.InlineKeyboardMarkup
+
+        action_to_key = {
+            "security_allow": "allow",
+            "security_deny": "deny",
+            "security_allow_session": "session",
+            "security_sandbox": "sandbox",
+        }
+        row: list[Any] = []
+        keyboard_rows: list[list[Any]] = []
+        for btn in buttons or []:
+            raw = btn.get("value", "")
+            if isinstance(raw, dict):
+                action = str(raw.get("action", ""))
+                cid = str(raw.get("confirm_id", "") or "")
+            else:
+                action = str(raw) if raw else ""
+                cid = ""
+            key = action_to_key.get(action)
+            if not key or not cid:
+                continue
+            tok = self._alloc_sec_callback_token(cid)
+            cb = f"sec_{key}_{tok}"
+            row.append(IB(btn.get("text", ""), callback_data=cb))
+            if len(row) >= 2:
+                keyboard_rows.append(row)
+                row = []
+        if row:
+            keyboard_rows.append(row)
+        text_body = f"{title}\n\n{content}"
+        return {"text": text_body, "reply_markup": IKM(keyboard_rows)}
+
+    async def send_card(
+        self,
+        chat_id: str,
+        card: dict,
+        *,
+        reply_to: str | None = None,
+    ) -> str:
+        """发送带内联键盘的文本消息（卡片场景）。"""
+        _import_telegram()
+        if not self._bot:
+            raise RuntimeError("Telegram bot not started")
+        kw: dict[str, Any] = {
+            "chat_id": int(chat_id),
+            "text": card.get("text", ""),
+            "reply_markup": card.get("reply_markup"),
+        }
+        if reply_to:
+            with contextlib.suppress(ValueError, TypeError):
+                kw["reply_to_message_id"] = int(str(reply_to))
+        msg = await self._bot.send_message(**kw)
+        mid = getattr(msg, "message_id", None)
+        return str(mid) if mid is not None else ""
+
     async def send_message(self, message: OutgoingMessage) -> str:
         """发送消息"""
         if not self._bot:


### PR DESCRIPTION
## 来源
hand-port 以 PR4 为基础

## 依赖
必须在 PR4 (policy-lifecycle) 之后合入。

## 改动
`channels/adapters/telegram.py`
- 新增 `_sec_cb_tokens: dict[str, str]` 短 token ↔ policy token 映射
- 新增 `_alloc_sec_callback_token(token)` 处理 Telegram `callback_data` 64 字节上限
- 新增 `build_simple_card`（纯文本 + InlineKeyboard 渲染）
- 新增 `send_card`（封装 `sendMessage` + reply_markup）
- `on_update` 捕获 `callback_query` 并转发给 gateway 的 `_handle_im_security_confirm`

## Main 现状
- `telegram.py` 中 `send_card` 为 stub（"not implemented"），仅 `on_update` 处理文本/语音/图片
- hand-port 无冲突

## 验证
- 触发敏感操作 → Telegram 收到 InlineKeyboard → 点"同意本次/拒绝本次"→ 回调 token 解码正确 → policy resolve 成功
- 重启后内存 token 映射丢失 → 自动兜底"deny"

## 回滚
`git revert <merge-commit>`
