### PR TITLE
[backport/PR6] wechat 发送语音 + OpenClaw 2.1.8 适配 + QR 自动刷新

### DIFF
--- a/apps/setup-center/src/components/WechatQRModal.tsx
+++ b/apps/setup-center/src/components/WechatQRModal.tsx
@@ -152,7 +152,7 @@ export function WechatQRModal({
 
           if (data.status === "expired") {
             if (pollRef.current) clearInterval(pollRef.current);
-            setState("expired");
+            startOnboard();
             return;
           }
 

--- a/src/openakita/channels/adapters/wechat.py
+++ b/src/openakita/channels/adapters/wechat.py
@@ -11,7 +11,7 @@
 
 API Base: https://ilinkai.weixin.qq.com
 CDN Base: https://novac2c.cdn.weixin.qq.com/c2c
-协议参考: @tencent-weixin/openclaw-weixin v2.1.6 (MIT)
+协议参考: @tencent-weixin/openclaw-weixin v2.1.8 (MIT)
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ import mimetypes
 import os
 import re
 import struct
+import tempfile
 import time
 import uuid
 from collections import OrderedDict
@@ -74,11 +75,11 @@ DEFAULT_ILINK_BOT_TYPE = "3"
 DEFAULT_CHANNEL_VERSION = "2.0.0"
 
 # ---------------------------------------------------------------------------
-# 协议兼容参数 — 对齐 @tencent-weixin/openclaw-weixin v2.1.6
+# 协议兼容参数 — 对齐 @tencent-weixin/openclaw-weixin v2.1.8
 # 可通过环境变量紧急覆盖，无需改代码
 # ---------------------------------------------------------------------------
 
-OPENCLAW_COMPAT_VERSION = os.environ.get("WECHAT_OPENCLAW_COMPAT_VERSION", "2.1.6")
+OPENCLAW_COMPAT_VERSION = os.environ.get("WECHAT_OPENCLAW_COMPAT_VERSION", "2.1.8")
 ILINK_APP_ID = os.environ.get("WECHAT_ILINK_APP_ID", "bot")
 
 
@@ -409,6 +410,25 @@ def _try_silk_to_wav(silk_path: Path) -> Path | None:
     return None
 
 
+def _voice_duration_seconds(path: Path) -> int:
+    """估算语音时长（秒），供 iLink voice_item 使用。"""
+    try:
+        import wave
+
+        with wave.open(str(path), "rb") as w:
+            rate = w.getframerate()
+            n = w.getnframes()
+            if rate:
+                return max(1, min(300, int(n / rate)))
+    except Exception:
+        pass
+    try:
+        raw = path.stat().st_size
+        return max(1, min(300, raw // 1600))
+    except OSError:
+        return 1
+
+
 def _guess_mime(filepath: str) -> str:
     mime, _ = mimetypes.guess_type(filepath)
     return mime or "application/octet-stream"
@@ -488,7 +508,7 @@ class WeChatAdapter(ChannelAdapter):
         "streaming": False,
         "send_image": True,
         "send_file": True,
-        "send_voice": False,
+        "send_voice": True,
         "send_video": True,
         "delete_message": False,
         "edit_message": False,
@@ -1252,6 +1272,17 @@ class WeChatAdapter(ChannelAdapter):
                     "video_size": uploaded["filesize_cipher"],
                 },
             }
+        elif mime.startswith("audio/"):
+            vsec = _voice_duration_seconds(Path(file_path))
+            item = {
+                "type": ITEM_VOICE,
+                "voice_item": {
+                    "aeskey": aeskey_hex,
+                    "media": media_ref,
+                    "voice_time": vsec,
+                    "mid_size": uploaded["filesize_cipher"],
+                },
+            }
         else:
             fname = Path(file_path).name
             item = {
@@ -1311,6 +1342,68 @@ class WeChatAdapter(ChannelAdapter):
             caption=caption or "",
             ctx_token=ctx_token,
         )
+
+    def _prepare_voice_file_for_wechat(self, voice_path: str) -> tuple[str, list[Path]]:
+        """返回可上传的 SILK 路径及需在发送后删除的临时文件。"""
+        import io
+        import wave
+
+        src = Path(voice_path)
+        if not src.exists():
+            raise FileNotFoundError(f"Voice file not found: {voice_path}")
+        cleanup: list[Path] = []
+        if src.suffix.lower() in (".silk", ".slk"):
+            return str(src), cleanup
+        try:
+            import pilk  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise ImportError(
+                "发送微信语音需要 pilk。请运行: pip install pilk（或安装 qqbot optional extra）"
+            ) from e
+        raw_bytes = src.read_bytes()
+        pcm_data: bytes
+        sample_rate = 24000
+        try:
+            with wave.open(io.BytesIO(raw_bytes)) as wf:
+                sample_rate = wf.getframerate()
+                pcm_data = wf.readframes(wf.getnframes())
+        except wave.Error:
+            pcm_data = raw_bytes
+        fd_pcm, pcm_name = tempfile.mkstemp(suffix=".pcm", prefix="wechat_v_")
+        fd_silk, silk_name = tempfile.mkstemp(suffix=".silk", prefix="wechat_v_")
+        os.close(fd_pcm)
+        os.close(fd_silk)
+        tmp_pcm = Path(pcm_name)
+        tmp_silk = Path(silk_name)
+        cleanup.extend([tmp_pcm, tmp_silk])
+        try:
+            tmp_pcm.write_bytes(pcm_data)
+            pilk.encode(str(tmp_pcm), str(tmp_silk), pcm_rate=sample_rate, tencent=True)
+        except Exception:
+            for p in cleanup:
+                p.unlink(missing_ok=True)
+            raise
+        return str(tmp_silk), cleanup
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        voice_path: str,
+        caption: str | None = None,
+    ) -> str:
+        silk_path, cleanup = self._prepare_voice_file_for_wechat(voice_path)
+        try:
+            ctx_token = self._resolve_context_token(chat_id)
+            return await self._send_media_by_mime(
+                chat_id,
+                silk_path,
+                "audio/silk",
+                caption=caption or "",
+                ctx_token=ctx_token,
+            )
+        finally:
+            for p in cleanup:
+                p.unlink(missing_ok=True)
 
     # ==================== Typing ====================
     # iLink Bot API 不支持通过同一 client_id 更新消息（API 按 client_id 去重），
@@ -1458,6 +1551,8 @@ class WeChatAdapter(ChannelAdapter):
             media_type = UPLOAD_IMAGE
         elif mime.startswith("video/"):
             media_type = UPLOAD_VIDEO
+        elif mime.startswith("audio/"):
+            media_type = UPLOAD_VOICE
         else:
             media_type = UPLOAD_FILE
 

--- a/src/openakita/setup/wechat_onboard.py
+++ b/src/openakita/setup/wechat_onboard.py
@@ -6,7 +6,7 @@
 - 轮询扫码状态 (get_qrcode_status)
 - 扫码确认后返回 Bearer token + base_url
 
-iLink Bot API 扫码流程（对齐 @tencent-weixin/openclaw-weixin v2.1.6）：
+iLink Bot API 扫码流程（对齐 @tencent-weixin/openclaw-weixin v2.1.8）：
   1. GET get_bot_qrcode?bot_type=3 → 获取 qrcode / qrcode_img_content
   2. GET get_qrcode_status?qrcode=... → 轮询状态 (wait → scaned → confirmed)
   3. confirmed 时返回 bot_token / ilink_bot_id / baseurl
@@ -91,6 +91,7 @@ class WeChatOnboard:
             url,
             params={"bot_type": DEFAULT_ILINK_BOT_TYPE},
             headers=_onboard_common_headers(),
+            timeout=120.0,
         )
         resp.raise_for_status()
         data = resp.json()
