### PR TITLE
Update the Tauri updater public key used by desktop release builds

### DIFF
--- a/apps/setup-center/src-tauri/tauri.conf.json
+++ b/apps/setup-center/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhDODlGOTVDQzcwOUNCOUEKUldTYXl3bkhYUG1KakxTS09JOGlHT21tOFduMEptVnc4Qk1ycVYycDJScEtMZlVGYlhiQUVQTzYK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ1RTQ1NjM2RkMxQ0Y4MDMKUldRRCtCejhObGJrUmR2VWdtbDMwSmhqdlE2RURSYTJKUTIxV25wRE1mcFA0Sy82Vi9zbUo3YWQK",
       "endpoints": [
         "https://openakita-admin-api.fzstack.com/updater/release.json?version={{current_version}}&platform={{target}}",
         "https://dl-openakita.fzstack.com/api/release.json"


### PR DESCRIPTION
## Summary

- update the Tauri updater public key embedded in the desktop app configuration
- align the configured public key with the rotated updater signing keypair used by release builds

## Testing

- generated a local test signature with `npx tauri signer sign --private-key-path`
- generated a second local test signature using `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
- verified both signatures against the new public key with `minisign-verify`
