### PR TITLE
add bulk deletion for LLM endpoint lists

### DIFF
--- a/apps/setup-center/src/views/LLMView.tsx
+++ b/apps/setup-center/src/views/LLMView.tsx
@@ -152,6 +152,11 @@ export function LLMView(props: LLMViewProps) {
   const [sttModel, setSttModel] = useState("");
   const [sttEndpointName, setSttEndpointName] = useState("");
   const [sttModels, setSttModels] = useState<ListedModel[]>([]);
+  const [selectedEndpointNames, setSelectedEndpointNames] = useState<Record<EndpointType, Set<string>>>(() => ({
+    endpoints: new Set(),
+    compiler_endpoints: new Set(),
+    stt_endpoints: new Set(),
+  }));
 
   // Edit modal
   const [editingOriginalName, setEditingOriginalName] = useState<string | null>(null);
@@ -236,12 +241,60 @@ export function LLMView(props: LLMViewProps) {
     await loadSavedEndpoints();
   }
 
+  function selectedNamesForType(endpointType: EndpointType): string[] {
+    return Array.from(selectedEndpointNames[endpointType]);
+  }
+
+  function setSelectedNamesForType(endpointType: EndpointType, names: Iterable<string>) {
+    setSelectedEndpointNames((prev) => ({
+      ...prev,
+      [endpointType]: new Set(names),
+    }));
+  }
+
+  function toggleEndpointSelected(endpointType: EndpointType, name: string) {
+    setSelectedEndpointNames((prev) => {
+      const next = new Set(prev[endpointType]);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return { ...prev, [endpointType]: next };
+    });
+  }
+
+  function setAllEndpointsSelected(endpointType: EndpointType, endpoints: EndpointDraft[], checked: boolean) {
+    setSelectedNamesForType(endpointType, checked ? endpoints.map((e) => e.name) : []);
+  }
+
   // ── Effects ──
 
   useEffect(() => {
     loadSavedEndpoints().catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId, dataMode, serviceRunning]);
+
+  useEffect(() => {
+    setSelectedEndpointNames((prev) => {
+      const keepByType: Record<EndpointType, Set<string>> = {
+        endpoints: new Set(savedEndpoints.map((e) => e.name)),
+        compiler_endpoints: new Set(savedCompilerEndpoints.map((e) => e.name)),
+        stt_endpoints: new Set(savedSttEndpoints.map((e) => e.name)),
+      };
+      let changed = false;
+      const next: Record<EndpointType, Set<string>> = {
+        endpoints: new Set(),
+        compiler_endpoints: new Set(),
+        stt_endpoints: new Set(),
+      };
+      (Object.keys(keepByType) as EndpointType[]).forEach((endpointType) => {
+        for (const name of prev[endpointType]) {
+          if (keepByType[endpointType].has(name)) next[endpointType].add(name);
+          else changed = true;
+        }
+        if (next[endpointType].size !== prev[endpointType].size) changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [savedEndpoints, savedCompilerEndpoints, savedSttEndpoints]);
 
   useEffect(() => {
     if (!selectedProvider) return;
@@ -1172,6 +1225,47 @@ export function LLMView(props: LLMViewProps) {
     }
   }
 
+  async function doDeleteSelectedEndpoints(names: string[], endpointType: EndpointType = "endpoints") {
+    if (!currentWorkspaceId && dataMode !== "remote") return;
+    if (!ensureEndpointConfigApiReady()) return;
+    const uniqueNames = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+    if (uniqueNames.length === 0) return;
+
+    const _busyId = notifyLoading(`删除 ${uniqueNames.length} 个端点...`);
+    try {
+      const res = await safeFetch(`${httpApiBase()}/api/config/endpoints`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          names: uniqueNames,
+          endpoint_type: endpointType,
+        }),
+      });
+      const data = await res.json();
+      if (data.status !== "ok") {
+        throw new Error(data.error || data.message || "批量删除失败");
+      }
+      const removedCount = Number(data.removed_count ?? 0);
+      if (removedCount <= 0) {
+        notifyError("未找到选中的端点，列表可能已经刷新。");
+        await syncEndpointConfigChange(endpointType);
+        return;
+      }
+      setSelectedNamesForType(endpointType, []);
+      await syncEndpointConfigChange(endpointType);
+      const reloadFailed = data.reload?.status === "failed";
+      notifySuccess(
+        reloadFailed
+          ? `已删除 ${removedCount} 个端点，当前运行中的服务暂未加载新配置。`
+          : `已删除 ${removedCount} 个端点`,
+      );
+    } catch (e) {
+      notifyError(friendlyConfigError(e));
+    } finally {
+      dismissLoading(_busyId);
+    }
+  }
+
   // Sync the actual model catalog of a relay/aggregator endpoint.
   // POST /api/config/sync-endpoint-models calls GET /v1/models on the
   // upstream and writes the result to llm_endpoints.json so:
@@ -1283,6 +1377,41 @@ export function LLMView(props: LLMViewProps) {
     return sections;
   }, [providers, savedEndpoints]);
 
+  function renderBatchDeleteToolbar(endpointType: EndpointType, endpoints: EndpointDraft[]) {
+    const selectedNames = selectedNamesForType(endpointType);
+    if (selectedNames.length === 0) return null;
+    return (
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2">
+        <div className="text-xs font-medium text-destructive">
+          已选择 {selectedNames.length} / {endpoints.length} 个端点
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setSelectedNamesForType(endpointType, [])}
+          >
+            取消选择
+          </Button>
+          <Button
+            variant="destructive"
+            size="xs"
+            disabled={endpointConfigDisabled}
+            onClick={() => askConfirm(`确定要删除选中的 ${selectedNames.length} 个端点吗？`, () => doDeleteSelectedEndpoints(selectedNames, endpointType))}
+            title={!endpointConfigApiReady ? endpointConfigUnavailableMessage : undefined}
+          >
+            <IconTrash size={12} />
+            批量删除
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  function allEndpointsSelected(endpointType: EndpointType, endpoints: EndpointDraft[]) {
+    return endpoints.length > 0 && endpoints.every((e) => selectedEndpointNames[endpointType].has(e.name));
+  }
+
   return (
     <>
       {/* ── Main endpoint list ── */}
@@ -1328,9 +1457,19 @@ export function LLMView(props: LLMViewProps) {
             <p className="text-sm">{t("llm.noEndpoints")}</p>
           </div>
         ) : (
+          <>
+          {renderBatchDeleteToolbar("endpoints", savedEndpoints)}
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
+                <TableHead className="w-[36px]">
+                  <Checkbox
+                    checked={allEndpointsSelected("endpoints", savedEndpoints)}
+                    onCheckedChange={(v) => setAllEndpointsSelected("endpoints", savedEndpoints, !!v)}
+                    disabled={endpointConfigDisabled}
+                    aria-label="选择全部聊天端点"
+                  />
+                </TableHead>
                 <TableHead className="w-[34px]"></TableHead>
                 <TableHead>{t("status.endpoint")}</TableHead>
                 <TableHead>{t("status.model")}</TableHead>
@@ -1341,12 +1480,23 @@ export function LLMView(props: LLMViewProps) {
               {groupedEndpointSections.map((section) => (
                 <Fragment key={section.key}>
                   <TableRow key={`${section.key}-group`} className="hover:bg-transparent">
-                    <TableCell colSpan={4} className="bg-muted/35 py-2 text-xs font-semibold text-muted-foreground">
+                    <TableCell colSpan={5} className="bg-muted/35 py-2 text-xs font-semibold text-muted-foreground">
                       {section.label} <span className="font-normal opacity-70">({section.endpoints.length})</span>
                     </TableCell>
                   </TableRow>
                   {section.endpoints.map((e) => (
-                    <TableRow key={e.name} className={e.enabled === false ? "opacity-45" : undefined}>
+                    <TableRow key={e.name} className={cn(
+                      selectedEndpointNames.endpoints.has(e.name) ? "bg-primary/5" : undefined,
+                      e.enabled === false ? "opacity-45" : undefined,
+                    )}>
+                      <TableCell className="align-middle">
+                        <Checkbox
+                          checked={selectedEndpointNames.endpoints.has(e.name)}
+                          onCheckedChange={() => toggleEndpointSelected("endpoints", e.name)}
+                          disabled={endpointConfigDisabled}
+                          aria-label={`选择端点 ${e.name}`}
+                        />
+                      </TableCell>
                       <TableCell className="align-middle">
                         {(envDraft[e.api_key_env] || "").trim() ? <DotGreen /> : <DotGray />}
                       </TableCell>
@@ -1398,6 +1548,7 @@ export function LLMView(props: LLMViewProps) {
               ))}
             </TableBody>
           </Table>
+          </>
         )}
       </div>
 
@@ -1418,9 +1569,19 @@ export function LLMView(props: LLMViewProps) {
             <p className="text-sm">{t("llm.noEndpoints")}</p>
           </div>
         ) : (
+          <>
+          {renderBatchDeleteToolbar("compiler_endpoints", savedCompilerEndpoints)}
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
+                <TableHead className="w-[36px]">
+                  <Checkbox
+                    checked={allEndpointsSelected("compiler_endpoints", savedCompilerEndpoints)}
+                    onCheckedChange={(v) => setAllEndpointsSelected("compiler_endpoints", savedCompilerEndpoints, !!v)}
+                    disabled={endpointConfigDisabled}
+                    aria-label="选择全部编译端点"
+                  />
+                </TableHead>
                 <TableHead>{t("status.endpoint")}</TableHead>
                 <TableHead>{t("status.model")}</TableHead>
                 <TableHead className="w-[140px]"></TableHead>
@@ -1428,7 +1589,18 @@ export function LLMView(props: LLMViewProps) {
             </TableHeader>
             <TableBody>
               {savedCompilerEndpoints.map((e) => (
-                <TableRow key={e.name} className={e.enabled === false ? "opacity-45" : undefined}>
+                <TableRow key={e.name} className={cn(
+                  selectedEndpointNames.compiler_endpoints.has(e.name) ? "bg-primary/5" : undefined,
+                  e.enabled === false ? "opacity-45" : undefined,
+                )}>
+                  <TableCell className="align-middle">
+                    <Checkbox
+                      checked={selectedEndpointNames.compiler_endpoints.has(e.name)}
+                      onCheckedChange={() => toggleEndpointSelected("compiler_endpoints", e.name)}
+                      disabled={endpointConfigDisabled}
+                      aria-label={`选择端点 ${e.name}`}
+                    />
+                  </TableCell>
                   <TableCell className="font-semibold">
                     <span>{e.name}</span>
                     {e.enabled === false && <span className="ml-1.5 text-[10px] font-bold text-muted-foreground">{t("llm.disabled")}</span>}
@@ -1446,6 +1618,7 @@ export function LLMView(props: LLMViewProps) {
               ))}
             </TableBody>
           </Table>
+          </>
         )}
       </div>
 
@@ -1466,9 +1639,19 @@ export function LLMView(props: LLMViewProps) {
             <p className="text-sm">{t("llm.noEndpoints")}</p>
           </div>
         ) : (
+          <>
+          {renderBatchDeleteToolbar("stt_endpoints", savedSttEndpoints)}
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
+                <TableHead className="w-[36px]">
+                  <Checkbox
+                    checked={allEndpointsSelected("stt_endpoints", savedSttEndpoints)}
+                    onCheckedChange={(v) => setAllEndpointsSelected("stt_endpoints", savedSttEndpoints, !!v)}
+                    disabled={endpointConfigDisabled}
+                    aria-label="选择全部 STT 端点"
+                  />
+                </TableHead>
                 <TableHead>{t("status.endpoint")}</TableHead>
                 <TableHead>{t("status.model")}</TableHead>
                 <TableHead className="w-[140px]"></TableHead>
@@ -1476,7 +1659,18 @@ export function LLMView(props: LLMViewProps) {
             </TableHeader>
             <TableBody>
               {savedSttEndpoints.map((e) => (
-                <TableRow key={e.name} className={e.enabled === false ? "opacity-45" : undefined}>
+                <TableRow key={e.name} className={cn(
+                  selectedEndpointNames.stt_endpoints.has(e.name) ? "bg-primary/5" : undefined,
+                  e.enabled === false ? "opacity-45" : undefined,
+                )}>
+                  <TableCell className="align-middle">
+                    <Checkbox
+                      checked={selectedEndpointNames.stt_endpoints.has(e.name)}
+                      onCheckedChange={() => toggleEndpointSelected("stt_endpoints", e.name)}
+                      disabled={endpointConfigDisabled}
+                      aria-label={`选择端点 ${e.name}`}
+                    />
+                  </TableCell>
                   <TableCell className="font-semibold">
                     <span>{e.name}</span>
                     {e.enabled === false && <span className="ml-1.5 text-[10px] font-bold text-muted-foreground">{t("llm.disabled")}</span>}
@@ -1494,6 +1688,7 @@ export function LLMView(props: LLMViewProps) {
               ))}
             </TableBody>
           </Table>
+          </>
         )}
       </div>
 
@@ -2309,4 +2504,3 @@ export function LLMView(props: LLMViewProps) {
     </>
   );
 }
-

--- a/src/openakita/api/routes/config.py
+++ b/src/openakita/api/routes/config.py
@@ -772,6 +772,12 @@ class DeleteEndpointRequest(BaseModel):
     clean_env: bool = True
 
 
+class DeleteEndpointsRequest(BaseModel):
+    names: list[str]
+    endpoint_type: str = "endpoints"
+    clean_env: bool = True
+
+
 def _normalize_endpoint_api_key(api_key: str | None) -> str | None:
     """Treat UI-masked secrets as an unchanged value, not a new API key."""
     if api_key is None:
@@ -944,6 +950,36 @@ async def save_endpoints(body: SaveEndpointsRequest, request: Request):
             "可以继续配置；如果马上要使用新模型，请重启服务或稍后再试。"
         )
     return response
+
+
+@router.delete("/api/config/endpoints")
+async def delete_endpoints(body: DeleteEndpointsRequest, request: Request):
+    """Delete multiple LLM endpoints by name and reload running clients once."""
+    mgr = _get_endpoint_manager()
+    try:
+        removed = mgr.delete_endpoints(
+            body.names,
+            endpoint_type=body.endpoint_type,
+            clean_env=body.clean_env,
+        )
+    except (ValueError, Exception) as e:
+        logger.error("[Config API] delete-endpoints failed: %s", e, exc_info=True)
+        return {"status": "error", "error": str(e)}
+
+    removed_names = {str(ep.get("name") or "") for ep in removed}
+    requested_names = [str(name).strip() for name in body.names if str(name).strip()]
+    not_found = [name for name in requested_names if name not in removed_names]
+    reload_result = (
+        _trigger_reload(request) if removed else {"status": "skipped", "reason": "no_match"}
+    )
+    return {
+        "status": "ok",
+        "removed": removed,
+        "removed_count": len(removed),
+        "not_found": not_found,
+        "version": mgr.get_version(),
+        "reload": reload_result,
+    }
 
 
 @router.delete("/api/config/endpoint/{name:path}")

--- a/src/openakita/llm/endpoint_manager.py
+++ b/src/openakita/llm/endpoint_manager.py
@@ -362,6 +362,52 @@ class EndpointManager:
             self._write_json(config)
             return removed
 
+    def delete_endpoints(
+        self,
+        names: list[str],
+        endpoint_type: str = "endpoints",
+        clean_env: bool = True,
+    ) -> list[dict]:
+        """Delete multiple endpoints by name in one write."""
+        if endpoint_type not in _ENDPOINT_LISTS:
+            raise ValueError(f"Invalid endpoint_type: {endpoint_type}")
+
+        wanted = {str(name).strip() for name in names if str(name).strip()}
+        if not wanted:
+            raise ValueError("No endpoint names to delete")
+
+        with self._lock:
+            config, _ = self._read_json_versioned()
+            ep_list = config.get(endpoint_type, [])
+
+            removed: list[dict] = []
+            new_list = []
+            for ep in ep_list:
+                if ep.get("name") in wanted:
+                    removed.append(ep)
+                else:
+                    new_list.append(ep)
+
+            if not removed:
+                return []
+
+            config[endpoint_type] = new_list
+
+            if clean_env:
+                removed_env_vars = {
+                    str(ep.get("api_key_env") or "").strip()
+                    for ep in removed
+                    if str(ep.get("api_key_env") or "").strip()
+                }
+                for env_var in sorted(removed_env_vars):
+                    still_used = self._find_endpoints_using_env_var(config, env_var)
+                    if not still_used:
+                        self._delete_env_key(env_var)
+                        os.environ.pop(env_var, None)
+
+            self._write_json(config)
+            return removed
+
     def list_endpoints(self, endpoint_type: str = "endpoints") -> list[dict]:
         """Read endpoints from config file."""
         config = self._read_json()

--- a/tests/unit/test_config_endpoint_save_api.py
+++ b/tests/unit/test_config_endpoint_save_api.py
@@ -18,6 +18,7 @@ class _FakeEndpointManager:
         self.enabled = False
         self.endpoints = []
         self.deleted_endpoint = None
+        self.deleted_endpoints = None
 
     def save_endpoint(
         self,
@@ -75,6 +76,20 @@ class _FakeEndpointManager:
             "clean_env": clean_env,
         }
         return {"name": name, "api_key_env": "STT_API_KEY"}
+
+    def delete_endpoints(
+        self,
+        names: list[str],
+        endpoint_type: str = "endpoints",
+        clean_env: bool = True,
+    ) -> list[dict]:
+        self.deleted_endpoints = {
+            "names": names,
+            "endpoint_type": endpoint_type,
+            "clean_env": clean_env,
+        }
+        wanted = set(names)
+        return [dict(ep) for ep in self.endpoints if ep.get("name") in wanted]
 
 
 @pytest.mark.asyncio
@@ -655,6 +670,44 @@ def test_delete_last_chat_endpoint_is_allowed(monkeypatch):
     assert manager.deleted_endpoint == {
         "name": "solo",
         "endpoint_type": "endpoints",
+        "clean_env": True,
+    }
+
+
+def test_delete_endpoints_batches_names_and_reloads_once(monkeypatch):
+    manager = _FakeEndpointManager()
+    manager.endpoints = [
+        {"name": "one", "provider": "openai", "model": "gpt-4o"},
+        {"name": "two", "provider": "openai", "model": "gpt-4o-mini"},
+    ]
+    reload_calls = []
+    monkeypatch.setattr(config_routes, "_get_endpoint_manager", lambda: manager)
+    monkeypatch.setattr(
+        config_routes,
+        "_trigger_reload",
+        lambda request: reload_calls.append(request) or {"status": "ok"},
+    )
+
+    app = FastAPI()
+    app.include_router(config_routes.router)
+    client = TestClient(app)
+
+    response = client.request(
+        "DELETE",
+        "/api/config/endpoints",
+        json={"names": ["one", "missing"], "endpoint_type": "compiler_endpoints"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["removed_count"] == 1
+    assert data["removed"][0]["name"] == "one"
+    assert data["not_found"] == ["missing"]
+    assert len(reload_calls) == 1
+    assert manager.deleted_endpoints == {
+        "names": ["one", "missing"],
+        "endpoint_type": "compiler_endpoints",
         "clean_env": True,
     }
 

--- a/tests/unit/test_endpoint_manager_original_name.py
+++ b/tests/unit/test_endpoint_manager_original_name.py
@@ -76,3 +76,41 @@ def test_save_endpoints_batch_shares_one_api_key_env(tmp_path):
     assert len({ep["api_key_env"] for ep in saved}) == 1
     assert len({ep["api_key_env"] for ep in endpoints}) == 1
     assert "OPENAI_API_KEY=sk-batch" in (tmp_path / ".env").read_text(encoding="utf-8")
+
+
+def test_delete_endpoints_removes_batch_and_cleans_unused_shared_key(tmp_path):
+    manager = EndpointManager(tmp_path, config_path=tmp_path / "data" / "llm_endpoints.json")
+    manager.save_endpoints(
+        [
+            {"name": "openai-a", "provider": "openai", "model": "a", "priority": 10},
+            {"name": "openai-b", "provider": "openai", "model": "b", "priority": 20},
+        ],
+        api_key="sk-batch",
+    )
+
+    removed = manager.delete_endpoints(["openai-a", "openai-b"])
+
+    config = json.loads((tmp_path / "data" / "llm_endpoints.json").read_text(encoding="utf-8"))
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert [ep["name"] for ep in removed] == ["openai-a", "openai-b"]
+    assert config["endpoints"] == []
+    assert "OPENAI_API_KEY=" not in env_text
+
+
+def test_delete_endpoints_keeps_key_when_other_endpoint_still_uses_it(tmp_path):
+    manager = EndpointManager(tmp_path, config_path=tmp_path / "data" / "llm_endpoints.json")
+    manager.save_endpoints(
+        [
+            {"name": "openai-a", "provider": "openai", "model": "a", "priority": 10},
+            {"name": "openai-b", "provider": "openai", "model": "b", "priority": 20},
+        ],
+        api_key="sk-batch",
+    )
+
+    removed = manager.delete_endpoints(["openai-a"])
+
+    config = json.loads((tmp_path / "data" / "llm_endpoints.json").read_text(encoding="utf-8"))
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert [ep["name"] for ep in removed] == ["openai-a"]
+    assert [ep["name"] for ep in config["endpoints"]] == ["openai-b"]
+    assert "OPENAI_API_KEY=sk-batch" in env_text


### PR DESCRIPTION
## Summary
- add multi-select controls and a bulk delete toolbar to the Setup Center LLM endpoint tables
- add a batch endpoint deletion API that removes selected names in one manager write and triggers only one runtime reload
- preserve shared API keys when another remaining endpoint still references the same env var

## Tests
- `uv run --no-sync pytest tests/unit/test_config_endpoint_save_api.py tests/unit/test_endpoint_manager_original_name.py`
- `uv run --no-sync ruff check src/openakita/api/routes/config.py src/openakita/llm/endpoint_manager.py tests/unit/test_config_endpoint_save_api.py tests/unit/test_endpoint_manager_original_name.py`
- `npm run build`
- `npm run lint -- --quiet`

Closes #644