### PR TITLE
bound filesystem glob searches with thread offload and scan budgets

### DIFF
--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -50,6 +50,12 @@ class Settings(BaseSettings):
         le=600,
         description="单次 grep（文件内容搜索）最大耗时（秒），超时返回提示以避免 worker 被大目录卡住。",
     )
+    glob_timeout_sec: int = Field(
+        default=30,
+        ge=5,
+        le=600,
+        description="单次 glob（文件名搜索）最大耗时（秒），超时返回提示以避免 worker 被大目录卡住。",
+    )
 
     # PR-R1: 系统 prompt / catalog header 的语言。
     # 取值 "zh"（中文，默认）/ "en"（英文）。tool_catalog header、AGENTS.md 段

--- a/src/openakita/tools/file.py
+++ b/src/openakita/tools/file.py
@@ -2,9 +2,13 @@
 File 工具 - 文件操作
 """
 
+import heapq
 import logging
 import re
 import shutil
+import threading
+import time
+from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -70,6 +74,23 @@ GREP_HARD_FORBIDDEN_PATH_FRAGMENTS = (
 
 GREP_DEFAULT_MAX_FILES = 5000
 GREP_DEFAULT_MAX_TOTAL_BYTES = 50 * 1024 * 1024  # 50 MiB
+
+GLOB_DEFAULT_MAX_DIRS = 3000
+GLOB_DEFAULT_MAX_FILES = 20000
+GLOB_DEFAULT_MAX_RESULTS = 200
+GLOB_DEFAULT_TIMEOUT_SEC = 30
+
+
+@dataclass(slots=True)
+class GlobScanResult:
+    """Bounded result returned by the synchronous glob scanner."""
+
+    matches: list[tuple[str, float]]
+    total_matches: int
+    dirs_scanned: int
+    files_scanned: int
+    skipped: int
+    capped_reason: str | None = None
 
 
 class FileTool:
@@ -442,6 +463,16 @@ class FileTool:
     @staticmethod
     def _grep_path_forbidden(dir_path: Path) -> str | None:
         """Return a human-readable rejection reason or ``None`` if path is safe."""
+        return FileTool._search_path_forbidden(dir_path, tool_name="grep")
+
+    @staticmethod
+    def _glob_path_forbidden(dir_path: Path) -> str | None:
+        """Return a human-readable rejection reason or ``None`` if path is safe."""
+        return FileTool._search_path_forbidden(dir_path, tool_name="glob")
+
+    @staticmethod
+    def _search_path_forbidden(dir_path: Path, *, tool_name: str) -> str | None:
+        """Return a human-readable rejection reason or ``None`` if path is safe."""
         try:
             resolved = dir_path.resolve()
         except OSError:
@@ -458,13 +489,13 @@ class FileTool:
                 )
 
         if resolved.parent == resolved:
-            return f"path '{path_str}' is a filesystem root; too broad for grep."
+            return f"path '{path_str}' is a filesystem root; too broad for {tool_name}."
         try:
             home = Path.home().resolve()
         except OSError:
             home = None
         if home is not None and resolved == home:
-            return f"path '{path_str}' is the user home directory; too broad for grep."
+            return f"path '{path_str}' is the user home directory; too broad for {tool_name}."
 
         return None
 
@@ -510,6 +541,17 @@ class FileTool:
                     yield from walk(child)
 
         yield from walk(dir_path)
+
+    @staticmethod
+    def _search_dir_name_blocked(name: str) -> bool:
+        return name in GREP_EXTRA_BLOCKED_DIR_NAMES
+
+    @staticmethod
+    def _search_path_fragment_blocked(path_norm: str) -> bool:
+        forbidden_norm = tuple(
+            f.replace("\\", "/").lower() for f in GREP_HARD_FORBIDDEN_PATH_FRAGMENTS
+        )
+        return any(frag in path_norm for frag in forbidden_norm)
 
     async def delete(self, path: str) -> bool:
         """删除单个文件或空目录。非空目录一律拒绝。"""
@@ -612,6 +654,157 @@ class FileTool:
                     matches.append(str(file_path.relative_to(dir_path)))
 
         return matches
+
+    def glob_scan(
+        self,
+        pattern: str,
+        path: str = ".",
+        *,
+        max_dirs: int | None = None,
+        max_files: int | None = None,
+        max_results: int | None = None,
+        max_seconds: float | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> GlobScanResult:
+        """Synchronous bounded glob scanner.
+
+        This runs in a worker thread from the async handler. The traversal
+        checks a deadline and cancel flag internally because cancelling
+        ``asyncio.to_thread`` does not stop the underlying thread immediately.
+        """
+        dir_path = self._resolve_path(path)
+        if not dir_path.is_dir():
+            raise FileNotFoundError(f"Directory not found: {dir_path}")
+
+        forbidden_reason = self._glob_path_forbidden(dir_path)
+        if forbidden_reason:
+            raise ValueError(f"glob refused: {forbidden_reason}")
+
+        dir_cap = (
+            max_dirs
+            if isinstance(max_dirs, int) and max_dirs > 0
+            else GLOB_DEFAULT_MAX_DIRS
+        )
+        file_cap = (
+            max_files
+            if isinstance(max_files, int) and max_files > 0
+            else GLOB_DEFAULT_MAX_FILES
+        )
+        result_cap = (
+            max_results
+            if isinstance(max_results, int) and max_results > 0
+            else GLOB_DEFAULT_MAX_RESULTS
+        )
+        duration_cap = (
+            float(max_seconds)
+            if isinstance(max_seconds, (int, float)) and max_seconds > 0
+            else float(GLOB_DEFAULT_TIMEOUT_SEC)
+        )
+        deadline = time.monotonic() + duration_cap
+
+        self.last_traversal_skipped = 0
+        skipped = 0
+        dirs_scanned = 0
+        files_scanned = 0
+        total_matches = 0
+        capped_reason: str | None = None
+        top_matches: list[tuple[float, str]] = []
+        stack = [dir_path]
+
+        def should_stop(*, include_dir_cap: bool) -> bool:
+            nonlocal capped_reason
+            if cancel_event is not None and cancel_event.is_set():
+                capped_reason = "cancelled by caller"
+                return True
+            if time.monotonic() >= deadline:
+                capped_reason = f"reached time cap ({duration_cap:.0f}s)"
+                return True
+            if include_dir_cap and dirs_scanned >= dir_cap:
+                capped_reason = f"reached directory cap ({dir_cap})"
+                return True
+            if files_scanned >= file_cap:
+                capped_reason = f"reached file cap ({file_cap})"
+                return True
+            return False
+
+        while stack:
+            if should_stop(include_dir_cap=True):
+                break
+
+            root = stack.pop()
+            try:
+                root_norm = str(root.resolve()).replace("\\", "/").lower()
+            except OSError:
+                root_norm = str(root).replace("\\", "/").lower()
+            if root != dir_path and self._search_path_fragment_blocked(root_norm):
+                skipped += 1
+                continue
+
+            dirs_scanned += 1
+
+            try:
+                for child in root.iterdir():
+                    if should_stop(include_dir_cap=False):
+                        break
+
+                    try:
+                        child_norm = str(child.resolve()).replace("\\", "/").lower()
+                    except OSError:
+                        child_norm = str(child).replace("\\", "/").lower()
+                    if self._search_path_fragment_blocked(child_norm):
+                        skipped += 1
+                        continue
+
+                    try:
+                        is_dir = child.is_dir()
+                        is_file = child.is_file()
+                    except OSError:
+                        skipped += 1
+                        continue
+
+                    if is_dir and self._search_dir_name_blocked(child.name):
+                        skipped += 1
+                        continue
+
+                    if self._should_skip_relative_path(child, dir_path):
+                        continue
+
+                    if is_file:
+                        if files_scanned >= file_cap:
+                            capped_reason = f"reached file cap ({file_cap})"
+                            break
+                        files_scanned += 1
+                        if self._matches_pattern(child, dir_path, pattern):
+                            total_matches += 1
+                            try:
+                                mtime = child.stat().st_mtime
+                            except OSError:
+                                mtime = 0
+                            rel = str(child.relative_to(dir_path))
+                            if len(top_matches) < result_cap:
+                                heapq.heappush(top_matches, (mtime, rel))
+                            elif top_matches and mtime > top_matches[0][0]:
+                                heapq.heapreplace(top_matches, (mtime, rel))
+
+                    if is_dir:
+                        stack.append(child)
+            except OSError:
+                skipped += 1
+
+        self.last_traversal_skipped = skipped
+        matches = sorted(
+            ((rel, mtime) for mtime, rel in top_matches),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        return GlobScanResult(
+            matches=matches,
+            total_matches=total_matches,
+            dirs_scanned=dirs_scanned,
+            files_scanned=files_scanned,
+            skipped=skipped,
+            capped_reason=capped_reason,
+        )
 
     def _iter_matching_paths(
         self,

--- a/src/openakita/tools/handlers/filesystem.py
+++ b/src/openakita/tools/handlers/filesystem.py
@@ -860,6 +860,9 @@ class FilesystemHandler:
 
     # grep 最大结果条目数
     GREP_MAX_RESULTS = 200
+    GLOB_MAX_RESULTS = 200
+    GLOB_DEFAULT_MAX_DIRS = 3000
+    GLOB_DEFAULT_MAX_FILES = 20000
 
     async def _grep(self, params: dict) -> str:
         """内容搜索"""
@@ -980,6 +983,9 @@ class FilesystemHandler:
 
     async def _glob(self, params: dict) -> str:
         """文件名模式搜索"""
+        import asyncio
+        import threading
+
         pattern = params.get("pattern", "")
         if not pattern:
             return "❌ glob 缺少必要参数 'pattern'。"
@@ -997,31 +1003,92 @@ class FilesystemHandler:
         if not dir_path.is_dir():
             return f"❌ 目录不存在: {path}"
 
-        results: list[tuple[str, float]] = []
         glob_pattern = pattern[3:] if pattern.startswith("**/") else pattern
-        for p in self.agent.file_tool._iter_matching_paths(
-            dir_path,
-            glob_pattern,
-            recursive=True,
-        ):
-            try:
-                mtime = p.stat().st_mtime
-            except OSError:
-                mtime = 0
-            results.append((str(p.relative_to(dir_path)), mtime))
+        max_show = params.get("max_results", self.GLOB_MAX_RESULTS)
+        try:
+            max_show = max(1, min(int(max_show), self.GLOB_MAX_RESULTS))
+        except (TypeError, ValueError):
+            max_show = self.GLOB_MAX_RESULTS
 
-        # 按修改时间降序排序
-        results.sort(key=lambda x: x[1], reverse=True)
+        max_dirs = params.get("max_dirs", self.GLOB_DEFAULT_MAX_DIRS)
+        try:
+            max_dirs = max(1, int(max_dirs))
+        except (TypeError, ValueError):
+            max_dirs = self.GLOB_DEFAULT_MAX_DIRS
 
-        if not results:
-            return self._append_traversal_note(f"未找到匹配 '{pattern}' 的文件。")
+        max_files = params.get("max_files", self.GLOB_DEFAULT_MAX_FILES)
+        try:
+            max_files = max(1, int(max_files))
+        except (TypeError, ValueError):
+            max_files = self.GLOB_DEFAULT_MAX_FILES
 
-        total = len(results)
-        max_show = self.LIST_DIR_DEFAULT_MAX
-        file_list = [r[0] for r in results[:max_show]]
+        try:
+            from ...config import settings
+
+            glob_timeout = max(
+                5,
+                min(int(getattr(settings, "glob_timeout_sec", 30) or 30), 600),
+            )
+        except Exception:
+            glob_timeout = 30
+
+        cancel_event = threading.Event()
+        try:
+            scan = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self.agent.file_tool.glob_scan,
+                    glob_pattern,
+                    str(dir_path),
+                    max_dirs=max_dirs,
+                    max_files=max_files,
+                    max_results=max_show,
+                    max_seconds=glob_timeout,
+                    cancel_event=cancel_event,
+                ),
+                timeout=glob_timeout,
+            )
+        except asyncio.CancelledError:
+            cancel_event.set()
+            raise
+        except FileNotFoundError as e:
+            return f"❌ {e}"
+        except ValueError as e:
+            msg = str(e)
+            if msg.startswith("glob refused"):
+                return (
+                    f"❌ glob 被拒绝执行: {msg}\n"
+                    f"提示: 请缩小 path 到具体的项目子目录（如 src/、docs/），"
+                    f"避免扫描运行时数据目录或整个用户主目录。"
+                )
+            return f"❌ glob 失败: {e}"
+        except TimeoutError:
+            cancel_event.set()
+            return (
+                f"❌ glob 超时（>{glob_timeout}s）。"
+                f"建议：1) 用更精确的 path 缩小范围；2) 用更具体的 pattern；"
+                f"3) 避免扫描运行时、依赖或日志目录。（可配置 glob_timeout_sec）"
+            )
+
+        if not scan.matches:
+            output = f"未找到匹配 '{pattern}' 的文件。"
+            if scan.capped_reason:
+                output += (
+                    f"\n[glob] 扫描提前停止: {scan.capped_reason}。"
+                    f"已扫描 {scan.dirs_scanned} 个目录 / {scan.files_scanned} 个文件。"
+                )
+            return self._append_traversal_note(output)
+
+        total = scan.total_matches
+        file_list = [r[0] for r in scan.matches[:max_show]]
         output = f"找到 {total} 个文件（按修改时间排序）:\n" + "\n".join(file_list)
 
-        if total > max_show:
+        if scan.capped_reason:
+            output += (
+                f"\n\n[OUTPUT_TRUNCATED] glob partial: {scan.capped_reason}。"
+                f"已扫描 {scan.dirs_scanned} 个目录 / {scan.files_scanned} 个文件，"
+                f"显示按修改时间排序的前 {len(file_list)} 个匹配。"
+            )
+        elif total > max_show:
             output += f"\n\n[OUTPUT_TRUNCATED] 共 {total} 个文件，已显示前 {max_show} 个。"
 
         return self._append_traversal_note(output)
@@ -1143,4 +1210,3 @@ def create_handler(agent: "Agent"):
     """
     handler = FilesystemHandler(agent)
     return handler.handle
