### PR TITLE
Add tag-triggered Docker Hub image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@ build
 # Node / Frontend build artifacts
 apps/setup-center/node_modules
 apps/setup-center/dist
+apps/setup-center/dist-web
+apps/setup-center/src-tauri/target
 
 # IDE & tooling
 .cursor

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,73 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  docker_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate Docker Hub configuration
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_IMAGE }}
+        run: |
+          if [ -z "$DOCKERHUB_USERNAME" ]; then
+            echo "DOCKERHUB_USERNAME secret is required"
+            exit 1
+          fi
+          if [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "DOCKERHUB_TOKEN secret is required"
+            exit 1
+          fi
+          if [ -z "$DOCKERHUB_IMAGE" ]; then
+            echo "DOCKERHUB_IMAGE secret is required, for example: openakita/openakita"
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref_name, 'v') && !contains(github.ref_name, '-') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app/apps/setup-center
 COPY apps/setup-center/package.json apps/setup-center/package-lock.json ./
 RUN npm ci
 COPY apps/setup-center/ ./
+COPY src/openakita/llm/registries/providers.json /app/src/openakita/llm/registries/providers.json
 RUN npm run build:web
 
 # ── Stage 2: Build Python package ──
@@ -51,7 +52,7 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 18900
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:18900/health || exit 1
+    CMD curl -f http://localhost:18900/api/health || exit 1
 
 ENTRYPOINT ["openakita"]
-CMD ["serve", "--host", "0.0.0.0", "--port", "18900"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary
- add a tag-triggered Docker Hub publish workflow that uses DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, and DOCKERHUB_IMAGE secrets
- generate semver/latest Docker tags through docker/metadata-action and push linux/amd64 images with Buildx GHA cache
- fix the Docker image build/runtime path so the web frontend can resolve shared provider metadata and the container starts with the current `openakita serve` CLI

## Verification
- `docker build --no-cache --progress=plain -t openakita:local-ci-test .`
- `docker build --progress=plain -t openakita:local-ci-test .`
- `docker run -d --name openakita-local-ci-test -e API_HOST=0.0.0.0 -e API_PORT=18900 -p 18999:18900 openakita:local-ci-test`
- `Invoke-WebRequest http://127.0.0.1:18999/api/health` returned `status: ok`
- Docker reported the test container as `healthy`
