### PR TITLE
fix custom agent identity placeholders across prompt paths

### DIFF
--- a/src/openakita/agents/factory.py
+++ b/src/openakita/agents/factory.py
@@ -504,6 +504,7 @@ class AgentFactory:
         isolated_mm = MemoryManager(
             data_dir=memory_dir,
             memory_md_path=memory_md_path,
+            identity_dir=profile_dir / "identity",
             brain=agent.brain,
             embedding_model=settings.embedding_model,
             embedding_device=settings.embedding_device,

--- a/src/openakita/agents/identity_resolver.py
+++ b/src/openakita/agents/identity_resolver.py
@@ -96,4 +96,5 @@ class ProfileIdentityResolver:
             agent_path=self.resolve_path("AGENT.md"),
             user_path=self.resolve_path("USER.md"),
             memory_path=self.resolve_path("MEMORY.md"),
+            sync_templates=False,
         )

--- a/src/openakita/core/agent.py
+++ b/src/openakita/core/agent.py
@@ -6496,7 +6496,11 @@ class Agent:
                     _identity_snippet = ""
                     if hasattr(self, "identity") and hasattr(self.identity, "get_system_prompt"):
                         _identity_snippet = (
-                            self.identity.get_system_prompt(include_active_task=False) or ""
+                            self.identity.get_system_prompt(
+                                include_active_task=False,
+                                agent_voice=self._resolve_agent_voice(),
+                            )
+                            or ""
                         )[:500]
 
                     _fast_system = (
@@ -6540,7 +6544,11 @@ class Agent:
                     _identity_snippet = ""
                     if hasattr(self, "identity") and hasattr(self.identity, "get_system_prompt"):
                         _identity_snippet = (
-                            self.identity.get_system_prompt(include_active_task=False) or ""
+                            self.identity.get_system_prompt(
+                                include_active_task=False,
+                                agent_voice=self._resolve_agent_voice(),
+                            )
+                            or ""
                         )[:500]
 
                     _fast_system = (
@@ -7103,7 +7111,11 @@ class Agent:
                 _identity_snippet = ""
                 if hasattr(self, "identity") and hasattr(self.identity, "get_system_prompt"):
                     _identity_snippet = (
-                        self.identity.get_system_prompt(include_active_task=False) or ""
+                        self.identity.get_system_prompt(
+                            include_active_task=False,
+                            agent_voice=self._resolve_agent_voice(),
+                        )
+                        or ""
                     )[:500]
 
                 _fast_system = (
@@ -7164,7 +7176,11 @@ class Agent:
                 _identity_snippet = ""
                 if hasattr(self, "identity") and hasattr(self.identity, "get_system_prompt"):
                     _identity_snippet = (
-                        self.identity.get_system_prompt(include_active_task=False) or ""
+                        self.identity.get_system_prompt(
+                            include_active_task=False,
+                            agent_voice=self._resolve_agent_voice(),
+                        )
+                        or ""
                     )[:500]
 
                 _fast_system = (
@@ -7262,6 +7278,7 @@ class Agent:
                 is_sub_agent=getattr(self, "_is_sub_agent_call", False),
                 request_id=_request_id,
                 turn_id=_turn_id,
+                agent_voice=self._resolve_agent_voice(),
             ):
                 # 收集回复文本（用于 session 保存 & memory）
                 if event.get("type") == "text_delta":
@@ -8308,6 +8325,7 @@ class Agent:
             tool_evidence_required=tool_evidence_required,
             is_sub_agent=getattr(self, "_is_sub_agent_call", False),
             mode=mode,
+            agent_voice=self._resolve_agent_voice(),
         )
 
     # ==================== 取消状态代理属性 ====================

--- a/src/openakita/core/identity.py
+++ b/src/openakita/core/identity.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 _HASH_FILE = "runtime/.file_hashes.json"
 _TRACKED_FILES = ["SOUL.md", "AGENT.md", "USER.md"]
+_AGENT_NAME_PLACEHOLDER = "{{agent_name}}"
 
 
 def _load_hashes(identity_dir: Path) -> dict[str, str]:
@@ -56,6 +57,17 @@ def _save_hashes(identity_dir: Path, hashes: dict[str, str]) -> None:
 
 def _file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def _apply_agent_name_placeholder(text: str, agent_voice: str | None = None) -> str:
+    if not text or _AGENT_NAME_PLACEHOLDER not in text:
+        return text
+    resolved = ""
+    if isinstance(agent_voice, str):
+        resolved = agent_voice.strip()
+    if not resolved:
+        resolved = getattr(settings, "agent_name", "") or "OpenAkita"
+    return text.replace(_AGENT_NAME_PLACEHOLDER, resolved)
 
 
 def _resolve_bundled_identity_template(rel_name: str) -> Path | None:
@@ -103,11 +115,13 @@ class Identity:
         agent_path: Path | None = None,
         user_path: Path | None = None,
         memory_path: Path | None = None,
+        sync_templates: bool = True,
     ):
         self.soul_path = soul_path or settings.soul_path
         self.agent_path = agent_path or settings.agent_path
         self.user_path = user_path or settings.user_path
         self.memory_path = memory_path or settings.memory_path
+        self.sync_templates = sync_templates
 
         self._soul: str | None = None
         self._agent: str | None = None
@@ -118,9 +132,14 @@ class Identity:
     def load(self) -> None:
         """加载所有核心文档，支持系统升级检测。"""
         self._pending_upgrades = []
-        self._soul = self._sync_identity_file(self.soul_path, "SOUL.md")
-        self._agent = self._sync_identity_file(self.agent_path, "AGENT.md")
-        self._user = self._sync_identity_file(self.user_path, "USER.md")
+        if self.sync_templates:
+            self._soul = self._sync_identity_file(self.soul_path, "SOUL.md")
+            self._agent = self._sync_identity_file(self.agent_path, "AGENT.md")
+            self._user = self._sync_identity_file(self.user_path, "USER.md")
+        else:
+            self._soul = self._load_file(self.soul_path, "SOUL.md")
+            self._agent = self._load_file(self.agent_path, "AGENT.md")
+            self._user = self._load_file(self.user_path, "USER.md")
         self._memory = self._load_file(self.memory_path, "MEMORY.md")
         logger.info("Identity loaded: SOUL.md, AGENT.md, USER.md, MEMORY.md")
 
@@ -289,7 +308,7 @@ class Identity:
             self.load()
         return self._memory or ""
 
-    def get_soul_summary(self) -> str:
+    def get_soul_summary(self, agent_voice: str | None = None) -> str:
         """
         获取 SOUL.md 完整内容
 
@@ -299,9 +318,10 @@ class Identity:
         if not soul:
             return ""
 
+        soul = _apply_agent_name_placeholder(soul, agent_voice)
         return f"## Soul (核心哲学)\n\n{soul}\n"
 
-    def get_agent_summary(self) -> str:
+    def get_agent_summary(self, agent_voice: str | None = None) -> str:
         """
         获取 AGENT.md 完整内容
 
@@ -311,9 +331,10 @@ class Identity:
         if not agent:
             return ""
 
+        agent = _apply_agent_name_placeholder(agent, agent_voice)
         return f"## Agent (行为规范)\n\n{agent}\n"
 
-    def get_user_summary(self) -> str:
+    def get_user_summary(self, agent_voice: str | None = None) -> str:
         """
         获取 USER.md 完整内容
 
@@ -323,9 +344,14 @@ class Identity:
         if not user:
             return "## User (用户偏好)\n\n(用户偏好将在交互中学习)\n"
 
+        user = _apply_agent_name_placeholder(user, agent_voice)
         return f"## User (用户偏好)\n\n{user}\n"
 
-    def get_memory_summary(self, include_active_task: bool = True) -> str:
+    def get_memory_summary(
+        self,
+        include_active_task: bool = True,
+        agent_voice: str | None = None,
+    ) -> str:
         """
         获取 MEMORY.md 完整内容
 
@@ -338,6 +364,7 @@ class Identity:
         if not memory:
             return ""
 
+        memory = _apply_agent_name_placeholder(memory, agent_voice)
         return f"## Memory (核心记忆)\n\n{memory}\n"
 
     @staticmethod
@@ -348,7 +375,11 @@ class Identity:
         except Exception:
             return "Asia/Shanghai"
 
-    def get_system_prompt(self, include_active_task: bool = True) -> str:
+    def get_system_prompt(
+        self,
+        include_active_task: bool = True,
+        agent_voice: str | None = None,
+    ) -> str:
         """
         生成系统提示词
 
@@ -370,11 +401,16 @@ class Identity:
         current_time = now.strftime("%Y-%m-%d %H:%M:%S")
         current_weekday = weekday_names[now.weekday()]
 
-        return f"""# OpenAkita System
+        return f"""# Agent System
 
-你是 OpenAkita，一个全能自进化AI助手。
+{self.get_soul_summary(agent_voice=agent_voice)}
 
 **当前时间: {current_time} {current_weekday}**
+
+## 运行平台说明
+
+OpenAkita 是运行平台或上游项目名称；当前 Agent 的自称以身份文件为准，\
+不要因为平台名称把自己介绍为 OpenAkita。
 
 ## ⚠️ 响应质量要求（最高优先级，严格执行）
 
@@ -461,22 +497,20 @@ class Identity:
 
 ---
 
-{self.get_agent_summary()}
+{self.get_agent_summary(agent_voice=agent_voice)}
 
-{self.get_user_summary()}
+{self.get_user_summary(agent_voice=agent_voice)}
 
-{self.get_memory_summary(include_active_task=include_active_task)}
-
-{self.get_soul_summary()}
+{self.get_memory_summary(include_active_task=include_active_task, agent_voice=agent_voice)}
 """
 
-    def get_session_system_prompt(self) -> str:
+    def get_session_system_prompt(self, agent_voice: str | None = None) -> str:
         """
         生成用于 IM Session 的系统提示词
 
         不包含全局 Active Task，避免与 Session 上下文冲突
         """
-        return self.get_system_prompt(include_active_task=False)
+        return self.get_system_prompt(include_active_task=False, agent_voice=agent_voice)
 
     def get_compiled_prompt(
         self,

--- a/src/openakita/core/reasoning_engine.py
+++ b/src/openakita/core/reasoning_engine.py
@@ -1906,6 +1906,7 @@ class ReasoningEngine:
         tool_evidence_required: bool = False,
         is_sub_agent: bool = False,
         mode: str = "agent",
+        agent_voice: str = "",
     ) -> str:
         """Outer wrapper for :meth:`_run_impl` (v1.27.14, plan S1.5).
 
@@ -1964,6 +1965,7 @@ class ReasoningEngine:
                 tool_evidence_required=tool_evidence_required,
                 is_sub_agent=is_sub_agent,
                 mode=mode,
+                agent_voice=agent_voice,
                 _on_state_resolved=_on_state_resolved,
             )
         finally:
@@ -2014,6 +2016,7 @@ class ReasoningEngine:
         tool_evidence_required: bool = False,
         is_sub_agent: bool = False,
         mode: str = "agent",
+        agent_voice: str = "",
         _on_state_resolved: Any = None,
     ) -> str:
         """
@@ -2245,8 +2248,10 @@ class ReasoningEngine:
         )
         _last_real_input_tokens: int | None = None
 
