### PR TITLE
ci disables Tauri updater artifact signing for PR full builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,12 @@ jobs:
         working-directory: apps/setup-center
         env:
           NO_STRIP: true
-        run: npx tauri build --bundles "deb"
+        # Fork PRs do not receive repository secrets. Disable updater artifact
+        # signing in CI; release/dryrun workflows still sign updater artifacts.
+        run: >
+          npx tauri build
+          --bundles "deb"
+          --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Verify bundle exists
         run: |


### PR DESCRIPTION
## Summary
- disable Tauri updater artifact generation during the CI PR full build
- keep release and dry-run workflows responsible for signed updater artifacts

## Verification
- checked that TAURI_CONFIG parses as JSON
- locally simulated the Tauri build path far enough to confirm the TAURI_SIGNING_PRIVATE_KEY error no longer appears
