### PR TITLE
fix profile identity export and prompt resolution

### DIFF
--- a/src/openakita/agents/identity_files.py
+++ b/src/openakita/agents/identity_files.py
@@ -1,0 +1,7 @@
+"""Shared profile identity file definitions."""
+
+PROFILE_IDENTITY_FILENAMES: frozenset[str] = frozenset(
+    {"SOUL.md", "AGENT.md", "USER.md", "MEMORY.md"}
+)
+
+__all__ = ["PROFILE_IDENTITY_FILENAMES"]

--- a/src/openakita/agents/packager.py
+++ b/src/openakita/agents/packager.py
@@ -17,6 +17,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+from .identity_files import PROFILE_IDENTITY_FILENAMES
 from .manifest import (
     MAX_PACKAGE_SIZE,
     MAX_SINGLE_FILE_SIZE,
@@ -149,6 +150,7 @@ class AgentPackager:
             profile_data.pop(key, None)
 
         license_3rd_party = self._generate_license_3rd_party(external_skill_refs)
+        identity_files = self._read_profile_identity_files(profile.id)
 
         def _write_zip(zf: zipfile.ZipFile) -> None:
             zf.writestr(
@@ -159,6 +161,8 @@ class AgentPackager:
                 zf.writestr("README.md", readme)
             if license_3rd_party:
                 zf.writestr("LICENSE-3RD-PARTY.md", license_3rd_party)
+            for filename, content in identity_files.items():
+                zf.writestr(f"identity/{filename}", content)
             for skill_name in bundled_skill_names:
                 skill_path = self._find_skill(skill_name)
                 if skill_path:
@@ -192,6 +196,28 @@ class AgentPackager:
             f"bundled={len(bundled_skill_names)}, external={len(external_skill_refs)})"
         )
         return output_path
+
+    def _read_profile_identity_files(self, profile_id: str) -> dict[str, str]:
+        try:
+            profile_dir = self.profile_store.get_profile_dir(profile_id)
+        except Exception:
+            return {}
+        identity_dir = profile_dir / "identity"
+        result: dict[str, str] = {}
+        for filename in sorted(PROFILE_IDENTITY_FILENAMES):
+            path = identity_dir / filename
+            if not path.is_file():
+                continue
+            try:
+                result[filename] = path.read_text(encoding="utf-8")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to include identity file %s for profile %s: %s",
+                    filename,
+                    profile_id,
+                    exc,
+                )
+        return result
 
     def _to_slug(self, profile_id: str) -> str:
         slug = re.sub(r"[^a-z0-9-]", "-", profile_id.lower())
@@ -372,6 +398,7 @@ class AgentInstaller:
 
             profile = AgentProfile.from_dict(profile_data)
             self.profile_store.save(profile)
+            self._install_identity_files(zf, profile.id)
 
         logger.info(
             f"Agent installed: {profile_id} "
@@ -380,6 +407,34 @@ class AgentInstaller:
             f"total installed: {installed_skills})"
         )
         return profile
+
+    def _install_identity_files(self, zf: zipfile.ZipFile, profile_id: str) -> None:
+        identity_members = [
+            name
+            for name in zf.namelist()
+            if name.startswith("identity/")
+            and not name.endswith("/")
+            and Path(name).name in PROFILE_IDENTITY_FILENAMES
+        ]
+        if not identity_members:
+            return
+
+        profile_dir = self.profile_store.ensure_profile_dir(profile_id)
+        identity_dir = profile_dir / "identity"
+        identity_dir.mkdir(parents=True, exist_ok=True)
+        for member in identity_members:
+            filename = Path(member).name
+            try:
+                content = zf.read(member).decode("utf-8")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to install identity file %s for profile %s: %s",
+                    member,
+                    profile_id,
+                    exc,
+                )
+                continue
+            (identity_dir / filename).write_text(content, encoding="utf-8")
 
     def _validate_file(self, package_path: Path) -> None:
         if not package_path.exists():

--- a/src/openakita/api/routes/agents.py
+++ b/src/openakita/api/routes/agents.py
@@ -8,6 +8,7 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from openakita.agents.identity_files import PROFILE_IDENTITY_FILENAMES
 from openakita.memory.json_utils import coerce_text
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,18 @@ def _invalidate_profile_agents(request: Request, profile_id: str) -> None:
                     f"[Agents API] Failed to invalidate profile pool "
                     f"({pool_attr}, profile={profile_id}): {e}"
                 )
