### PR TITLE
Enable CI on pushes and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Run the CI workflow automatically on push events.
- Run the CI workflow automatically on pull request events.
- Keep manual workflow_dispatch support.

## Testing
- Not run; workflow trigger-only change.