+        _content_safety_name = agent_voice.strip() if isinstance(agent_voice, str) else ""
+        _content_safety_identity = _content_safety_name or "一个 AI 助手"
         _CONTENT_SAFETY_MINIMAL_PROMPT = (
-            "你是 OpenAkita，一个 AI 助手。始终使用与用户当前消息相同的语言回复。"
+            f"你是 {_content_safety_identity}。始终使用与用户当前消息相同的语言回复。"
         )
 
         def _build_effective_system_prompt() -> str:
@@ -3863,6 +3868,7 @@ class ReasoningEngine:
         is_sub_agent: bool = False,
         request_id: str = "",
         turn_id: str = "",
+        agent_voice: str = "",
     ):
         """Outer wrapper for :meth:`_reason_stream_impl` (v1.27.14, plan S1.5).
 
@@ -3929,6 +3935,7 @@ class ReasoningEngine:
                 is_sub_agent=is_sub_agent,
                 request_id=request_id,
                 turn_id=turn_id,
+                agent_voice=agent_voice,
                 _on_state_resolved=_on_state_resolved,
             ):
                 # v1.27.15 (S2 P0-3): record streamed text/thinking into
@@ -4007,6 +4014,7 @@ class ReasoningEngine:
         is_sub_agent: bool = False,
         request_id: str = "",
         turn_id: str = "",
+        agent_voice: str = "",
         _on_state_resolved: Any = None,
     ):
         """