+
+
+def _invalidate_profile_runtime(request: Request, profile_id: str, reason: str) -> None:
+    """Invalidate prompt and pooled runtime state after profile-affecting edits."""
+    try:
+        from openakita.prompt.builder import clear_prompt_section_cache
+
+        clear_prompt_section_cache()
+    except Exception as exc:
+        logger.warning(f"[Agents API] Failed to clear prompt cache ({reason}): {exc}")
+
+    _invalidate_profile_agents(request, profile_id)
 
 
 # ─── Pydantic models ─────────────────────────────────────────────────────
@@ -620,11 +633,8 @@ class IdentityFileRequest(BaseModel):
     content: str = ""
 
 
-_ALLOWED_IDENTITY_FILES = frozenset({"SOUL.md", "AGENT.md", "USER.md", "MEMORY.md"})
-
-
 @router.post("/api/agents/profiles/{profile_id}/identity/init")
-async def init_profile_identity(profile_id: str):
+async def init_profile_identity(profile_id: str, request: Request):
     """Initialize the profile-specific identity directory."""
     from openakita.agents.profile import get_profile_store
 
@@ -642,13 +652,14 @@ async def init_profile_identity(profile_id: str):
     resolver = ProfileIdentityResolver(identity_dir, settings.identity_path)
     resolver.ensure_independent_files()
 
+    _invalidate_profile_runtime(request, profile_id, "profile identity init")
     return {"status": "ok", "identity_dir": str(identity_dir)}
 
 
 @router.get("/api/agents/profiles/{profile_id}/identity/{filename}")
 async def read_profile_identity_file(profile_id: str, filename: str):
     """Read a profile-specific identity file. Returns global content if profile has none."""
-    if filename not in _ALLOWED_IDENTITY_FILES:
+    if filename not in PROFILE_IDENTITY_FILENAMES:
         raise HTTPException(status_code=400, detail=f"Invalid identity file: {filename}")
 
     from openakita.agents.profile import get_profile_store
@@ -676,9 +687,14 @@ async def read_profile_identity_file(profile_id: str, filename: str):
 
 
 @router.put("/api/agents/profiles/{profile_id}/identity/{filename}")
-async def write_profile_identity_file(profile_id: str, filename: str, body: IdentityFileRequest):
+async def write_profile_identity_file(
+    profile_id: str,
+    filename: str,
+    body: IdentityFileRequest,
+    request: Request,
+):
     """Write a profile-specific identity file."""
-    if filename not in _ALLOWED_IDENTITY_FILES:
+    if filename not in PROFILE_IDENTITY_FILENAMES:
         raise HTTPException(status_code=400, detail=f"Invalid identity file: {filename}")
 
     from openakita.agents.profile import get_profile_store
@@ -695,6 +711,7 @@ async def write_profile_identity_file(profile_id: str, filename: str, body: Iden
     fp = identity_dir / filename
     fp.write_text(body.content, encoding="utf-8")
 
+    _invalidate_profile_runtime(request, profile_id, f"profile identity {filename} write")
     logger.info(f"[Agents API] Wrote identity file {filename} for profile {profile_id}")
     return {"status": "ok", "filename": filename}
 

--- a/src/openakita/api/routes/hub.py
+++ b/src/openakita/api/routes/hub.py
@@ -25,6 +25,8 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
+from openakita.agents.identity_files import PROFILE_IDENTITY_FILENAMES
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -61,6 +63,70 @@ def _get_stores():
 
     skills_dir = Path(settings.skills_path)
     return profile_store, skills_dir, root
+
+
+def _read_profile_identity_files(profile_store, profile_id: str) -> dict[str, str]:
+    profile_dir = profile_store.get_profile_dir(profile_id)
+    identity_dir = profile_dir / "identity"
+    result: dict[str, str] = {}
+    for filename in sorted(PROFILE_IDENTITY_FILENAMES):
+        path = identity_dir / filename
+        if not path.is_file():
+            continue
+        try:
+            result[filename] = path.read_text(encoding="utf-8")
+        except Exception as exc:
+            logger.warning(
+                "[AgentPackage] Failed to read identity file %s for %s: %s",
+                filename,
+                profile_id,
+                exc,
+            )
+    return result
+
+
+def _write_profile_identity_files(
+    profile_store,
+    profile_id: str,
+    identity_files: dict | None,
+) -> None:
+    if not isinstance(identity_files, dict) or not identity_files:
+        return
+    profile_dir = profile_store.ensure_profile_dir(profile_id)
+    identity_dir = profile_dir / "identity"
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    for filename, content in identity_files.items():
+        if filename not in PROFILE_IDENTITY_FILENAMES:
+            continue
+        if not isinstance(content, str):
+            continue
+        (identity_dir / filename).write_text(content, encoding="utf-8")
+
+
+def _invalidate_imported_profile_runtime(request: Request, profile_id: str) -> None:
+    try:
+        from openakita.prompt.builder import clear_prompt_section_cache
+
+        clear_prompt_section_cache()
+    except Exception as exc:
+        logger.warning("[AgentPackage] Failed to clear prompt cache after import: %s", exc)
+
+    for pool_attr in ("agent_pool", "orchestrator"):
+        obj = getattr(request.app.state, pool_attr, None)
+        if obj is None:
+            continue
+        pool = getattr(obj, "_pool", obj)
+        if not hasattr(pool, "invalidate_profile"):
+            continue
+        try:
+            pool.invalidate_profile(profile_id)
+        except Exception as exc:
+            logger.warning(
+                "[AgentPackage] Failed to invalidate profile runtime (%s, profile=%s): %s",
+                pool_attr,
+                profile_id,
+                exc,
+            )
 
 
 def _reload_skills(request) -> None:
@@ -236,6 +302,7 @@ async def export_agent_json(req: ExportJsonRequest):
         "format": "akita-agent",
         "version": req.version,
         "profile": data,
+        "identity_files": _read_profile_identity_files(profile_store, profile.id),
     }
 
     if req.output_path:
