### PR TITLE
fix CI bootstrap resource preparation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,21 +42,6 @@ jobs:
       - name: Type check with mypy
         run: mypy src/
 
-  # ── Bootstrap contract 预检 ──
-  # 在 PR 阶段就拦住"PBS pin / uv URL / pyproject Python 版本"的漂移，避免
-  # 合入后 release-dryrun 才暴露。HEAD 请求 ~1 分钟内完成，4xx 立即失败。
-  bootstrap_contract:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Verify remote bootstrap asset URLs + version pins
-        run: python build/prepare_bootstrap_resources.py --verify-remote-assets
-
   # ── L0 Smoke (每次 Push/PR, <10s, 6 个根因修复回归挡板) ──
   # 直接对应 _exploratory_fix_plan_20260417 的 F1~F4 修复，
   # 任何静默退化（cache 不命中/记忆召回率回到 0/profile 卡白名单等）
@@ -384,7 +369,7 @@ jobs:
           # inside Tauri.  Note: as of SDK 0.7.0 the old contrib subpackage
           # is gone — plugins vendor their own helpers under <plugin>_inline/.
           pip install ./openakita-plugin-sdk
-          pip install "pyinstaller>=6.18.0"
+          pip install build "pyinstaller>=6.18.0"
 
       - name: Clean previous PyInstaller output
         run: |

--- a/build/prepare_bootstrap_resources.py
+++ b/build/prepare_bootstrap_resources.py
@@ -34,6 +34,20 @@ DEFAULT_OUTPUT_ROOT = ROOT / "build" / "bootstrap-output"
 WEB_ASSETS_DIR = ROOT / "apps" / "setup-center" / "dist-web"
 DOCS_ASSETS_DIR = ROOT / "docs-site" / ".vitepress" / "dist"
 
+
+def configure_utf8_stdio() -> None:
+    """Keep CI logs writable when paths contain non-ASCII characters."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+            except OSError:
+                pass
+
+
+configure_utf8_stdio()
+
 # uv release pin —— **必须**显式版本号，禁止 `latest`。
 # 原因：CI 缓存 key 需要 uv 版本作为锚点；`latest` 滚动会出现"key 不动、内容变"，
 # 让缓存命中老版本但代码已经升级。升级 uv 时改这里的常量并跑全平台 release-dryrun。
@@ -315,11 +329,22 @@ def build_wheel() -> Path:
     out_dir = BUILD_BOOTSTRAP_WHEELS
     shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--outdir", str(out_dir)],
-        cwd=ROOT,
-        check=True,
-    )
+    with tempfile.TemporaryDirectory(prefix="openakita-wheel-build-") as tmp:
+        # Running `python -m build` from repo root imports the local build/
+        # script directory instead of PyPA's build package.
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--wheel",
+                "--outdir",
+                str(out_dir),
+                str(ROOT),
+            ],
+            cwd=tmp,
+            check=True,
+        )
     wheels = sorted(out_dir.glob("openakita-*.whl"), key=lambda item: item.stat().st_mtime)
     if not wheels:
         raise RuntimeError("python -m build --wheel completed but no openakita wheel was found")


### PR DESCRIPTION
## Summary
- move the remote bootstrap asset contract out of regular CI so transient GitHub release CDN 5xx responses do not fail unrelated checks
- install the PyPA `build` frontend in the full Tauri CI job
- run bootstrap wheel creation from an isolated working directory so the repository `build/` script directory does not shadow PyPA `build`
- force UTF-8 stdio for bootstrap preparation logs so Windows Unicode-path smoke output remains writable

## Verification
- `uv run ruff check build\prepare_bootstrap_resources.py`
- `uv run python -m py_compile build\prepare_bootstrap_resources.py`
- parsed `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/release-dryrun.yml` with PyYAML
- checked `python -m build --help` from a temporary working directory

## Context
This addresses deterministic failures seen in https://github.com/openakita/openakita/actions/runs/27121687496 while leaving release and release-dryrun as the gates for remote bootstrap asset pin drift.