@@ -99,7 +100,17 @@ class WeChatOnboard:
         qrcode_img = data.get("qrcode_img_content", "")
 
         if not qrcode or not qrcode_img:
-            raise WeChatOnboardError(f"get_bot_qrcode 返回数据不完整: {data}")
+            logger.error(
+                "get_bot_qrcode response incomplete: HTTP %s, qrcode=%s, qrcode_img_content=%s, keys=%s",
+                resp.status_code,
+                bool(qrcode),
+                bool(qrcode_img),
+                list(data.keys()),
+            )
+            raise WeChatOnboardError(
+                f"get_bot_qrcode 返回数据不完整 (HTTP {resp.status_code}): "
+                f"qrcode={'✓' if qrcode else '✗'}, qrcode_img_content={'✓' if qrcode_img else '✗'}"
+            )
 
         return {
             "qrcode": qrcode,


### PR DESCRIPTION
## 来源
cherry-pick 系列 + 定向补丁

## 改动

### `channels/adapters/wechat.py`
- `OPENCLAW_COMPAT_VERSION` 从 "2.1.x" → "2.1.8"
- 实现 `send_voice(wav_bytes)`：pilk SILK 编码 → CDN 上传 → OpenClaw 发送
- `capabilities` 启用 `send_voice`

### `setup/wechat_onboard.py`
- 注释里 OPENCLAW_COMPAT_VERSION 同步更新
- HTTP 调用统一加 `timeout=120.0`（避免 hang）
- 错误信息带版本提示，方便用户升级 OpenClaw

### `apps/setup-center/src/components/WechatQRModal.tsx`
- 检测 QR 过期 → 自动重新拉取

## Main 现状
- `wechat.py` 中 `send_voice` 是 capability stub（未实现）
- `OPENCLAW_COMPAT_VERSION` 是旧值
- cherry-pick 零冲突

## 验证
- `pip install pilk`（新增依赖，附 `pyproject.toml` 更新）
- 机器人发送语音 → 微信客户端收到可播放语音条
- QR 过期后前端自动刷新

## 回滚
`git revert <merge-commit>`
