### PR TITLE
Fix CI bootstrap contract failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,8 +445,7 @@ jobs:
         working-directory: apps/setup-center
         env:
           NO_STRIP: true
-          APPIMAGE_EXTRACT_AND_RUN: 1
-        run: npx tauri build --bundles "deb,appimage"
+        run: npx tauri build --bundles "deb"
 
       - name: Verify bundle exists
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,8 @@ jobs:
         shell: bash
         env:
           UNICODE_STAGE: ${{ env.UNICODE_STAGE }}
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: utf-8
         run: |
           set -euo pipefail
           if [ "${{ runner.os }}" = "Windows" ]; then
@@ -555,6 +557,8 @@ jobs:
         shell: bash
         env:
           UNICODE_STAGE: ${{ env.UNICODE_STAGE }}
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: utf-8
         run: |
           set -euo pipefail
           if [ "${{ runner.os }}" = "Windows" ]; then

--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -1748,6 +1748,8 @@ fn apply_runtime_env_builder(
     cmd.env("OPENAKITA_ENV_PURPOSE", purpose.as_str());
     cmd.env("OPENAKITA_ENV_TRUST_SOURCE", "host-runtime");
     cmd.env("PYTHONNOUSERSITE", "1");
+    cmd.env("PYTHONUTF8", "1");
+    cmd.env("PYTHONIOENCODING", "utf-8");
 
     let effective_pip_index;
     let pip_index = match pip_index {

--- a/build/prepare_bootstrap_resources.py
+++ b/build/prepare_bootstrap_resources.py
@@ -637,6 +637,9 @@ def _smoke_test_seed(seed_python: Path) -> None:
     result = subprocess.run(
         [str(seed_python), "-c", code],
         capture_output=True,
+        encoding="utf-8",
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
+        errors="replace",
         text=True,
         timeout=30,
     )


### PR DESCRIPTION
## Summary
- force UTF-8 stdio for Windows Unicode bootstrap Python paths in CI, bootstrap seed smoke tests, and OpenAkita-managed runtime subprocesses
- align the Linux Tauri CI full-build check with the release/dry-run Linux bundle target by building only the deb package

## Verification
- uv run ruff check build\prepare_bootstrap_resources.py
- uv run python -m py_compile build\prepare_bootstrap_resources.py
- parsed all workflow YAML files with PyYAML
- git diff --check
- reproduced the Windows Unicode-path stdout failure locally with cp1252 and verified it succeeds with PYTHONUTF8=1 / PYTHONIOENCODING=utf-8
