### PR TITLE
make session persistence use strict atomic JSON replacement

### DIFF
--- a/src/openakita/agents/orchestrator.py
+++ b/src/openakita/agents/orchestrator.py
@@ -1183,14 +1183,14 @@ class AgentOrchestrator:
     def _persist_sub_states(self) -> None:
         """Write _sub_agent_states to disk so they survive restarts.
 
-        Uses ``safe_json_write`` for atomic temp+rename + ``.bak`` backup
+        Uses ``atomic_json_write`` for atomic temp+rename + ``.bak`` backup
         so kill -9 mid-write can't leave a half-written JSON that would
         crash next boot.
         """
         if self._log_dir is None:
             return
         try:
-            from openakita.utils.atomic_io import safe_json_write
+            from openakita.utils.atomic_io import atomic_json_write
 
             path = self._log_dir.parent / "sub_agent_states.json"
             snapshot = {}
@@ -1200,7 +1200,7 @@ class AgentOrchestrator:
                     for k, v in state.items()
                     if isinstance(v, (str, int, float, bool, list, dict, type(None)))
                 }
-            safe_json_write(path, snapshot)
+            atomic_json_write(path, snapshot)
         except Exception:
             logger.debug("[Orchestrator] Failed to persist sub-agent states", exc_info=True)
 

