### PR TITLE
[backport/PR11] 记忆列表排序 + 分页

### DIFF
--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -1215,6 +1215,223 @@ button.btnApplyRestart:hover {
   color: #000;
 }
 
+/* Feedback reply markdown content */
+.feedbackMdContent {
+  font-size: 13px;
+  line-height: 1.65;
+  color: inherit;
+}
+.feedbackMdContent p {
+  margin: 0.3em 0;
+}
+.feedbackMdContent p:first-child {
+  margin-top: 0;
+}
+.feedbackMdContent p:last-child {
+  margin-bottom: 0;
+}
+.feedbackMdContent strong {
+  font-weight: 600;
+}
+.feedbackMdContent ul,
+.feedbackMdContent ol {
+  padding-left: 18px;
+  margin: 0.3em 0;
+}
+.feedbackMdContent li {
+  margin: 0.15em 0;
+}
+.feedbackMdContent code {
+  background: var(--bg-app, rgba(0,0,0,0.06));
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+.feedbackMdContent pre {
+  background: var(--bg-app, rgba(0,0,0,0.04));
+  border: 1px solid var(--line, rgba(0,0,0,0.1));
+  border-radius: 6px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  font-size: 12px;
+  margin: 6px 0;
+}
+.feedbackMdContent pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+.feedbackMdContent blockquote {
+  border-left: 3px solid var(--brand, #3b82f6);
+  margin: 0.3em 0;
+  padding: 2px 10px;
+  color: var(--muted, #888);
+}
+.feedbackMdContent a {
+  color: var(--brand, #3b82f6);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.feedbackMdContent hr {
+  border: none;
+  border-top: 1px solid var(--line, rgba(0,0,0,0.1));
+  margin: 8px 0;
+}
+
+/* ─── Memory tooltip (hover to see full content) ─── */
+.memory-tip-wrap {
+  max-width: 480px !important;
+  min-width: 200px;
+  padding: 10px 14px !important;
+  text-align: left !important;
+  white-space: normal !important;
+  border-radius: 8px !important;
+}
+.memory-tip-wrap [data-slot="tooltip-arrow"] {
+  display: none;
+}
+.memory-tip-content {
+  font-size: 13px;
+  line-height: 1.65;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+/* ─── Skill detail markdown ─── */
+.skillMdContent {
+  color: var(--text);
+  word-break: break-word;
+}
+.skillMdContent h1,
+.skillMdContent h2,
+.skillMdContent h3,
+.skillMdContent h4,
+.skillMdContent h5,
+.skillMdContent h6 {
+  font-weight: 600;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.35;
+  color: var(--text);
+}
+.skillMdContent h1 { font-size: 1.5em; border-bottom: 1px solid var(--line, rgba(0,0,0,0.1)); padding-bottom: 0.3em; }
+.skillMdContent h2 { font-size: 1.3em; border-bottom: 1px solid var(--line, rgba(0,0,0,0.08)); padding-bottom: 0.25em; }
+.skillMdContent h3 { font-size: 1.15em; }
+.skillMdContent h4 { font-size: 1.05em; }
+.skillMdContent p {
+  margin: 0.6em 0;
+  line-height: 1.7;
+}
+.skillMdContent ul,
+.skillMdContent ol {
+  padding-left: 1.6em;
+  margin: 0.5em 0;
+}
+.skillMdContent li {
+  margin: 0.25em 0;
+  line-height: 1.65;
+}
+.skillMdContent li > p {
+  margin: 0.3em 0;
+}
+.skillMdContent code {
+  background: var(--panel2, rgba(0,0,0,0.06));
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  color: var(--text);
+}
+.skillMdContent pre {
+  background: var(--bg-app, #f6f8fa);
+  border: 1px solid var(--line, rgba(0,0,0,0.1));
+  border-radius: 8px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 12px 0;
+  color: var(--text);
+}
+.skillMdContent pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.skillMdContent blockquote {
+  border-left: 3px solid var(--brand, #3b82f6);
+  margin: 0.8em 0;
+  padding: 4px 14px;
+  color: var(--muted, #666);
+  background: var(--panel2, rgba(0,0,0,0.02));
+  border-radius: 0 6px 6px 0;
+}
+.skillMdContent blockquote p {
+  margin: 0.3em 0;
+}
+.skillMdContent a {
+  color: var(--brand, #3b82f6);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.skillMdContent a:hover {
+  opacity: 0.8;
+}
+.skillMdContent hr {
+  border: none;
+  border-top: 1px solid var(--line, rgba(0,0,0,0.1));
+  margin: 16px 0;
+}
+.skillMdContent table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 12px 0;
+  font-size: 13px;
+}
+.skillMdContent th,
+.skillMdContent td {
+  border: 1px solid var(--line, rgba(0,0,0,0.12));
+  padding: 8px 12px;
+  text-align: left;
+}
+.skillMdContent th {
+  background: var(--panel2, rgba(0,0,0,0.04));
+  font-weight: 600;
+}
+.skillMdContent tr:nth-child(even) {
+  background: var(--panel2, rgba(0,0,0,0.02));
+}
+.skillMdContent img {
+  max-width: 100%;
+  border-radius: 6px;
+  margin: 8px 0;
+}
+.skillMdContent strong {
+  font-weight: 600;
+}
+.skillMdContent em {
+  font-style: italic;
+}
+
+/* Dark-mode refinements for skill markdown */
+:root[data-theme="dark"] .skillMdContent pre {
+  background: rgba(255,255,255,0.05);
+  border-color: rgba(255,255,255,0.1);
+}
+:root[data-theme="dark"] .skillMdContent code {
+  background: rgba(255,255,255,0.08);
+}
+:root[data-theme="dark"] .skillMdContent blockquote {
+  background: rgba(255,255,255,0.03);
+}
+:root[data-theme="dark"] .skillMdContent th {
+  background: rgba(255,255,255,0.06);
+}
+:root[data-theme="dark"] .skillMdContent tr:nth-child(even) {
+  background: rgba(255,255,255,0.03);
+}
+
 /* Bouncing dots animation */
 .dotBounce {
   display: inline-block;

--- a/apps/setup-center/src/views/MemoryView.tsx
+++ b/apps/setup-center/src/views/MemoryView.tsx
@@ -16,8 +16,10 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { Loader2, RefreshCw, Trash2, Pencil, Check, X, Search, Brain, Ban, List, Network } from "lucide-react";
+import { Loader2, RefreshCw, Trash2, Pencil, Check, X, Search, Brain, Ban, List, Network, ArrowUpDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from "@/components/ui/table";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
+import { useMdModules, type MdModules } from "../hooks/useMdModules";
 
 const MemoryGraph3D = lazy(() =>
   import("../components/MemoryGraph3D").then((m) => ({ default: m.MemoryGraph3D }))
@@ -90,6 +92,16 @@ const TYPE_COLORS: Record<string, string> = {
   context: "#6b7280",
 };
 
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: "importance_score", label: "重要性" },
+  { value: "created_at", label: "创建时间" },
+  { value: "updated_at", label: "更新时间" },
+  { value: "last_accessed_at", label: "最近访问" },
+  { value: "access_count", label: "访问次数" },
+];
+
+const PAGE_SIZE = 50;
+
 function fmtDate(iso: string | null): string {
   if (!iso) return "-";
   try {
@@ -98,6 +110,46 @@ function fmtDate(iso: string | null): string {
   } catch {
     return iso;
   }
+}
+
+function stripMd(s: string): string {
+  return s
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\n/g, " ");
+}
+
+function MemoryContent({ content, mdMods }: { content: string; mdMods: MdModules | null }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div style={{
+          fontSize: 13, lineHeight: 1.6, color: "var(--text)",
+          overflow: "hidden", textOverflow: "ellipsis",
+          whiteSpace: "nowrap", cursor: "pointer",
+        }}>
+          {stripMd(content)}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="memory-tip-wrap bg-popover text-popover-foreground border border-border shadow-lg"
+      >
+        {mdMods ? (
+          <div className="feedbackMdContent memory-tip-content">
+            <mdMods.ReactMarkdown remarkPlugins={[mdMods.remarkGfm]}>{content}</mdMods.ReactMarkdown>
+          </div>
+        ) : (
+          <div className="memory-tip-content" style={{ whiteSpace: "pre-wrap" }}>{content}</div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 interface Props {
@@ -109,6 +161,7 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
   const { t } = useTranslation();
   const API_BASE = apiBaseUrl;
   const typeLabel = (type: string) => TYPE_LABEL_KEYS[type] ? t(TYPE_LABEL_KEYS[type]) : type;
+  const mdMods = useMdModules();
   const [memories, setMemories] = useState<MemoryItem[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(false);
@@ -125,12 +178,18 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null);
   const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth <= 768);
   const [viewMode, setViewMode] = useState<"list" | "graph">("list");
+  const [sortBy, setSortBy] = useState("importance_score");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [page, setPage] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
 
   useEffect(() => {
     const onResize = () => setIsMobile(window.innerWidth <= 768);
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
+
+  const isSearchMode = !!searchQuery;
 
   const loadMemories = useCallback(async () => {
     if (!serviceRunning) return;
@@ -139,15 +198,23 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
       const params = new URLSearchParams();
       if (searchQuery) params.set("search", searchQuery);
       if (filterType) params.set("type", filterType);
+      if (!searchQuery) {
+        params.set("sort_by", sortBy);
+        params.set("sort_order", sortOrder);
+        params.set("limit", String(PAGE_SIZE));
+        params.set("offset", String(page * PAGE_SIZE));
+      }
       const res = await safeFetch(`${API_BASE}/api/memories?${params}`);
       const data = await res.json();
       setMemories(data.memories || []);
+      setTotalCount(data.total ?? 0);
+      setSelected(new Set());
     } catch (e: any) {
       toast.error(e.message || t("memory.loadFailed"));
     } finally {
       setLoading(false);
     }
-  }, [serviceRunning, searchQuery, filterType, API_BASE]);
+  }, [serviceRunning, searchQuery, filterType, sortBy, sortOrder, page, API_BASE]);
 
   const loadStats = useCallback(async () => {
     if (!serviceRunning) return;
@@ -353,6 +420,7 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
   const graphPanelHeight = isMobile ? "max(560px, calc(100vh - 22rem))" : "max(620px, calc(100vh - 18rem))";
 
   return (
+    <TooltipProvider delayDuration={300}>
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-6 py-5">
       {/* Stats bar */}
       {stats && (
@@ -392,13 +460,13 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
                 <Input
                   placeholder={t("memory.searchPlaceholder")}
                   value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
+                  onChange={e => { setSearchQuery(e.target.value); setPage(0); }}
                   onKeyDown={e => e.key === "Enter" && loadMemories()}
                   className="h-9 pl-9 text-sm"
                 />
               </div>
 
-              <Select value={filterType || "__all__"} onValueChange={v => setFilterType(v === "__all__" ? "" : v)}>
+              <Select value={filterType || "__all__"} onValueChange={v => { setFilterType(v === "__all__" ? "" : v); setPage(0); }}>
                 <SelectTrigger className="h-9 w-[110px] text-sm md:w-[130px]">
                   <SelectValue />
                 </SelectTrigger>
@@ -409,6 +477,35 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
                   ))}
                 </SelectContent>
               </Select>
+
+              <Select
+                value={sortBy}
+                onValueChange={v => { setSortBy(v); setPage(0); }}
+                disabled={isSearchMode}
+              >
+                <SelectTrigger className="h-9 w-[120px] text-sm" title={isSearchMode ? "搜索结果按相关度排序" : ""}>
+                  <ArrowUpDown size={12} className="mr-1 shrink-0" />
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SORT_OPTIONS.map(o => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-9 w-9 shrink-0"
+                disabled={isSearchMode}
+                title={sortOrder === "desc" ? "降序（点击切换升序）" : "升序（点击切换降序）"}
+                onClick={() => { setSortOrder(prev => prev === "desc" ? "asc" : "desc"); setPage(0); }}
+              >
+                <span style={{ fontSize: 13, fontWeight: 600, opacity: isSearchMode ? 0.4 : 1 }}>
+                  {sortOrder === "desc" ? "↓" : "↑"}
+                </span>
+              </Button>
 
               <Button variant="outline" onClick={loadMemories} disabled={loading} className="h-9 px-3 shrink-0" title={t("memory.refresh")}>
                 {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
@@ -683,20 +780,28 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
       ) : (
         /* ── Desktop: table layout ── */
         <Card className="gap-0 overflow-hidden border-border/80 py-0 shadow-sm">
-          <Table>
+          <Table style={{ tableLayout: "fixed", width: "100%" }}>
+            <colgroup>
+              <col style={{ width: 36 }} />
+              <col style={{ width: 80 }} />
+              <col />
+              <col style={{ width: 60 }} />
+              <col style={{ width: 90 }} />
+              <col style={{ width: 80 }} />
+            </colgroup>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[36px] px-3">
+                <TableHead className="px-3">
                   <Checkbox
                     checked={selected.size === memories.length && memories.length > 0}
                     onCheckedChange={selectAll}
                   />
                 </TableHead>
-                <TableHead className="w-[80px]">{t("memory.type")}</TableHead>
+                <TableHead>{t("memory.type")}</TableHead>
                 <TableHead>{t("memory.content")}</TableHead>
-                <TableHead className="w-[60px] text-center">{t("memory.score")}</TableHead>
-                <TableHead className="w-[90px] text-center">{t("memory.createdAt")}</TableHead>
-                <TableHead className="w-[100px] text-center">{t("memory.actions")}</TableHead>
+                <TableHead className="text-center">{t("memory.score")}</TableHead>
+                <TableHead className="text-center">{t("memory.createdAt")}</TableHead>
+                <TableHead className="text-center">{t("memory.actions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -731,7 +836,7 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
                       {typeLabel(m.type)}
                     </span>
                   </TableCell>
-                  <TableCell className="max-w-[400px]">
+                  <TableCell style={{ overflow: "hidden" }}>
                     {editingId === m.id ? (
                       <div className="flex flex-col gap-1.5">
                         <Textarea
@@ -758,11 +863,9 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
                       </div>
                     ) : (
                       <div>
-                        <div className="leading-relaxed break-words whitespace-pre-wrap">
-                          {m.content}
-                        </div>
+                        <MemoryContent content={m.content} mdMods={mdMods} />
                         {(m.subject || m.predicate) && (
-                          <div className="mt-1 text-[11px] text-muted-foreground">
+                          <div className="mt-1 text-[11px] text-muted-foreground" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                             {m.subject && <span>{t("memory.subject")}: {m.subject}</span>}
                             {m.subject && m.predicate && <span> · </span>}
                             {m.predicate && <span>{t("memory.predicate")}: {m.predicate}</span>}
@@ -806,6 +909,27 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
           </Table>
         </Card>
       )}
+      {/* Pagination */}
+      {!isSearchMode && totalCount > 0 && (() => {
+        const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+        if (totalPages <= 1) return null;
+        return (
+          <div className="flex items-center justify-between gap-2 flex-wrap" style={{ fontSize: 13 }}>
+            <span className="text-muted-foreground text-xs">
+              共 {totalCount} 条 · 第 {page + 1}/{totalPages} 页
+            </span>
+            <div className="flex items-center gap-1">
+              <Button variant="outline" size="sm" disabled={page <= 0} onClick={() => setPage(p => p - 1)}>
+                <ChevronLeft size={14} /> 上一页
+              </Button>
+              <Button variant="outline" size="sm" disabled={page >= totalPages - 1} onClick={() => setPage(p => p + 1)}>
+                下一页 <ChevronRight size={14} />
+              </Button>
+            </div>
+          </div>
+        );
+      })()}
+
       <AlertDialog open={!!confirmDialog} onOpenChange={open => { if (!open) setConfirmDialog(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -821,5 +945,6 @@ export function MemoryView({ serviceRunning, apiBaseUrl = "" }: Props) {
         </AlertDialogContent>
       </AlertDialog>
     </div>
+    </TooltipProvider>
   );
 }

--- a/src/openakita/api/routes/memory.py
+++ b/src/openakita/api/routes/memory.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -151,7 +150,10 @@ async def list_memories(
     search: str | None = None,
     q: str | None = None,
     min_score: float = 0.0,
-    limit: int = 200,
+    limit: int = 50,
+    offset: int = 0,
+    sort_by: str = "importance_score",
+    sort_order: str = "desc",
 ):
     store = _get_store(request)
     if not store:
@@ -162,22 +164,26 @@ async def list_memories(
 
     if search:
         results = store.search_semantic(search, limit=limit, filter_type=type)
-    else:
-        results = store.load_all_memories()
-        if type:
-            results = [
-                m
-                for m in results
-                if (m.type.value if hasattr(m.type, "value") else str(m.type)) == type
-            ]
-        if min_score > 0:
-            results = [m for m in results if m.importance_score >= min_score]
-        results.sort(key=lambda m: (m.importance_score, m.created_at or datetime.min), reverse=True)
-        results = results[:limit]
+        return {
+            "memories": [_serialize(m) for m in results],
+            "total": len(results),
+            "limit": limit,
+            "offset": 0,
+        }
 
+    results, total = store.query_paged(
+        memory_type=type,
+        min_importance=min_score if min_score > 0 else None,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
+    )
     return {
         "memories": [_serialize(m) for m in results],
-        "total": len(results),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
     }
 
 

--- a/src/openakita/memory/storage.py
+++ b/src/openakita/memory/storage.py
@@ -750,6 +750,70 @@ class MemoryStorage:
         except Exception:
             return 0
 
+    SORTABLE_COLUMNS = frozenset({
+        "importance_score", "created_at", "updated_at",
+        "last_accessed_at", "access_count",
+    })
+
+    def query_paged(
+        self,
+        *,
+        memory_type: str | None = None,
+        min_importance: float | None = None,
+        scope: str | None = None,
+        scope_owner: str | None = None,
+        sort_by: str = "importance_score",
+        sort_order: str = "desc",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[dict], int]:
+        """Paginated query with SQL-level sorting. Returns (rows, total_count)."""
+        if not self._conn:
+            return [], 0
+
+        if sort_by not in self.SORTABLE_COLUMNS:
+            sort_by = "importance_score"
+        if sort_order.lower() not in ("asc", "desc"):
+            sort_order = "desc"
+
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if memory_type:
+            conditions.append("type = ?")
+            params.append(memory_type)
+        if min_importance is not None:
+            conditions.append("importance_score >= ?")
+            params.append(min_importance)
+        if scope is not None:
+            conditions.append("(scope IS NULL OR scope = ?)")
+            params.append(scope)
+        if scope_owner is not None:
+            conditions.append("(scope_owner IS NULL OR scope_owner = ?)")
+            params.append(scope_owner)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+
+        try:
+            count_cur = self._conn.execute(
+                f"SELECT COUNT(*) FROM memories WHERE {where}", params
+            )
+            total = count_cur.fetchone()[0]
+
+            order = sort_order.upper()
+            page_params = params + [limit, offset]
+            cursor = self._conn.execute(
+                f"SELECT * FROM memories WHERE {where} "
+                f"ORDER BY {sort_by} {order} "
+                f"LIMIT ? OFFSET ?",
+                page_params,
+            )
+            rows = self._rows_to_dicts(cursor)
+            return rows, total
+        except Exception as e:
+            logger.error(f"Failed to query_paged memories: {e}")
+            return [], 0
+
     # ======================================================================
     # FTS5 Search
     # ======================================================================

--- a/src/openakita/memory/unified_store.py
+++ b/src/openakita/memory/unified_store.py
@@ -276,6 +276,11 @@ class UnifiedStore:
         rows = self.db.load_all(scope=scope, scope_owner=scope_owner)
         return [SemanticMemory.from_dict(r) for r in rows]
 
+    def query_paged(self, **kwargs: Any) -> tuple[list[SemanticMemory], int]:
+        """Paginated query delegating to storage.query_paged()."""
+        rows, total = self.db.query_paged(**kwargs)
+        return [SemanticMemory.from_dict(r) for r in rows], total
+
     # ======================================================================
     # Episode Memory
     # ======================================================================


### PR DESCRIPTION
## 来源
cherry-pick 相关子集 + 轻量改造

## 改动

### 后端
- `memory/storage.py` 新增 `query_paged(skip, limit, sort_by, sort_order)` 方法
- `memory/unified_store.py` 透传分页参数
- `api/routes/memory.py` `/api/memory/list` 接受 `skip/limit/sort_by/sort_order` 查询参数

### 前端
- `views/MemoryView.tsx` 列表视图新增：
  - 排序下拉（time / score / content）
  - 方向切换按钮
  - 底部分页组件
  - 新 state: `skip/limit/sortBy/sortOrder`
- `styles.css` 补充 `.memory-sort-*` / `.memory-page-footer` 样式

## Main 现状
- `storage.query` 未支持分页
- `MemoryView` 仅"加载全部"，无排序
- cherry-pick 零冲突

## 验证
- 语义记忆量 > 1k 条时，列表分页流畅
- 切换 sort_by=score 后打分倒序正确
- mobile 响应式无错位

## 回滚
`git revert <merge-commit>`