@@ -275,6 +342,7 @@ async def batch_export_agents_json(req: BatchExportJsonRequest):
         data = profile.to_dict()
         data.pop("ephemeral", None)
         data.pop("inherit_from", None)
+        data["identity_files"] = _read_profile_identity_files(profile_store, profile.id)
         exported.append(data)
 
     result = {
@@ -317,17 +385,23 @@ async def import_agent(
             raise HTTPException(400, f"无效的 JSON 文件: {e}")
 
         if data.get("format") == "akita-agent-batch":
-            agents_data = data.get("agents", [])
-        elif data.get("format") == "akita-agent":
-            agents_data = [data.get("profile", {})]
+            raw_agents = data.get("agents", [])
         elif isinstance(data.get("profile"), dict):
-            agents_data = [data["profile"]]
+            raw_agents = [data]
+        elif data.get("format") == "akita-agent":
+            raw_agents = [{}]
         else:
             raise HTTPException(400, "无法识别的 JSON 格式，缺少 profile 或 agents 字段")
 
         imported = []
         skipped = []
-        for pdata in agents_data:
+        for item in raw_agents:
+            if isinstance(item, dict) and isinstance(item.get("profile"), dict):
+                pdata = dict(item.get("profile", {}))
+                identity_files = item.get("identity_files")
+            else:
+                pdata = dict(item) if isinstance(item, dict) else {}
+                identity_files = pdata.pop("identity_files", None)
             if not pdata or not isinstance(pdata, dict):
                 continue
             pid = pdata.get("id", "")
@@ -346,6 +420,8 @@ async def import_agent(
 
             profile = AgentProfile.from_dict(pdata)
             profile_store.save(profile)
+            _write_profile_identity_files(profile_store, profile.id, identity_files)
+            _invalidate_imported_profile_runtime(request, profile.id)
             imported.append(profile.to_dict())
 
         _reload_skills(request)
@@ -377,6 +453,7 @@ async def import_agent(
         tmp_path.unlink(missing_ok=True)
 
     _reload_skills(request)
+    _invalidate_imported_profile_runtime(request, profile.id)
 
     return {
         "message": "Agent imported successfully",

--- a/src/openakita/core/agent.py
+++ b/src/openakita/core/agent.py
@@ -3438,6 +3438,69 @@ class Agent:
         """构建系统提示词（统一使用编译管线 v2）。"""
         return self._build_system_prompt_compiled_sync(task_description, session_type=session_type)
 
+    def _prepare_prompt_identity_dir(self) -> Path:
+        """Return an identity dir whose files match the active Identity object.
+
+        Profile identities may inherit SOUL.md / AGENT.md from the global
+        identity while keeping USER.md / MEMORY.md inside the profile dir.
+        The prompt compiler accepts one directory, so materialize the resolved
+        source files into a private runtime input dir for custom identities.
+        """
+        identity = getattr(self, "identity", None)
+        soul_path = Path(getattr(identity, "soul_path", settings.soul_path))
+        agent_path = Path(getattr(identity, "agent_path", settings.agent_path))
+        user_path = Path(getattr(identity, "user_path", settings.user_path))
+        paths = {
+            "SOUL.md": soul_path,
+            "AGENT.md": agent_path,
+            "USER.md": user_path,
+        }
+
+        global_identity_dir = settings.identity_path.resolve()
+        source_dirs = {p.parent.resolve() for p in paths.values()}
+        if len(source_dirs) == 1:
+            return next(iter(source_dirs))
+
+        profile_id = getattr(self, "_agent_profile_id", None) or getattr(self, "name", "agent")
+        safe_profile_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(profile_id)).strip("._")
+        runtime_root = Path(
+            getattr(self, "_prompt_identity_runtime_root", None) or settings.openakita_home
+        )
+        resolved_dir = runtime_root / "runtime" / "profile_identity" / (safe_profile_id or "agent")
+        resolved_dir.mkdir(parents=True, exist_ok=True)
+
+        for filename, src in paths.items():
+            dst = resolved_dir / filename
+            try:
+                content = src.read_text(encoding="utf-8") if src.exists() else ""
+            except Exception as exc:
+                logger.warning("Failed to read resolved identity file %s: %s", src, exc)
+                content = ""
+            existing = ""
+            try:
+                existing = dst.read_text(encoding="utf-8") if dst.exists() else ""
+            except Exception:
+                existing = ""
+            if existing != content:
+                dst.write_text(content, encoding="utf-8")
+
+        source_meta = {
+            name: str(path)
+            for name, path in paths.items()
+            if path.parent.resolve() != global_identity_dir
+        }
+        meta_path = resolved_dir / "runtime" / "sources.json"
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            current_meta = meta_path.read_text(encoding="utf-8") if meta_path.exists() else ""
+        except Exception:
+            current_meta = ""
+        meta_text = json.dumps(source_meta, ensure_ascii=False, sort_keys=True, indent=2)
+        if current_meta != meta_text:
+            meta_path.write_text(meta_text, encoding="utf-8")
+
+        return resolved_dir
+
     def _resolve_agent_voice(self) -> str:
         """Return the display name that SOUL.md's ``{{agent_name}}`` should expand to.
 
@@ -3472,12 +3535,14 @@ class Agent:
                 return ctx.system
 
         ctx_window = self._get_raw_context_window()
+        identity_dir = self._prepare_prompt_identity_dir()
         prompt = self.prompt_assembler._build_compiled_sync(
             task_description,
             session_type=session_type,
             context_window=ctx_window,
             is_sub_agent=self._is_sub_agent_call,
             agent_voice=self._resolve_agent_voice(),
+            identity_dir=identity_dir,
         )
         if self._custom_prompt_suffix:
             prompt += f"\n\n{self._custom_prompt_suffix}"
@@ -3756,6 +3821,7 @@ class Agent:
         except Exception:
             _working_facts_cache_key = ""
         _resolved_voice = self._resolve_agent_voice()
+        _identity_dir = self._prepare_prompt_identity_dir()
         _cache_key = (
             _conv_id,
             _effective_mode,
@@ -3775,6 +3841,7 @@ class Agent:
             _working_facts_cache_key,
             bool((session_context or {}).get("evidence_recommended", False)),
             _resolved_voice,
+            str(_identity_dir),
         )
 
         if (
@@ -3805,6 +3872,7 @@ class Agent:
                 include_project_guidelines=_strategy.include_project_guidelines,
                 intent_tool_hints=_intent_tool_hints,
                 agent_voice=_resolved_voice,
+                identity_dir=_identity_dir,
             )
             self._system_prompt_cache[_cache_key] = prompt
             self._system_prompt_cache_dirty = False
@@ -10210,4 +10278,3 @@ class Agent:
     def get_memory_stats(self) -> dict:
         """获取记忆统计"""
         return self.memory_manager.get_stats()
-

--- a/src/openakita/core/prompt_assembler.py
+++ b/src/openakita/core/prompt_assembler.py
@@ -7,6 +7,7 @@
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from ..config import settings
@@ -84,6 +85,7 @@ class PromptAssembler:
         include_project_guidelines: bool | None = None,
         intent_tool_hints: list[str] | None = None,
         agent_voice: str = "",
+        identity_dir: Path | None = None,
     ) -> str:
         """
         使用编译管线构建系统提示词 (v2) - 异步版本。
@@ -108,14 +110,14 @@ class PromptAssembler:
         from ..prompt.budget import BudgetConfig
         from ..prompt.builder import build_system_prompt
 
-        identity_dir = settings.identity_path
+        effective_identity_dir = identity_dir or settings.identity_path
 
         budget_config = (
             BudgetConfig.for_context_window(context_window) if context_window > 0 else None
         )
 
         return build_system_prompt(
-            identity_dir=identity_dir,
+            identity_dir=effective_identity_dir,
             tools_enabled=tools_enabled,
             tool_catalog=self._tool_catalog if tools_enabled else None,
             skill_catalog=self._skill_catalog if tools_enabled else None,
@@ -153,24 +155,25 @@ class PromptAssembler:
         context_window: int = 0,
         is_sub_agent: bool = False,
         agent_voice: str = "",
+        identity_dir: Path | None = None,
     ) -> str:
         """同步版本：启动时构建初始系统提示词"""
         from ..prompt.budget import BudgetConfig
         from ..prompt.builder import build_system_prompt
         from ..prompt.compiler import check_compiled_outdated, compile_all
 
-        identity_dir = settings.identity_path
+        effective_identity_dir = identity_dir or settings.identity_path
 
-        if check_compiled_outdated(identity_dir):
+        if check_compiled_outdated(effective_identity_dir):
             logger.info("Compiled identity files outdated, recompiling...")
-            compile_all(identity_dir)
+            compile_all(effective_identity_dir)
 
         budget_config = (
             BudgetConfig.for_context_window(context_window) if context_window > 0 else None
         )
 
         return build_system_prompt(
-            identity_dir=identity_dir,
+            identity_dir=effective_identity_dir,
             tools_enabled=True,
             tool_catalog=self._tool_catalog,
             skill_catalog=self._skill_catalog,
@@ -185,4 +188,3 @@ class PromptAssembler:
             is_sub_agent=is_sub_agent,
             agent_voice=agent_voice,
         )
-

--- a/tests/unit/test_agent_json_identity_files.py
+++ b/tests/unit/test_agent_json_identity_files.py
@@ -1,0 +1,20 @@
+from openakita.agents.profile import AgentProfile, ProfileStore
+from openakita.api.routes import hub
+
+
+def test_json_identity_file_helpers_round_trip_profile_identity(tmp_path):
+    source_store = ProfileStore(tmp_path / "source-agents")
+    source_store.save(AgentProfile(id="clawra", name="Clawra", identity_mode="custom"))
+    source_identity = source_store.ensure_profile_dir("clawra") / "identity"
+    (source_identity / "SOUL.md").write_text("clawra soul", encoding="utf-8")
+
+    exported = hub._read_profile_identity_files(source_store, "clawra")
+
+    assert exported == {"SOUL.md": "clawra soul"}
+
+    target_store = ProfileStore(tmp_path / "target-agents")
+    target_store.save(AgentProfile(id="clawra", name="Clawra", identity_mode="custom"))
+    hub._write_profile_identity_files(target_store, "clawra", exported)
+
+    target_identity = target_store.get_profile_dir("clawra") / "identity" / "SOUL.md"
+    assert target_identity.read_text(encoding="utf-8") == "clawra soul"

--- a/tests/unit/test_agent_package_identity_files.py
+++ b/tests/unit/test_agent_package_identity_files.py
@@ -1,0 +1,41 @@
+import zipfile
+
+from openakita.agents.packager import AgentInstaller, AgentPackager
+from openakita.agents.profile import AgentProfile, ProfileStore
+
+
+def test_agent_package_round_trips_profile_identity_files(tmp_path):
+    source_store = ProfileStore(tmp_path / "source-agents")
+    skills_dir = tmp_path / "skills"
+    output_dir = tmp_path / "packages"
+    profile = AgentProfile(
+        id="clawra",
+        name="Clawra",
+        description="Custom identity test agent",
+        identity_mode="custom",
+        memory_mode="isolated",
+    )
+    source_store.save(profile)
+
+    identity_dir = source_store.ensure_profile_dir("clawra") / "identity"
+    (identity_dir / "SOUL.md").write_text("clawra soul", encoding="utf-8")
+    (identity_dir / "AGENT.md").write_text("clawra behavior", encoding="utf-8")
+
+    package_path = AgentPackager(
+        profile_store=source_store,
+        skills_dir=skills_dir,
+        output_dir=output_dir,
+    ).package("clawra")
+
+    with zipfile.ZipFile(package_path) as zf:
+        assert zf.read("identity/SOUL.md").decode("utf-8") == "clawra soul"
+        assert zf.read("identity/AGENT.md").decode("utf-8") == "clawra behavior"
+
+    target_store = ProfileStore(tmp_path / "target-agents")
+    installed = AgentInstaller(profile_store=target_store, skills_dir=skills_dir).install(
+        package_path
+    )
+    installed_identity_dir = target_store.get_profile_dir(installed.id) / "identity"
+
+    assert (installed_identity_dir / "SOUL.md").read_text(encoding="utf-8") == "clawra soul"
+    assert (installed_identity_dir / "AGENT.md").read_text(encoding="utf-8") == "clawra behavior"

--- a/tests/unit/test_profile_identity_prompt.py
+++ b/tests/unit/test_profile_identity_prompt.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from openakita.core.agent import Agent
+from openakita.core.identity import Identity
+
+
+def test_agent_materializes_mixed_profile_identity(monkeypatch, tmp_path: Path):
+    global_dir = tmp_path / "identity"
+    profile_dir = tmp_path / "agents" / "clawra" / "identity"
+    global_dir.mkdir(parents=True)
+    profile_dir.mkdir(parents=True)
+
+    global_agent = global_dir / "AGENT.md"
+    profile_soul = profile_dir / "SOUL.md"
+    profile_user = profile_dir / "USER.md"
+    global_agent.write_text("global agent behavior", encoding="utf-8")
+    profile_soul.write_text("clawra soul", encoding="utf-8")
+    profile_user.write_text("clawra user", encoding="utf-8")
+
+    agent = Agent.__new__(Agent)
+    agent.name = "Clawra"
+    agent._agent_profile_id = "clawra"
+    agent._prompt_identity_runtime_root = tmp_path / "home"
+    agent.identity = Identity(
+        soul_path=profile_soul,
+        agent_path=global_agent,
+        user_path=profile_user,
+        memory_path=profile_dir / "MEMORY.md",
+    )
+
+    resolved_dir = agent._prepare_prompt_identity_dir()
+
+    assert resolved_dir != global_dir
+    assert (resolved_dir / "SOUL.md").read_text(encoding="utf-8") == "clawra soul"
+    assert (resolved_dir / "AGENT.md").read_text(encoding="utf-8") == "global agent behavior"
+    assert (resolved_dir / "USER.md").read_text(encoding="utf-8") == "clawra user"

--- a/tests/unit/test_skill_token_paths.py
+++ b/tests/unit/test_skill_token_paths.py
@@ -136,6 +136,31 @@ async def test_prompt_assembler_passes_intent_tool_hints(monkeypatch):
     assert captured["intent_tool_hints"] == ["File System"]
 
 
+@pytest.mark.asyncio
+async def test_prompt_assembler_uses_explicit_identity_dir(monkeypatch, tmp_path: Path):
+    captured = {}
+    identity_dir = tmp_path / "profile-identity"
+
+    def fake_build_system_prompt(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("openakita.prompt.builder.build_system_prompt", fake_build_system_prompt)
+    assembler = PromptAssembler(
+        tool_catalog=None,
+        skill_catalog=None,
+        mcp_catalog=None,
+        memory_manager=None,
+        profile_manager=None,
+        brain=None,
+    )
+
+    result = await assembler.build_system_prompt_compiled(identity_dir=identity_dir)
+
+    assert result == "ok"
+    assert captured["identity_dir"] == identity_dir
+
+
 def test_list_skills_defaults_to_compact_directory(tmp_path: Path):
     long_description = "A skill with " + ("long trigger description " * 120)
     skill_path = tmp_path / "long-skill" / "SKILL.md"


### PR DESCRIPTION
## Summary
- route prompt assembly through the active profile identity directory so custom agents can use profile-specific SOUL.md and AGENT.md
- include profile identity files in JSON and .akita-agent import/export flows
- invalidate cached prompt sections and pooled profile agents after identity edits or imports
- share the allowed profile identity filename set across API routes and the packager

## Tests
- uv run ruff check src/openakita/agents/identity_files.py src/openakita/agents/packager.py src/openakita/api/routes/hub.py src/openakita/api/routes/agents.py
- uv run pytest tests/unit/test_agent_json_identity_files.py tests/unit/test_agent_package_identity_files.py tests/unit/test_profile_identity_prompt.py tests/unit/test_skill_token_paths.py
