### PR TITLE
fix CI regressions exposed by clean Linux test runs

### DIFF
--- a/build/prepare_bootstrap_resources.py
+++ b/build/prepare_bootstrap_resources.py
@@ -830,12 +830,60 @@ def _is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _is_dangerous_clean_target(path: Path) -> bool:
+    resolved = path.resolve()
+    anchors = {Path(resolved.anchor).resolve()} if resolved.anchor else set()
+    protected = {
+        ROOT.resolve(),
+        Path.home().resolve(),
+        *anchors,
+    }
+    if resolved in protected:
+        return True
+    # Refuse shallow paths such as /tmp or C:\Users. Legit staging paths have
+    # at least one specific child directory beyond those roots.
+    return len(resolved.parts) < 3
+
+
+def _is_empty_dir(path: Path) -> bool:
+    if not path.exists():
+        return True
+    if not path.is_dir():
+        return False
+    return next(path.iterdir(), None) is None
+
+
+def _has_bootstrap_manifest(path: Path) -> bool:
+    manifest_path = path / "manifest.json"
+    if not manifest_path.is_file():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        manifest.get("schema_version") == 1
+        and manifest.get("app_name") == "openakita"
+        and isinstance(manifest.get("wheel"), dict)
+        and isinstance(manifest.get("uv"), dict)
+    )
+
+
 def clean_output_dir(output_dir: Path) -> None:
     if output_dir.resolve() == BOOTSTRAP_DIR.resolve():
         return
-    if not _is_within(output_dir, ROOT / "build"):
-        raise RuntimeError(f"Refusing to clean non-build output directory: {output_dir}")
-    shutil.rmtree(output_dir, ignore_errors=True)
+    if _is_within(output_dir, ROOT / "build"):
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return
+    if _is_dangerous_clean_target(output_dir):
+        raise RuntimeError(f"Refusing to clean unsafe output directory: {output_dir}")
+    if _is_empty_dir(output_dir) or _has_bootstrap_manifest(output_dir):
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return
+    raise RuntimeError(
+        "Refusing to clean non-build output directory without an OpenAkita "
+        f"bootstrap manifest: {output_dir}"
+    )
 
 
 def print_output_summary(output_dir: Path, generated: list[Path], *, commit_resources: bool) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 
     # Async and HTTP
     "httpx[socks]>=0.27.0",
+    "aiohttp>=3.13.0",
     "aiofiles>=24.1.0",
     "nest-asyncio>=1.5.0",
 

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -317,6 +317,10 @@ def _mount_web_frontend(app: FastAPI) -> None:
     app.mount("/web", StaticFiles(directory=str(web_dist), html=True), name="web-frontend")
 
 