@@ -4100,8 +4108,10 @@ class ReasoningEngine:
             # === 动态 System Prompt（追加活跃 Plan） ===
             _base_sp = base_system_prompt or system_prompt
 
+            _content_safety_name = agent_voice.strip() if isinstance(agent_voice, str) else ""
+            _content_safety_identity = _content_safety_name or "一个 AI 助手"
             _CONTENT_SAFETY_MINIMAL_PROMPT_STREAM = (
-                "你是 OpenAkita，一个 AI 助手。始终使用与用户当前消息相同的语言回复。"
+                f"你是 {_content_safety_identity}。始终使用与用户当前消息相同的语言回复。"
             )
 
             def _build_effective_prompt() -> str:
@@ -6960,6 +6970,7 @@ class ReasoningEngine:
         session: Any = None,
         force_tool_retries: int | None = None,
         is_sub_agent: bool = False,
+        agent_voice: str = "",
     ):
         """
         统一流式接口: 将 reason_stream 包装为标准化异步生成器。
@@ -7009,6 +7020,7 @@ class ReasoningEngine:
             session=session,
             force_tool_retries=force_tool_retries,
             is_sub_agent=is_sub_agent,
+            agent_voice=agent_voice,
         ):
             # Track token usage for budget
             if budget and event.get("type") == "usage":

--- a/src/openakita/memory/manager.py
+++ b/src/openakita/memory/manager.py
@@ -183,12 +183,14 @@ class MemoryManager:
         embedding_api_key: str = "",
         embedding_api_model: str = "",
         agent_id: str = "",
+        identity_dir: Path | None = None,
     ):
         self.data_dir = Path(data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.agent_id = agent_id
 
         self.memory_md_path = Path(memory_md_path)
+        self.identity_dir = Path(identity_dir) if identity_dir else self.memory_md_path.parent
         self.brain = brain
         self._ensure_memory_md_exists()
 
@@ -2193,13 +2195,12 @@ class MemoryManager:
     ) -> dict:
         """每日归纳 (v2: 委托给 LifecycleManager)"""
         try:
-            from ..config import settings
             from .lifecycle import LifecycleManager
 
             lifecycle = LifecycleManager(
                 store=self.store,
                 extractor=self.extractor,
-                identity_dir=settings.identity_path,
+                identity_dir=self.identity_dir,
             )
             result = await lifecycle.consolidate_daily(
                 checkpoint=checkpoint,
@@ -2225,7 +2226,6 @@ class MemoryManager:
                 self._reload_from_sqlite()
                 raise  # LLM unavailable — legacy fallback would fail too
             logger.error(f"[Manager] Daily consolidation failed, using legacy: {e}")
-            from ..config import settings
             from .daily_consolidator import DailyConsolidator
 
             dc = DailyConsolidator(
@@ -2233,7 +2233,7 @@ class MemoryManager:
                 memory_md_path=self.memory_md_path,
                 memory_manager=self,
                 brain=self.brain,
-                identity_dir=settings.identity_path,
+                identity_dir=self.identity_dir,
             )
             result = await dc.consolidate_daily()
 

--- a/src/openakita/prompt/builder.py
+++ b/src/openakita/prompt/builder.py
@@ -326,8 +326,8 @@ _SAFETY_SECTION = """\
 - 告诉用户你记得他什么（USER.md 的内容）、当前所处的目录结构
 - 说明为什么某个操作做不了（缺哪个工具/技能/凭据）
 