-

--- a/tests/unit/test_filesystem_tools.py
+++ b/tests/unit/test_filesystem_tools.py
@@ -5,13 +5,14 @@ filesystem tools introduced to match Cursor-like capabilities.
 """
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import aiofiles
 import pytest
 
-from openakita.tools.file import DEFAULT_IGNORE_DIRS, FileTool
+from openakita.tools.file import DEFAULT_IGNORE_DIRS, FileTool, GlobScanResult
 from openakita.tools.handlers.filesystem import FilesystemHandler
 
 # ---------------------------------------------------------------------------
@@ -277,6 +278,49 @@ class TestGlob:
         assert "app.js" in result
         assert "node_modules" not in result
 
+    def test_glob_scan_skips_heavy_runtime_dirs(self, file_tool, tmp_path):
+        blocked = tmp_path / ".openakita" / "runtime" / "sessions"
+        blocked.mkdir(parents=True)
+        (blocked / "hidden.py").write_text("x", encoding="utf-8")
+        workspace = tmp_path / ".openakita" / "workspaces" / "default"
+        workspace.mkdir(parents=True)
+        (workspace / "also_hidden.py").write_text("x", encoding="utf-8")
+        site_packages = tmp_path / "venv" / "Lib" / "site-packages" / "pkg"
+        site_packages.mkdir(parents=True)
+        (site_packages / "pkg.py").write_text("x", encoding="utf-8")
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "app.py").write_text("x", encoding="utf-8")
+        (tmp_path / "visible.py").write_text("x", encoding="utf-8")
+
+        scan = file_tool.glob_scan("*.py", path=str(tmp_path))
+
+        assert [path for path, _mtime in scan.matches] == ["visible.py"]
+        assert scan.skipped >= 3
+
+    def test_glob_scan_caps_directories_files_and_results(self, file_tool, tmp_path):
+        (tmp_path / "root.py").write_text("x", encoding="utf-8")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "nested.py").write_text("x", encoding="utf-8")
+        scan = file_tool.glob_scan("*.py", path=str(tmp_path), max_dirs=1)
+        assert [path for path, _mtime in scan.matches] == ["root.py"]
+        assert scan.capped_reason == "reached directory cap (1)"
+
+        for i in range(5):
+            (tmp_path / f"file_{i}.txt").write_text("x", encoding="utf-8")
+        scan = file_tool.glob_scan("*.txt", path=str(tmp_path), max_files=2)
+        assert scan.files_scanned == 2
+        assert scan.capped_reason == "reached file cap (2)"
+
+        for i in range(5):
+            time.sleep(0.01)
+            (tmp_path / f"match_{i}.md").write_text("x", encoding="utf-8")
+        scan = file_tool.glob_scan("*.md", path=str(tmp_path), max_results=2)
+        assert scan.total_matches == 5
+        assert len(scan.matches) == 2
+        assert [path for path, _mtime in scan.matches] == ["match_4.md", "match_3.md"]
+
     async def test_glob_skips_directories_that_disappear_mid_scan(
         self,
         handler,
@@ -317,6 +361,42 @@ class TestGlob:
         lines = result.strip().split("\n")
         file_lines = [line for line in lines if line.endswith(".py")]
         assert file_lines[0] == "new.py"
+
+    async def test_handler_glob_timeout_sets_cancel_flag(self, handler, tmp_path, monkeypatch):
+        import asyncio
+
+        seen_cancel_flags = []
+        real_wait_for = asyncio.wait_for
+
+        async def fast_wait_for(awaitable, timeout=None):
+            return await real_wait_for(awaitable, timeout=0.05)
+
+        def slow_scan(*_args, **kwargs):
+            cancel_event = kwargs["cancel_event"]
+            seen_cancel_flags.append(cancel_event)
+            while not cancel_event.is_set():
+                time.sleep(0.01)
+            return GlobScanResult(
+                matches=[],
+                total_matches=0,
+                dirs_scanned=0,
+                files_scanned=0,
+                skipped=0,
+                capped_reason="cancelled by caller",
+            )
+
+        monkeypatch.setattr(asyncio, "wait_for", fast_wait_for)
+        monkeypatch.setattr(handler.agent.file_tool, "glob_scan", slow_scan)
+        monkeypatch.setattr(
+            "openakita.tools.handlers.filesystem.settings.glob_timeout_sec",
+            5,
+            raising=False,
+        )
+        result = await handler.handle("glob", {"pattern": "*.py", "path": str(tmp_path)})
+
+        assert "glob 超时" in result
+        assert seen_cancel_flags
+        assert seen_cancel_flags[0].is_set()
 
 
 # ===========================================================================
@@ -571,4 +651,3 @@ class TestIgnoreDirs:
     def test_common_dirs_present(self):
         for d in [".git", "node_modules", "__pycache__", ".venv"]:
             assert d in DEFAULT_IGNORE_DIRS
-


### PR DESCRIPTION
## Summary

- move recursive filesystem glob scanning off the async API path with `asyncio.to_thread()` and an outer timeout
- add hard scan budgets for directories, files, elapsed time, and returned matches
- prune protected runtime/workspace, dependency, and log directories during glob traversal
- cover the bounded scanner and timeout cancellation path with unit tests

Fixes openakita/openakita#618.

## Tests

- `uv run ruff check src/openakita/tools/file.py src/openakita/tools/handlers/filesystem.py src/openakita/config.py tests/unit/test_filesystem_tools.py`
- `uv run pytest tests/unit/test_filesystem_tools.py tests/unit/tools/test_grep_safety.py -q`
- HTTP smoke test against local `openakita serve`: `/api/chat` triggered `glob` and skipped protected/heavy directories