+def _has_web_frontend_mount(app: FastAPI) -> bool:
+    return any(getattr(route, "name", None) == "web-frontend" for route in app.routes)
+
+
 def create_app(
     agent: Any = None,
     shutdown_event: asyncio.Event | None = None,
@@ -521,7 +525,7 @@ def create_app(
     async def root():
         # If web frontend is available, redirect to it
         web_dist = _find_web_dist()
-        if web_dist:
+        if web_dist or _has_web_frontend_mount(app):
             from fastapi.responses import RedirectResponse
 
             return RedirectResponse(url="/web/")

--- a/src/openakita/core/policy_v2/audit_writer.py
+++ b/src/openakita/core/policy_v2/audit_writer.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import Any
@@ -119,7 +120,7 @@ class AsyncBatchAuditWriter:
         # the same value regardless of OS separator. Without this the
         # singleton path lookup fails on Windows because ``Path(...)``
         # stringifies with ``\`` while the caller passed ``/``.
-        self._path = str(Path(path))
+        self._path = os.path.normpath(str(path).replace("\\", os.sep))
         self._writer: ChainedJsonlWriter = get_writer(self._path)
         self._max_batch_size = max(1, max_batch_size)
         self._max_batch_delay_s = max_batch_delay_ms / 1000.0

--- a/src/openakita/core/policy_v2/defaults.py
+++ b/src/openakita/core/policy_v2/defaults.py
@@ -45,7 +45,10 @@ def default_protected_paths() -> list[str]:
 
     v1 ``_default_protected_paths`` 完全等价（C8b-1 audit 验证）。
     """
-    paths: list[str] = []
+    paths: list[str] = [
+        "${CWD}/identity/**",
+        "${CWD}/data/**",
+    ]
     if platform.system() == "Windows":
         paths.extend(
             [

--- a/src/openakita/prompt/compiler.py
+++ b/src/openakita/prompt/compiler.py
@@ -18,6 +18,7 @@ Prompt Compiler (v2) — LLM 辅助编译 + 缓存 + 规则降级
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -143,7 +144,7 @@ class PromptCompiler:
                 )
             results[target] = output_path
 
-        (runtime_dir / ".compiled_at").write_text(datetime.now().isoformat(), encoding="utf-8")
+        _write_compiled_timestamp(identity_dir, runtime_dir)
         return results
 
     async def _compile_with_llm(self, content: str, config: dict) -> str:
@@ -205,8 +206,30 @@ def compile_all(identity_dir: Path, use_llm: bool = False) -> dict[str, Path]:
 
     _cleanup_orphan_files(runtime_dir)
 
-    (runtime_dir / ".compiled_at").write_text(datetime.now().isoformat(), encoding="utf-8")
+    _write_compiled_timestamp(identity_dir, runtime_dir)
     return results
+
+
+def _source_paths(identity_dir: Path) -> list[Path]:
+    return [
+        identity_dir / source_file
+        for source_file in set(_SOURCE_MAP.values())
+        if (identity_dir / source_file).exists()
+    ]
+
+
+def _write_compiled_timestamp(identity_dir: Path, runtime_dir: Path) -> None:
+    timestamp_file = runtime_dir / ".compiled_at"
+    timestamp_file.write_text(datetime.now().isoformat(), encoding="utf-8")
+    try:
+        max_source_mtime_ns = max(
+            (source.stat().st_mtime_ns for source in _source_paths(identity_dir)),
+            default=timestamp_file.stat().st_mtime_ns,
+        )
+        target_ns = max(max_source_mtime_ns + 1, timestamp_file.stat().st_mtime_ns)
+        os.utime(timestamp_file, ns=(target_ns, target_ns))
+    except OSError:
+        pass
 
 
 def _cleanup_orphan_files(runtime_dir: Path) -> None:
@@ -548,7 +571,7 @@ def _is_up_to_date(source: Path, output: Path) -> bool:
     if not output.exists():
         return False
     try:
-        return output.stat().st_mtime > source.stat().st_mtime
+        return output.stat().st_mtime_ns >= source.stat().st_mtime_ns
     except Exception:
         return False
 
@@ -566,11 +589,20 @@ def check_compiled_outdated(identity_dir: Path, max_age_hours: int = 24) -> bool
     except Exception:
         return True
 
+    try:
+        compiled_mtime_ns = timestamp_file.stat().st_mtime_ns
+    except OSError:
+        return True
+
     # Source file mtime check: recompile if any source changed after last compilation
     for target, source_file in _SOURCE_MAP.items():
         source_path = identity_dir / source_file
         output_path = runtime_dir / _OUTPUT_MAP[target]
-        if source_path.exists() and not _is_up_to_date(source_path, output_path):
+        if not source_path.exists():
+            continue
+        if source_path.stat().st_mtime_ns > compiled_mtime_ns:
+            return True
+        if not _is_up_to_date(source_path, output_path):
             return True
 
     return False
@@ -618,4 +650,3 @@ def compile_user(content: str) -> str:
 
 def compile_persona(content: str) -> str:
     return _compile_with_rules(content, _COMPILE_PROMPTS["persona_custom"])
-

--- a/src/openakita/skills/watcher.py
+++ b/src/openakita/skills/watcher.py
@@ -140,9 +140,10 @@ def clear_all_skill_caches() -> None:
 
     # F13: Clear parser memoization cache
     try:
-        from .parser import SkillParser
+        from .parser import SkillParser, invalidate_global_parse_cache
 
         if hasattr(SkillParser, "_parse_cache"):
             SkillParser._parse_cache.clear()
+        invalidate_global_parse_cache()
     except Exception:
         pass

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -15,17 +15,25 @@
 
 from __future__ import annotations
 
-import os
-
 import httpx
 import pytest
 
 from openakita.api.server import create_app
 
+TEST_PASSWORD = "integration-test-pw-42"
+
 
 @pytest.fixture
-def app():
-    return create_app()
+def app(monkeypatch, tmp_path):
+    from openakita.config import settings
+
+    monkeypatch.setattr(settings, "project_root", tmp_path)
+    monkeypatch.delenv("OPENAKITA_WEB_PASSWORD", raising=False)
+    monkeypatch.delenv("TRUST_PROXY", raising=False)
+
+    app = create_app()
+    app.state.web_access_config.change_password(TEST_PASSWORD)
+    return app
 
 
 @pytest.fixture
@@ -154,10 +162,9 @@ class TestWebSocketAuth:
         monkeypatch.setattr(ws_mod, "_is_local_ws", lambda ws: True)
         from starlette.testclient import TestClient
 
-        with TestClient(app) as tc:
-            with tc.websocket_connect("/ws/events") as ws:
-                data = ws.receive_json()
-                assert data["event"] == "connected"
+        with TestClient(app) as tc, tc.websocket_connect("/ws/events") as ws:
+            data = ws.receive_json()
+            assert data["event"] == "connected"
 
     async def test_ws_proxy_without_token_rejected(self, app, monkeypatch):
         monkeypatch.setenv("TRUST_PROXY", "true")
@@ -165,26 +172,28 @@ class TestWebSocketAuth:
 
         monkeypatch.setattr(ws_mod, "_is_local_ws", lambda ws: True)
         from starlette.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
 
-        with TestClient(app) as tc:
-            with pytest.raises(Exception):
-                with tc.websocket_connect(
-                    "/ws/events",
-                    headers={"X-Forwarded-For": "203.0.113.50"},
-                ):
-                    pass
+        with (
+            TestClient(app) as tc,
+            pytest.raises(WebSocketDisconnect),
+            tc.websocket_connect(
+                "/ws/events",
+                headers={"X-Forwarded-For": "203.0.113.50"},
+            ),
+        ):
+            pass
 
     async def test_ws_proxy_with_valid_token_connects(self, app, access_token, monkeypatch):
         monkeypatch.setenv("TRUST_PROXY", "true")
         from starlette.testclient import TestClient
 
-        with TestClient(app) as tc:
-            with tc.websocket_connect(
-                f"/ws/events?token={access_token}",
-                headers={"X-Forwarded-For": "203.0.113.50"},
-            ) as ws:
-                data = ws.receive_json()
-                assert data["event"] == "connected"
+        with TestClient(app) as tc, tc.websocket_connect(
+            f"/ws/events?token={access_token}",
+            headers={"X-Forwarded-For": "203.0.113.50"},
+        ) as ws:
+            data = ws.receive_json()
+            assert data["event"] == "connected"
 
 
 # ---------------------------------------------------------------------------
@@ -305,4 +314,3 @@ class TestTokenRefresh:
             },
         )
         assert resp.status_code == 200
-


### PR DESCRIPTION
## Summary
- Fix clean Linux CI failures around path normalization, auth-flow setup state, prompt compiler staleness, skill parse cache invalidation, web root redirects, and default protected paths.
- Add the missing `aiohttp` runtime dependency used by integration adapters.
- Allow safe external Unicode bootstrap staging cleanup without permitting arbitrary directory deletion.

## Verification
- `ruff check src/`
- `mypy src/`
- `pytest tests/smoke/ -x -v`
- `pytest tests/unit/ -x -v`
- `pytest tests/component/ -x -v`
- `pytest tests/integration/ -v`
- `LLM_TEST_MODE=replay pytest tests/e2e/ -v`
- `pytest tests/quality/ -v`
- Plugin SDK lint/build/install
- `python -m build`