--- a/src/openakita/api/routes/config.py
+++ b/src/openakita/api/routes/config.py
@@ -1201,10 +1201,10 @@ async def write_skills_config(body: SkillsWriteRequest, request: Request):
     if isinstance(al, list):
         set_skill_external_allowlist([str(x).strip() for x in al if str(x).strip()])
     else:
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         sk_path = _project_root() / "data" / "skills.json"
-        safe_json_write(sk_path, content)
+        atomic_json_write(sk_path, content)
         logger.warning(
             "[Config API] skills.json written via non-standard payload — "
             "consider using set_skill_external_allowlist or allowlist_io APIs"
@@ -1247,10 +1247,10 @@ async def read_disabled_views():
 @router.post("/api/config/disabled-views")
 async def write_disabled_views(body: DisabledViewsRequest):
     """Update the list of disabled module views."""
-    from openakita.utils.atomic_io import safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write
 
     dv_path = _project_root() / "data" / "disabled_views.json"
-    safe_json_write(dv_path, {"disabled_views": body.views})
+    atomic_json_write(dv_path, {"disabled_views": body.views})
     logger.info(f"[Config API] Updated disabled_views: {body.views}")
     return {"status": "ok", "disabled_views": body.views}
 

--- a/src/openakita/api/routes/mcp.py
+++ b/src/openakita/api/routes/mcp.py
@@ -379,14 +379,14 @@ async def toggle_mcp_server(request: Request, server_name: str, body: MCPToggleR
     catalog.invalidate_cache()
 
     if server_info.config_dir:
-        from openakita.utils.atomic_io import read_json_safe, safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write, read_json_safe
 
         metadata_path = Path(server_info.config_dir) / "SERVER_METADATA.json"
         if metadata_path.exists():
             try:
                 metadata = read_json_safe(metadata_path) or {}
                 metadata["enabled"] = body.enabled
-                safe_json_write(metadata_path, metadata)
+                atomic_json_write(metadata_path, metadata)
             except Exception as e:
                 logger.warning("Failed to persist enabled state for %s: %s", server_name, e)
 

--- a/src/openakita/api/routes/skills.py
+++ b/src/openakita/api/routes/skills.py
@@ -702,14 +702,14 @@ async def update_skill_config(request: Request):
     except Exception:
         config_file = Path.cwd() / "data" / "skill_configs.json"
 
-    from openakita.utils.atomic_io import read_json_safe, safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write, read_json_safe
 
     existing = read_json_safe(config_file) or {}
     if not isinstance(existing, dict):
         existing = {}
 
     existing[skill_name] = config_values
-    safe_json_write(config_file, existing)
+    atomic_json_write(config_file, existing)
 
     return {"status": "ok", "skill": skill_name, "config": config_values}
 

--- a/src/openakita/channels/adapters/telegram.py
+++ b/src/openakita/channels/adapters/telegram.py
@@ -139,10 +139,10 @@ class TelegramPairingManager:
 
     def _save_paired_users(self) -> None:
         """保存已配对用户"""
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         try:
-            safe_json_write(self.paired_file, self.paired_users)
+            atomic_json_write(self.paired_file, self.paired_users)
         except Exception as e:
             logger.error(f"Failed to save paired users: {e}")
 

--- a/src/openakita/channels/dm_pairing.py
+++ b/src/openakita/channels/dm_pairing.py
@@ -22,7 +22,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..utils.atomic_io import safe_json_write
+from ..utils.atomic_io import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class DMPairingManager:
         self._authorized = set()
 
     def _save_authorized(self) -> None:
-        safe_json_write(self._auth_file, {"authorized": sorted(self._authorized)})
+        atomic_json_write(self._auth_file, {"authorized": sorted(self._authorized)})
 
     def _make_key(self, channel: str, chat_id: str) -> str:
         return f"{channel}:{chat_id}"

--- a/src/openakita/channels/media/storage.py
+++ b/src/openakita/channels/media/storage.py
@@ -257,9 +257,9 @@ class MediaStorage:
 
     def _save_index(self) -> None:
         """保存索引"""
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         try:
-            safe_json_write(self.index_file, self._index)
+            atomic_json_write(self.index_file, self._index)
         except Exception as e:
             logger.error(f"Failed to save media index: {e}")

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -1294,14 +1294,14 @@ class RuntimeState:
 
     def save(self) -> None:
         """把当前 settings 中的可持久化字段写入 JSON 文件（原子写入 + 备份）。"""
-        from .utils.atomic_io import safe_json_write
+        from .utils.atomic_io import atomic_json_write
         from .utils.redaction import redact_value
 
         data: dict = {}
         for key in _PERSISTABLE_KEYS:
             data[key] = getattr(settings, key)
         try:
-            safe_json_write(self.state_file, data)
+            atomic_json_write(self.state_file, data)
             logger.info(f"[RuntimeState] Saved: {redact_value(data)}")
         except Exception as e:
             logger.error(f"[RuntimeState] Failed to save: {e}")

--- a/src/openakita/core/identity.py
+++ b/src/openakita/core/identity.py
@@ -49,10 +49,10 @@ def _load_hashes(identity_dir: Path) -> dict[str, str]:
 
 
 def _save_hashes(identity_dir: Path, hashes: dict[str, str]) -> None:
-    from openakita.utils.atomic_io import safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write
 
     hash_path = identity_dir / _HASH_FILE
-    safe_json_write(hash_path, hashes)
+    atomic_json_write(hash_path, hashes)
 
 
 def _file_hash(path: Path) -> str:

--- a/src/openakita/core/proactive.py
+++ b/src/openakita/core/proactive.py
@@ -81,7 +81,7 @@ class ProactiveFeedbackTracker:
             logger.warning(f"Failed to load proactive feedback: {e}")
 
     def _save(self) -> None:
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         data = {
             "records": [
@@ -94,7 +94,7 @@ class ProactiveFeedbackTracker:
                 for r in self.records[-200:]
             ]
         }
-        safe_json_write(self.data_file, data)
+        atomic_json_write(self.data_file, data)
 
     def record_send(self, msg_type: str, timestamp: datetime | None = None) -> None:
         """记录一次主动消息发送"""

--- a/src/openakita/core/user_profile.py
+++ b/src/openakita/core/user_profile.py
@@ -455,9 +455,9 @@ class UserProfileManager:
     def _save_state(self) -> None:
         """保存状态"""
         try:
-            from openakita.utils.atomic_io import safe_json_write
+            from openakita.utils.atomic_io import atomic_json_write
 
-            safe_json_write(self.state_file, self.state.to_dict())
+            atomic_json_write(self.state_file, self.state.to_dict())
         except Exception as e:
             logger.error(f"Failed to save profile state: {e}")
 

--- a/src/openakita/hub/device.py
+++ b/src/openakita/hub/device.py
@@ -19,7 +19,7 @@ def get_or_create_device_id(data_dir: Path) -> str:
 
     The ID is a 16-character hex string persisted in ``data_dir/device.json``.
     """
-    from openakita.utils.atomic_io import read_json_safe, safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write, read_json_safe
 
     fp = data_dir / _DEVICE_FILE
     data = read_json_safe(fp)
@@ -30,6 +30,6 @@ def get_or_create_device_id(data_dir: Path) -> str:
         logger.warning("Corrupt device.json — regenerating device_id")
 
     did = uuid.uuid4().hex[:16]
-    safe_json_write(fp, {"device_id": did})
+    atomic_json_write(fp, {"device_id": did})
     logger.info("Generated new device_id: %s", did)
     return did

--- a/src/openakita/llm/client.py
+++ b/src/openakita/llm/client.py
@@ -2705,7 +2705,7 @@ class LLMClient:
         if not self._config_path:
             return
 
-        from ..utils.atomic_io import read_json_safe, safe_json_write
+        from ..utils.atomic_io import atomic_json_write, read_json_safe
 
         config_data = read_json_safe(self._config_path)
         if config_data is None:
@@ -2721,7 +2721,7 @@ class LLMClient:
 
         ep_list.sort(key=lambda e: (int(e.get("priority", 999)), e.get("name", "")))
         config_data["endpoints"] = ep_list
-        safe_json_write(self._config_path, config_data)
+        atomic_json_write(self._config_path, config_data)
 
     async def close(self):
         """关闭所有 Provider"""

--- a/src/openakita/llm/registries/__init__.py
+++ b/src/openakita/llm/registries/__init__.py
@@ -110,10 +110,10 @@ def load_custom_providers() -> list[dict]:
 
 def save_custom_providers(entries: list[dict]) -> None:
     """保存自定义服务商列表到工作区 (atomic write + .bak backup)."""
-    from openakita.utils.atomic_io import safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write
 
     path = _get_custom_providers_path()
-    safe_json_write(path, entries)
+    atomic_json_write(path, entries)
     _logger.info(f"Saved {len(entries)} custom providers to {path}")
 
 

--- a/src/openakita/orgs/manager.py
+++ b/src/openakita/orgs/manager.py
@@ -591,10 +591,10 @@ class OrgManager:
         return data if isinstance(data, dict) else {}
 
     def save_state(self, org_id: str, state: dict) -> None:
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         p = self._state_json(org_id)
-        safe_json_write(p, state)
+        atomic_json_write(p, state)
 
     # ------------------------------------------------------------------
     # Internal

--- a/src/openakita/plugins/api.py
+++ b/src/openakita/plugins/api.py
@@ -205,12 +205,12 @@ class PluginAPI:
     def set_config(self, updates: dict) -> None:
         if not self._check_permission("config.write"):
             return
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         config = self._read_config_file()
         config.update(updates)
         config_path = self._data_dir / "config.json"
-        safe_json_write(config_path, config)
+        atomic_json_write(config_path, config)
 
     def get_data_dir(self) -> Path | None:
         if not self._check_permission("data.own"):

--- a/src/openakita/scheduler/consolidation_tracker.py
+++ b/src/openakita/scheduler/consolidation_tracker.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from ..utils.atomic_io import safe_json_write
+from ..utils.atomic_io import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class ConsolidationTracker:
 
     def _save(self) -> None:
         try:
-            safe_json_write(self.tracker_file, self._state)
+            atomic_json_write(self.tracker_file, self._state)
         except Exception as e:
             logger.error(f"Failed to save consolidation tracker: {e}")
 

--- a/src/openakita/scheduler/scheduler.py
+++ b/src/openakita/scheduler/scheduler.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from ..utils.atomic_io import safe_json_write, safe_write
+from ..utils.atomic_io import atomic_json_write, safe_write
 from ._naming import quarantine_invalid_task_name, validate_task_name
 from .locks import (
     HEARTBEAT_INTERVAL_SECONDS,
@@ -1230,7 +1230,7 @@ class TaskScheduler:
                 for task in self._tasks.values()
                 if task.durability != TaskDurability.SESSION
             ]
-            safe_json_write(tasks_file, data, fsync=True)
+            atomic_json_write(tasks_file, data, fsync=True)
 
         except Exception as e:
             logger.error(f"Failed to save tasks: {e}")

--- a/src/openakita/sessions/manager.py
+++ b/src/openakita/sessions/manager.py
@@ -195,7 +195,8 @@ class SessionManager:
         assistant 回复完成后调用。调用方无需关心 mark_dirty + flush 细节。
         """
         self._dirty = False
-        self._save_sessions()
+        if not self._save_sessions():
+            self._dirty = True
 
     def _dispatch_hook_fire_and_forget(self, hook_name: str, **kwargs) -> None:
         """Dispatch a plugin hook from sync context (best-effort, non-blocking)."""
@@ -227,7 +228,8 @@ class SessionManager:
         """
         if self._dirty:
             self._dirty = False
-            self._save_sessions()
+            if not self._save_sessions():
+                self._dirty = True
 
     def set_turn_loader(self, loader) -> None:
         """设置 turn_loader 回调（延迟绑定，Agent 初始化完成后调用）。
@@ -711,9 +713,7 @@ class SessionManager:
             data = self._try_load_sessions_file(temp_file)
             if data is not None:
                 try:
-                    if sessions_file.exists():
-                        sessions_file.unlink()
-                    temp_file.rename(sessions_file)
+                    temp_file.replace(sessions_file)
                     logger.info("Recovered sessions.json from .tmp successfully")
                 except Exception as e:
                     logger.warning(f"Failed to promote .tmp to sessions.json: {e}")
@@ -1000,39 +1000,19 @@ class SessionManager:
         返回 True 表示保存成功，False 表示失败（调用方应重试）。
         """
         sessions_file = self.storage_path / "sessions.json"
-        temp_file = self.storage_path / "sessions.json.tmp"
-        backup_file = self.storage_path / "sessions.json.bak"
-
         try:
             data = [session.to_dict() for session in self._sessions.values()]
-
-            # 1. 先写入临时文件
-            with open(temp_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
-
-            # 2. 验证临时文件可以正确解析
-            with open(temp_file, encoding="utf-8") as f:
-                json.load(f)  # 验证 JSON 格式正确
-
-            # 3. 备份旧文件（如果存在）
-            if sessions_file.exists():
-                try:
-                    sessions_file.replace(backup_file)
-                except Exception as e:
-                    logger.warning(f"Failed to backup sessions file: {e}")
-
-            # 4. 原子重命名临时文件为正式文件 (replace works on Windows too)
-            temp_file.replace(sessions_file)
-
-            logger.debug(f"Saved {len(data)} sessions to storage (atomic)")
+            atomic_json_write(
+                sessions_file,
+                data,
+                fsync=True,
+                allow_fallback=False,
+            )
+            logger.debug(f"Saved {len(data)} sessions to storage (atomic fsync)")
             return True
 
         except Exception as e:
             logger.error(f"Failed to save sessions: {e}", exc_info=True)
-            # 清理临时文件
-            if temp_file.exists():
-                with contextlib.suppress(Exception):
-                    temp_file.unlink()
             return False
 
     async def _save_sessions_async(self) -> None:

--- a/src/openakita/sessions/user.py
+++ b/src/openakita/sessions/user.py
@@ -384,13 +384,13 @@ class UserManager:
 
     def _save_users(self) -> None:
         """保存用户数据"""
-        from openakita.utils.atomic_io import safe_json_write
+        from openakita.utils.atomic_io import atomic_json_write
 
         users_file = self.storage_path / "users.json"
 
         try:
             data = [user.to_dict() for user in self._users.values()]
-            safe_json_write(users_file, data)
+            atomic_json_write(users_file, data)
             logger.debug(f"Saved {len(data)} users to storage")
 
         except Exception as e:

--- a/src/openakita/tools/handlers/todo_store.py
+++ b/src/openakita/tools/handlers/todo_store.py
@@ -2,7 +2,7 @@
 Todo 状态 JSON 持久化层
 
 原子写 + 防抖，复用项目已有的 atomic_io 工具：
-safe_json_write (.tmp → .bak → replace) / read_json_safe (.bak 回退)
+atomic_json_write (.tmp → .bak → replace) / read_json_safe (.bak 回退)
 
 仅持久化 status == "in_progress" 的 plan，已完成/取消的自动清理。
 """
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from ...utils.atomic_io import read_json_safe, safe_json_write
+from ...utils.atomic_io import atomic_json_write, read_json_safe
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class TodoStore:
             "todos": {k: v for k, v in self._data.items() if v.get("status") == "in_progress"},
         }
         try:
-            safe_json_write(self._path, payload)
+            atomic_json_write(self._path, payload)
             self._dirty = False
             return True
         except Exception as e:

--- a/src/openakita/tools/mcp_workspace.py
+++ b/src/openakita/tools/mcp_workspace.py
@@ -145,10 +145,10 @@ async def add_server_to_workspace(
     if headers:
         metadata["headers"] = headers
 
-    from openakita.utils.atomic_io import safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write
 
     metadata_file = server_dir / "SERVER_METADATA.json"
-    safe_json_write(metadata_file, metadata)
+    atomic_json_write(metadata_file, metadata)
 
     if instructions:
         (server_dir / "INSTRUCTIONS.md").write_text(instructions, encoding="utf-8")

--- a/src/openakita/utils/atomic_io.py
+++ b/src/openakita/utils/atomic_io.py
@@ -7,102 +7,124 @@
 
 import json
 import logging
+import os
 import shutil
+import threading
 import time
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_LOCKS_GUARD = threading.Lock()
+_WRITE_LOCKS: dict[Path, threading.Lock] = {}
 
-def atomic_json_write(path: Path, data: Any, *, indent: int = 2) -> None:
-    """原子写入 JSON 文件（temp + rename 模式）。
 
-    先写入临时文件，验证 JSON 正确性后再重命名为目标文件。
-    在 POSIX 系统上 rename 是原子操作；Windows 上通过 replace 保证覆盖。
+def _lock_for_path(path: Path) -> threading.Lock:
+    resolved = path.resolve()
+    with _LOCKS_GUARD:
+        lock = _WRITE_LOCKS.get(resolved)
+        if lock is None:
+            lock = threading.Lock()
+            _WRITE_LOCKS[resolved] = lock
+        return lock
 
-    Args:
-        path: 目标文件路径
-        data: 可 JSON 序列化的数据
-        indent: JSON 缩进级别
-    """
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
 
+def _fsync_parent_dir(path: Path) -> None:
+    """Best-effort directory fsync so a committed rename survives power loss."""
+    if os.name == "nt":
+        return
     try:
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=indent)
-
-        # Windows 不支持 rename 覆盖已存在文件，使用 replace
-        tmp.replace(path)
-    except Exception:
-        if tmp.exists():
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
-        raise
-
-
-# ---------------------------------------------------------------------------
-# Enhanced: atomic write with .bak backup + Windows PermissionError retry
-# ---------------------------------------------------------------------------
+        fd = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def safe_write(
-    path: Path, content: str, *, backup: bool = True, retries: int = 3, fsync: bool = False
+    path: Path,
+    content: str,
+    *,
+    backup: bool = True,
+    retries: int = 3,
+    fsync: bool = False,
+    allow_fallback: bool = True,
 ) -> None:
     """Atomic text write with optional .bak backup and Windows retry.
 
     Flow: backup existing → write to .tmp → (fsync) → rename .tmp → target.
     On Windows, PermissionError on rename is retried up to *retries* times
-    before falling back to a direct (non-atomic) write.
+    before falling back to a direct (non-atomic) write, unless
+    ``allow_fallback`` is disabled.
     """
-    import os
-
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-
-    if backup and path.exists():
-        bak = path.with_suffix(path.suffix + ".bak")
-        try:
-            shutil.copy2(path, bak)
-        except OSError as e:
-            logger.warning("Failed to create backup %s: %s", bak, e)
-
     tmp = path.with_suffix(path.suffix + ".tmp")
-    with open(tmp, "w", encoding="utf-8") as f:
-        f.write(content)
-        if fsync:
-            f.flush()
-            os.fsync(f.fileno())
 
-    last_err: Exception | None = None
-    for attempt in range(retries):
+    with _lock_for_path(path):
+        if backup and path.exists():
+            bak = path.with_suffix(path.suffix + ".bak")
+            try:
+                shutil.copy2(path, bak)
+                if fsync:
+                    _fsync_parent_dir(path)
+            except OSError as e:
+                logger.warning("Failed to create backup %s: %s", bak, e)
+
         try:
-            tmp.replace(path)
-            return
-        except PermissionError as e:
-            last_err = e
-            if attempt < retries - 1:
-                time.sleep(0.2 * (attempt + 1))
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(content)
+                if fsync:
+                    f.flush()
+                    os.fsync(f.fileno())
 
-    logger.warning(
-        "Atomic rename failed after %d retries (%s), falling back to direct write",
-        retries,
-        last_err,
-    )
-    path.write_text(content, encoding="utf-8")
-    tmp.unlink(missing_ok=True)
+            last_err: Exception | None = None
+            for attempt in range(retries):
+                try:
+                    tmp.replace(path)
+                    if fsync:
+                        _fsync_parent_dir(path)
+                    return
+                except PermissionError as e:
+                    last_err = e
+                    if attempt < retries - 1:
+                        time.sleep(0.2 * (attempt + 1))
+
+            if not allow_fallback:
+                raise PermissionError(
+                    f"Atomic replace failed after {retries} attempts for {path}"
+                ) from last_err
+
+            logger.warning(
+                "Atomic rename failed after %d retries (%s), falling back to direct write",
+                retries,
+                last_err,
+            )
+            path.write_text(content, encoding="utf-8")
+            if fsync:
+                with open(path, "r+", encoding="utf-8") as f:
+                    f.flush()
+                    os.fsync(f.fileno())
+                _fsync_parent_dir(path)
+        finally:
+            tmp.unlink(missing_ok=True)
 
 
-def safe_json_write(
-    path: Path, data: Any, *, indent: int = 2, backup: bool = True, fsync: bool = False
+def atomic_json_write(
+    path: Path,
+    data: Any,
+    *,
+    indent: int = 2,
+    backup: bool = True,
+    fsync: bool = False,
+    allow_fallback: bool = True,
 ) -> None:
-    """Atomic JSON write with .bak backup (convenience wrapper around safe_write)."""
+    """Atomic JSON write with optional .bak backup and fsync."""
     content = json.dumps(data, ensure_ascii=False, indent=indent) + "\n"
-    safe_write(path, content, backup=backup, fsync=fsync)
+    safe_write(path, content, backup=backup, fsync=fsync, allow_fallback=allow_fallback)
 
 
 def append_jsonl(path: Path, obj: dict, *, fsync: bool = False) -> None:

--- a/src/openakita/workspace/backup.py
+++ b/src/openakita/workspace/backup.py
@@ -133,10 +133,10 @@ def read_backup_settings(workspace_path: Path) -> dict[str, Any]:
 
 def write_backup_settings(workspace_path: Path, settings: dict[str, Any]) -> None:
     """Persist backup settings to data/backup_settings.json."""
-    from openakita.utils.atomic_io import safe_json_write
+    from openakita.utils.atomic_io import atomic_json_write
 
     settings_path = workspace_path / "data" / BACKUP_SETTINGS_FILE
-    safe_json_write(settings_path, settings)
+    atomic_json_write(settings_path, settings)
 
 
 # ── Backup creation ─────────────────────────────────────────────────

--- a/tests/unit/test_json_atomic_migration.py
+++ b/tests/unit/test_json_atomic_migration.py
@@ -1,4 +1,4 @@
-"""Stage 2 regression tests: every JSON writer migrated to safe_json_write.
+"""Stage 2 regression tests: every JSON writer migrated to atomic_json_write.
 
 For each migrated writer we verify two invariants:
 
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from openakita.utils.atomic_io import read_json_safe, safe_json_write
+from openakita.utils.atomic_io import atomic_json_write, read_json_safe
 
 
 def _corrupt(path: Path) -> None:
@@ -33,10 +33,10 @@ def _corrupt(path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_safe_json_write_creates_bak_on_overwrite(tmp_path):
+def test_atomic_json_write_creates_bak_on_overwrite(tmp_path):
     path = tmp_path / "config.json"
-    safe_json_write(path, {"v": 1})
-    safe_json_write(path, {"v": 2})
+    atomic_json_write(path, {"v": 1})
+    atomic_json_write(path, {"v": 2})
 
     bak = path.with_suffix(path.suffix + ".bak")
     assert bak.exists(), "second write should leave a .bak backup of v1"
@@ -44,10 +44,32 @@ def test_safe_json_write_creates_bak_on_overwrite(tmp_path):
     assert json.loads(path.read_text(encoding="utf-8"))["v"] == 2
 
 
+def test_atomic_json_write_can_fail_without_direct_overwrite(tmp_path, monkeypatch):
+    path = tmp_path / "state.json"
+    atomic_json_write(path, {"v": 1})
+
+    path_type = type(path)
+
+    def locked_replace(self, target):
+        if self.name == "state.json.tmp":
+            raise PermissionError("locked by another process")
+        return original_replace(self, target)
+
+    original_replace = path_type.replace
+    monkeypatch.setattr(path_type, "replace", locked_replace)
+    monkeypatch.setattr("openakita.utils.atomic_io.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(PermissionError):
+        atomic_json_write(path, {"v": 2}, allow_fallback=False)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {"v": 1}
+    assert not path.with_suffix(path.suffix + ".tmp").exists()
+
+
 def test_read_json_safe_falls_back_to_bak(tmp_path):
     path = tmp_path / "data.json"
-    safe_json_write(path, {"good": True})
-    safe_json_write(path, {"good": True, "more": 2})
+    atomic_json_write(path, {"good": True})
+    atomic_json_write(path, {"good": True, "more": 2})
     _corrupt(path)
 
     data = read_json_safe(path)
@@ -59,8 +81,8 @@ def test_read_json_safe_falls_back_to_bak(tmp_path):
 
 def test_read_json_safe_returns_none_when_both_corrupt(tmp_path):
     path = tmp_path / "lost.json"
-    safe_json_write(path, {"good": True})
-    safe_json_write(path, {"good": True, "v": 2})
+    atomic_json_write(path, {"good": True})
+    atomic_json_write(path, {"good": True, "v": 2})
     _corrupt(path)
     bak = path.with_suffix(path.suffix + ".bak")
     _corrupt(bak)
@@ -72,19 +94,19 @@ def test_read_json_safe_returns_none_when_both_corrupt(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_orchestrator_persist_uses_safe_json_write(tmp_path, monkeypatch):
-    """``Orchestrator._persist_sub_states`` writes via safe_json_write."""
+def test_orchestrator_persist_uses_atomic_json_write(tmp_path, monkeypatch):
+    """``Orchestrator._persist_sub_states`` writes via atomic_json_write."""
     calls = {}
 
     from openakita.utils import atomic_io as _io
 
-    real = _io.safe_json_write
+    real = _io.atomic_json_write
 
     def spy(path, data, **kw):
         calls["path"] = Path(path)
         return real(path, data, **kw)
 
-    monkeypatch.setattr("openakita.agents.orchestrator.safe_json_write", spy, raising=False)
+    monkeypatch.setattr("openakita.agents.orchestrator.atomic_json_write", spy, raising=False)
 
     # We can't run the full orchestrator; instead exercise the imported
     # symbol path. The import statement inside the method ensures any
@@ -129,7 +151,7 @@ def test_migrated_module_exports_target_functions(module_path, functions):
         assert f"def {fn}(" in src, f"{module_path} missing function {fn} after refactor"
 
 
-def test_device_id_persists_via_safe_json_write(tmp_path):
+def test_device_id_persists_via_atomic_json_write(tmp_path):
     from openakita.hub.device import get_or_create_device_id
 
     did = get_or_create_device_id(tmp_path)
@@ -159,7 +181,7 @@ def test_device_id_recovers_from_corruption(tmp_path):
     get_or_create_device_id(tmp_path)  # idempotent
 
     # Now write something else so we get a .bak
-    safe_json_write(p, {"device_id": "ffffeeee00001111"})
+    atomic_json_write(p, {"device_id": "ffffeeee00001111"})
     assert bak.exists()
 
     # Corrupt the primary; reader should still get a valid id back.

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -87,6 +87,37 @@ class TestSessionCreation:
         assert restored.context.focus_terms == s.context.focus_terms
 
 
+class TestSessionPersistence:
+    def test_save_sessions_uses_strict_atomic_json_write(self, tmp_path, monkeypatch):
+        manager = SessionManager(storage_path=tmp_path / "sessions")
+        session = manager.get_session("cli", "chat-1", "user-1")
+        session.add_message("user", "hello")
+        calls = {}
+
+        def spy(path, data, **kwargs):
+            calls["path"] = path
+            calls["data"] = data
+            calls["kwargs"] = kwargs
+
+        monkeypatch.setattr("openakita.sessions.manager.atomic_json_write", spy)
+
+        assert manager._save_sessions() is True
+
+        assert calls["path"] == tmp_path / "sessions" / "sessions.json"
+        assert calls["kwargs"]["fsync"] is True
+        assert calls["kwargs"]["allow_fallback"] is False
+        assert calls["data"][0]["context"]["messages"][0]["content"] == "hello"
+
+    def test_persist_keeps_dirty_on_atomic_write_failure(self, tmp_path, monkeypatch):
+        manager = SessionManager(storage_path=tmp_path / "sessions")
+        manager._dirty = True
+        monkeypatch.setattr(manager, "_save_sessions", lambda: False)
+
+        manager.persist()
+
+        assert manager._dirty is True
+
+
 class TestSessionState:
     def test_all_states_exist(self):
         assert SessionState.ACTIVE.value == "active"


### PR DESCRIPTION
## Summary
- consolidate JSON persistence under `atomic_json_write`
- make `sessions.json` writes fsync-backed and fail closed without direct overwrite fallback
- keep session dirty state when an immediate persist fails so the save loop can retry

## Tests
- `uv run pytest tests/unit/test_json_atomic_migration.py tests/unit/test_session.py -q`
- `uv run ruff check src/openakita/agents/orchestrator.py src/openakita/api/routes/config.py src/openakita/api/routes/mcp.py src/openakita/api/routes/skills.py src/openakita/channels/adapters/telegram.py src/openakita/channels/dm_pairing.py src/openakita/channels/media/storage.py src/openakita/config.py src/openakita/core/identity.py src/openakita/core/proactive.py src/openakita/core/user_profile.py src/openakita/hub/device.py src/openakita/llm/client.py src/openakita/llm/registries/__init__.py src/openakita/orgs/manager.py src/openakita/plugins/api.py src/openakita/scheduler/consolidation_tracker.py src/openakita/scheduler/scheduler.py src/openakita/sessions/manager.py src/openakita/sessions/user.py src/openakita/tools/handlers/todo_store.py src/openakita/tools/mcp_workspace.py src/openakita/utils/atomic_io.py src/openakita/workspace/backup.py tests/unit/test_json_atomic_migration.py tests/unit/test_session.py`

Fixes #647