-不需要把内部配置文件原文整段贴出来，但**不要装神秘**——OpenAkita 是开源项目，\
-源码和默认配置在 GitHub 上公开。
+不需要把内部配置文件原文整段贴出来，但**不要装神秘**——运行平台/上游项目 \
+OpenAkita 是开源项目，源码和默认配置在 GitHub 上公开。
 
 ## 解释失败的语气
 当工具调用因配置缺失、凭据不足、模式限制等原因没法执行时：
@@ -571,7 +571,7 @@ def build_system_prompt(
     user_parts: list[str] = []
 
     # 1. Per-model base prompt
-    base_prompt = _select_base_prompt(model_id)
+    base_prompt = _select_base_prompt(model_id, agent_voice=agent_voice)
     if base_prompt:
         system_parts.append(base_prompt)
 
@@ -926,7 +926,7 @@ def _build_persona_section(persona_manager: "PersonaManager") -> str:
         return ""
 
 
-def _select_base_prompt(model_id: str) -> str:
+def _select_base_prompt(model_id: str, agent_voice: str = "") -> str:
     """根据模型 ID 选择 per-model 基础提示词。
 
     查找 prompt/models/ 目录下的 .txt 文件，按模型族匹配。
@@ -957,9 +957,10 @@ def _select_base_prompt(model_id: str) -> str:
         return ""
 
     try:
-        return prompt_file.read_text(encoding="utf-8").strip()
+        text = prompt_file.read_text(encoding="utf-8").strip()
     except Exception:
         return ""
+    return _apply_agent_voice(text, agent_voice)
 
 
 def build_mode_rules(mode: str) -> str:
@@ -1126,6 +1127,7 @@ def _read_with_fallback(path: Path, fallback_key: str) -> str:
 
 _AGENT_VOICE_PLACEHOLDER = "{{agent_name}}"
 _DEFAULT_AGENT_VOICE = "OpenAkita"
+_DEFAULT_BASE_PROMPT_SELF_INTRO = "你是 OpenAkita，一个帮助用户完成各类任务的 AI 助手。"
 
 
 def _resolve_agent_voice(agent_voice: str | None) -> str:
@@ -1141,6 +1143,15 @@ def _resolve_agent_voice(agent_voice: str | None) -> str:
         if stripped:
             return stripped
     return _DEFAULT_AGENT_VOICE
+
+
+def _apply_agent_voice(text: str, agent_voice: str | None) -> str:
+    """Apply the current Agent display name to prompt self-reference text."""
+    resolved = _resolve_agent_voice(agent_voice)
+    return text.replace(_AGENT_VOICE_PLACEHOLDER, resolved).replace(
+        _DEFAULT_BASE_PROMPT_SELF_INTRO,
+        f"你是 {resolved}，一个帮助用户完成各类任务的 AI 助手。",
+    )
 
 
 def _build_identity_section(
@@ -1161,8 +1172,17 @@ def _build_identity_section(
     """
     parts = []
 
-    parts.append("# OpenAkita System")
+    parts.append("# Agent Identity")
     parts.append("")
+
+    resolved_voice = _resolve_agent_voice(agent_voice)
+    if resolved_voice != _DEFAULT_AGENT_VOICE:
+        parts.append(
+            f"当前 Agent 的自称是「{resolved_voice}」。OpenAkita 仅指运行平台或上游"
+            "开源项目，不是当前 Agent 的自称；除非身份文件明确要求，不要把自己"
+            "介绍为 OpenAkita。"
+        )
+        parts.append("")
 
     identity_core = compiled.get("identity_core") or _BUILT_IN_DEFAULTS.get("soul", "")
     if identity_core:
@@ -1201,9 +1221,7 @@ def _build_identity_section(
             pass
 
     text = "\n".join(parts)
-    if _AGENT_VOICE_PLACEHOLDER in text:
-        text = text.replace(_AGENT_VOICE_PLACEHOLDER, _resolve_agent_voice(agent_voice))
-    return text
+    return _apply_agent_voice(text, agent_voice)
 
 
 def _get_current_time(timezone_name: str = "Asia/Shanghai") -> str:

--- a/src/openakita/tools/handlers/skills.py
+++ b/src/openakita/tools/handlers/skills.py
@@ -903,6 +903,9 @@ class SkillsHandler:
             endpoint_override = skill.model
 
         try:
+            agent_voice = ""
+            if hasattr(self.agent, "_resolve_agent_voice"):
+                agent_voice = self.agent._resolve_agent_voice()
             result = await self.agent.reasoning_engine.run(
                 fork_messages,
                 tools=tools,
@@ -913,6 +916,7 @@ class SkillsHandler:
                 conversation_id=fork_conv_id,
                 is_sub_agent=True,
                 endpoint_override=endpoint_override,
+                agent_voice=agent_voice,
             )
         except Exception as e:
             logger.error("Fork execution of skill '%s' failed: %s", skill_name, e, exc_info=True)

--- a/tests/component/test_manager_extra.py
+++ b/tests/component/test_manager_extra.py
@@ -155,3 +155,34 @@ class TestEndSession:
 
     def test_end_session_empty(self, manager):
         manager.end_session("empty session")
+
+
+class TestIdentityDirWriteback:
+    def test_memory_manager_defaults_identity_dir_to_memory_md_parent(self, tmp_path, mock_brain):
+        from openakita.memory.manager import MemoryManager
+
+        identity_dir = tmp_path / "agent" / "identity"
+        memory_md = identity_dir / "MEMORY.md"
+
+        manager = MemoryManager(
+            data_dir=tmp_path / "agent" / "memory",
+            memory_md_path=memory_md,
+            brain=mock_brain,
+        )
+
+        assert manager.identity_dir == identity_dir
+
+    def test_memory_manager_accepts_explicit_identity_dir(self, tmp_path, mock_brain):
+        from openakita.memory.manager import MemoryManager
+
+        identity_dir = tmp_path / "profiles" / "a-bot" / "identity"
+        memory_md = tmp_path / "elsewhere" / "MEMORY.md"
+
+        manager = MemoryManager(
+            data_dir=tmp_path / "profiles" / "a-bot" / "memory",
+            memory_md_path=memory_md,
+            identity_dir=identity_dir,
+            brain=mock_brain,
+        )
+
+        assert manager.identity_dir == identity_dir

--- a/tests/component/test_prompt_compiler.py
+++ b/tests/component/test_prompt_compiler.py
@@ -184,6 +184,33 @@ class TestBuildSystemPrompt:
         assert "你是 码哥，一个 AI 助手。" in prompt
         assert "你是 OpenAkita，一个 AI 助手。" not in prompt
 
+    def test_agent_voice_replaces_per_model_base_prompt(self, tmp_path):
+        """Per-model 基础提示词不能把自定义 Agent 重新钉死为 OpenAkita。"""
+        from openakita.prompt.builder import PromptMode, PromptProfile, build_system_prompt
+
+        identity_dir = tmp_path / "identity"
+        identity_dir.mkdir()
+        (identity_dir / "SOUL.md").write_text(
+            "# Soul\n你是 CloseBeta，当前名称是 {{agent_name}}。",
+            encoding="utf-8",
+        )
+        (identity_dir / "AGENT.md").write_text("# Agent\n保持诚实。", encoding="utf-8")
+
+        prompt = build_system_prompt(
+            identity_dir=identity_dir,
+            tools_enabled=False,
+            prompt_mode=PromptMode.MINIMAL,
+            prompt_profile=PromptProfile.CONSUMER_CHAT,
+            model_id="qwen3-max",
+            agent_voice="叮叮",
+        )
+
+        assert "你是 叮叮，一个帮助用户完成各类任务的 AI 助手。" in prompt
+        assert "你是 OpenAkita，一个帮助用户完成各类任务的 AI 助手。" not in prompt
+        assert "# Agent Identity" in prompt
+        assert "# OpenAkita System" not in prompt
+        assert "OpenAkita 仅指运行平台或上游开源项目，不是当前 Agent 的自称" in prompt
+
     def test_agent_voice_whitespace_only_falls_back(self, tmp_path):
         """全空白的 agent_voice 也算作"未提供"，回退到默认产品名。"""
         from openakita.prompt.builder import build_system_prompt

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -58,6 +58,59 @@ class TestIdentityLoading:
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
+    def test_get_system_prompt_does_not_inject_openakita_self_identity(self, tmp_path):
+        identity_dir = tmp_path / "identity"
+        identity_dir.mkdir()
+        (identity_dir / "SOUL.md").write_text("# Soul\n\n你是 CloseBeta。", encoding="utf-8")
+        (identity_dir / "AGENT.md").write_text("# Agent\n\n保持诚实。", encoding="utf-8")
+        (identity_dir / "USER.md").write_text("# User\n\n用户偏好中文。", encoding="utf-8")
+        (identity_dir / "MEMORY.md").write_text("# Memory\n\n无。", encoding="utf-8")
+
+        identity = Identity(
+            soul_path=identity_dir / "SOUL.md",
+            agent_path=identity_dir / "AGENT.md",
+            user_path=identity_dir / "USER.md",
+            memory_path=identity_dir / "MEMORY.md",
+        )
+        identity.load()
+
+        prompt = identity.get_system_prompt(include_active_task=False)
+        assert "你是 CloseBeta" in prompt
+        assert "你是 OpenAkita，一个全能自进化AI助手。" not in prompt
+
+    def test_get_system_prompt_replaces_agent_name_placeholder(self, tmp_path):
+        identity_dir = tmp_path / "identity"
+        identity_dir.mkdir()
+        (identity_dir / "SOUL.md").write_text(
+            "# Soul\n\n我是 {{agent_name}}，由 CloseBeta 项目驱动。",
+            encoding="utf-8",
+        )
+        (identity_dir / "AGENT.md").write_text(
+            "# Agent\n\n{{agent_name}} 保持诚实。",
+            encoding="utf-8",
+        )
+        (identity_dir / "USER.md").write_text(
+            "# User\n\n用户正在和 {{agent_name}} 聊天。",
+            encoding="utf-8",
+        )
+        (identity_dir / "MEMORY.md").write_text(
+            "# Memory\n\n{{agent_name}} 的独立记忆。",
+            encoding="utf-8",
+        )
+
+        identity = Identity(
+            soul_path=identity_dir / "SOUL.md",
+            agent_path=identity_dir / "AGENT.md",
+            user_path=identity_dir / "USER.md",
+            memory_path=identity_dir / "MEMORY.md",
+        )
+        identity.load()
+
+        prompt = identity.get_system_prompt(include_active_task=False, agent_voice="叮叮")
+        assert "我是 叮叮" in prompt
+        assert "叮叮 保持诚实" in prompt
+        assert "{{agent_name}}" not in prompt
+
     def test_get_soul_summary(self, identity_dir):
         identity = Identity(soul_path=identity_dir / "SOUL.md")
         identity.load()
@@ -69,7 +122,6 @@ class TestIdentityUpdate:
     def test_update_memory(self, identity_dir):
         identity = Identity(memory_path=identity_dir / "MEMORY.md")
         identity.load()
-        original = identity.memory
         # update_memory returns bool
         result = identity.update_memory("preferences", "用户喜欢咖啡")
         assert isinstance(result, bool)
@@ -129,7 +181,6 @@ class TestSyncIdentityFileBundledFallback:
         assert "{{agent_name}}" in identity.soul
 
     def test_preserves_user_edits_when_hash_mismatches_via_bundled(self, tmp_path, monkeypatch):
-        original = "# Soul\n\n你是 OpenAkita。\n"
         user_edited = "# Soul\n\n你是 我的自定义角色。\n"
         new_template = "# Soul\n\n你是 {{agent_name}}，一只秋田犬。\n"
 

--- a/tests/unit/test_profile_identity_prompt.py
+++ b/tests/unit/test_profile_identity_prompt.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+import openakita.core.identity as identity_mod
+from openakita.agents.identity_resolver import ProfileIdentityResolver
 from openakita.core.agent import Agent
-from openakita.core.identity import Identity
+from openakita.core.identity import Identity, _file_hash, _save_hashes
 
 
 def test_agent_materializes_mixed_profile_identity(monkeypatch, tmp_path: Path):
@@ -34,3 +36,52 @@ def test_agent_materializes_mixed_profile_identity(monkeypatch, tmp_path: Path):
     assert (resolved_dir / "SOUL.md").read_text(encoding="utf-8") == "clawra soul"
     assert (resolved_dir / "AGENT.md").read_text(encoding="utf-8") == "global agent behavior"
     assert (resolved_dir / "USER.md").read_text(encoding="utf-8") == "clawra user"
+
+
+def test_profile_identity_load_does_not_sync_bundled_templates(monkeypatch, tmp_path: Path):
+    global_dir = tmp_path / "identity"
+    profile_dir = tmp_path / "agents" / "a-bot" / "identity"
+    bundled_dir = tmp_path / "bundled"
+    global_dir.mkdir(parents=True)
+    profile_dir.mkdir(parents=True)
+    bundled_dir.mkdir(parents=True)
+
+    profile_soul = profile_dir / "SOUL.md"
+    profile_agent = profile_dir / "AGENT.md"
+    profile_user = profile_dir / "USER.md"
+    profile_soul.write_text("# Soul\n\n你是 CloseBeta。", encoding="utf-8")
+    profile_agent.write_text("# Agent\n\n我是 CloseBeta。", encoding="utf-8")
+    profile_user.write_text("# User\n\n由 CloseBeta 自动维护。", encoding="utf-8")
+
+    _save_hashes(
+        profile_dir,
+        {
+            "SOUL.md": _file_hash(profile_soul),
+            "AGENT.md": _file_hash(profile_agent),
+            "USER.md": _file_hash(profile_user),
+        },
+    )
+
+    bundled_soul = bundled_dir / "SOUL.md.example"
+    bundled_agent = bundled_dir / "AGENT.md.example"
+    bundled_user = bundled_dir / "USER.md.example"
+    bundled_soul.write_text("# Soul\n\n你是 OpenAkita。", encoding="utf-8")
+    bundled_agent.write_text("# Agent\n\n我是 OpenAkita。", encoding="utf-8")
+    bundled_user.write_text("# User\n\n由 OpenAkita 自动维护。", encoding="utf-8")
+
+    def fake_resolver(rel_name: str) -> Path | None:
+        return {
+            "SOUL.md.example": bundled_soul,
+            "AGENT.md.example": bundled_agent,
+            "USER.md.example": bundled_user,
+        }.get(rel_name)
+
+    monkeypatch.setattr(identity_mod, "_resolve_bundled_identity_template", fake_resolver)
+
+    identity = ProfileIdentityResolver(profile_dir, global_dir).build_identity()
+    identity.load()
+
+    assert profile_soul.read_text(encoding="utf-8") == "# Soul\n\n你是 CloseBeta。"
+    assert profile_agent.read_text(encoding="utf-8") == "# Agent\n\n我是 CloseBeta。"
+    assert profile_user.read_text(encoding="utf-8") == "# User\n\n由 CloseBeta 自动维护。"
+    assert identity.get_pending_upgrades() == []

--- a/tests/unit/test_reason_stream_state_race.py
+++ b/tests/unit/test_reason_stream_state_race.py
@@ -539,3 +539,17 @@ class TestAllReasoningTransitionsGuarded:
             "without a `try:` guard within 5 lines. Issue #572 was caused "
             f"by exactly this oversight. Offending lines: {bare}"
         )
+
+
+class TestContentSafetyMinimalPromptIdentity:
+    def test_run_impl_accepts_agent_voice_for_content_safety_prompt(self) -> None:
+        src = inspect.getsource(ReasoningEngine._run_impl)
+        assert 'agent_voice: str = ""' in src
+        assert '_content_safety_identity = _content_safety_name or "一个 AI 助手"' in src
+        assert "你是 {_content_safety_identity}" in src
+
+    def test_reason_stream_accepts_agent_voice_for_content_safety_prompt(self) -> None:
+        src = inspect.getsource(ReasoningEngine._reason_stream_impl)
+        assert 'agent_voice: str = ""' in src
+        assert '_content_safety_identity = _content_safety_name or "一个 AI 助手"' in src
+        assert "你是 {_content_safety_identity}" in src


### PR DESCRIPTION
## Summary
- make custom agent display names replace `{{agent_name}}` across compiled prompts, fast replies, and content-safety fallback prompts
- keep OpenAkita references as platform/upstream attribution instead of agent self-identity
- prevent profile identity template sync from overwriting custom profile files
- keep isolated memory consolidation writebacks scoped to the profile identity directory

## Tests
- `uv run pytest tests/unit/test_identity.py tests/component/test_prompt_compiler.py tests/unit/test_profile_identity_prompt.py tests/unit/test_reason_stream_state_race.py tests/component/test_manager_extra.py -q`
- `uv run ruff check src/openakita/agents/factory.py src/openakita/agents/identity_resolver.py src/openakita/core/agent.py src/openakita/core/identity.py src/openakita/core/reasoning_engine.py src/openakita/memory/manager.py src/openakita/prompt/builder.py src/openakita/tools/handlers/skills.py tests/component/test_manager_extra.py tests/component/test_prompt_compiler.py tests/unit/test_identity.py tests/unit/test_profile_identity_prompt.py tests/unit/test_reason_stream_state_race.py`