### PR TITLE
fix: stream category mass action progress

### DIFF
--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -505,6 +505,18 @@
       "disableAll": "Disable all",
       "disableAllTitle": "Disable all skills in this category",
       "disabledAll": "Disabled all skills in category \"{{name}}\"",
+      "massStarting": "Starting...",
+      "massWorking": "Updating skills...",
+      "massSyncing": "Syncing list...",
+      "massStage": {
+        "starting": "Starting...",
+        "scanning": "Scanning category skills...",
+        "allowlist": "Updating enabled skill list...",
+        "propagating": "Reloading skill runtime...",
+        "syncing": "Syncing list...",
+        "done": "Done",
+        "working": "Updating skills..."
+      },
       "noSkillsInCategory": "No actionable skills found in category \"{{name}}\"",
       "allSystemSkills": "All {{count}} skills in \"{{name}}\" are system skills and cannot be toggled",
       "delete": "Delete",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -505,6 +505,18 @@
       "disableAll": "全部禁用",
       "disableAllTitle": "禁用该分类下的所有技能",
       "disabledAll": "已禁用「{{name}}」分类下的全部技能",
+      "massStarting": "正在开始...",
+      "massWorking": "正在更新技能...",
+      "massSyncing": "正在同步列表...",
+      "massStage": {
+        "starting": "正在开始...",
+        "scanning": "正在扫描分类技能...",
+        "allowlist": "正在更新启用列表...",
+        "propagating": "正在刷新技能运行时...",
+        "syncing": "正在同步列表...",
+        "done": "已完成",
+        "working": "正在更新技能..."
+      },
       "noSkillsInCategory": "「{{name}}」分类下未找到可操作的技能",
       "allSystemSkills": "「{{name}}」分类下的 {{count}} 个技能均为系统技能，无法被启用/禁用",
       "delete": "删除",

--- a/apps/setup-center/src/views/SkillManager.tsx
+++ b/apps/setup-center/src/views/SkillManager.tsx
@@ -79,6 +79,41 @@ function friendlyError(e: unknown, t: (key: string) => string, context: ErrorCon
   return t(contextMap[context]);
 }
 
+type CategoryMassAction = "enable" | "disable";
+
+type CategoryMassActionResult = {
+  status?: string;
+  name?: string;
+  added?: number;
+  removed?: number;
+  system_count?: number;
+  total?: number;
+  processed?: number;
+  error?: string;
+  detail?: string;
+};
+
+type CategoryMassProgressEvent = {
+  stage?: string;
+  message?: string;
+  percent?: number;
+  total?: number;
+  processed?: number;
+  finished?: boolean;
+  error?: string;
+  result?: CategoryMassActionResult;
+};
+
+type CategoryMassProgressState = {
+  category: string;
+  action: CategoryMassAction;
+  stage: string;
+  message: string;
+  percent: number;
+  total: number;
+  processed: number;
+};
+
 // ─── 分类对话框（新建 / 编辑） ───
 
 type CategoryDialogState = {
@@ -1315,6 +1350,7 @@ export function SkillManager({
   const [categories, setCategories] = useState<CategoryInfo[]>([]);
   const [groupView, setGroupView] = useState(true);
   const [categoryBusy, setCategoryBusy] = useState<string | null>(null);
+  const [categoryMassProgress, setCategoryMassProgress] = useState<CategoryMassProgressState | null>(null);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [categoryDialogState, setCategoryDialogState] = useState<CategoryDialogState>(null);
   const [categoryDeleteConfirm, setCategoryDeleteConfirm] = useState<string | null>(null);
@@ -1536,61 +1572,113 @@ export function SkillManager({
   );
 
   // ── 大类启用/禁用 / 创建 / 删除（mass action over allowlist） ──
-  const handleCategoryEnableAll = useCallback(async (name: string) => {
-    if (apiBaseUrl == null) return;
-    setCategoryBusy(name);
-    try {
-      const res = await safeFetch(`${apiBaseUrl}/api/skill-categories/${encodeURIComponent(name)}/enable`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-        signal: AbortSignal.timeout(15_000),
-      });
-      const data = await res.json().catch(() => ({}));
-      const count = data?.added ?? -1;
-      const sysCount = data?.system_count ?? 0;
-      if (count === 0 && sysCount > 0) {
-        toast.info(t("skills.category.allSystemSkills", { name: displayCategoryName(name), count: sysCount }));
-      } else if (count === 0) {
-        toast.warning(t("skills.category.noSkillsInCategory", { name: displayCategoryName(name) }));
-      } else {
-        toast.success(t("skills.category.enabledAll", { name: displayCategoryName(name) }));
-      }
-      await refreshAfterCategoryMutation();
-    } catch (e) {
-      toast.error(friendlyError(e, t, "save"));
-    } finally {
-      setCategoryBusy(null);
+  const runCategoryMassAction = useCallback(async (
+    name: string,
+    action: CategoryMassAction,
+  ): Promise<CategoryMassActionResult> => {
+    const actionPath = action === "enable" ? "enable" : "disable";
+    const url = `${apiBaseUrl}/api/skill-categories/${encodeURIComponent(name)}/${actionPath}?stream=1`;
+    const res = await safeFetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+      body: "{}",
+      signal: AbortSignal.timeout(120_000),
+    });
+    const contentType = res.headers.get("content-type") || "";
+    if (!contentType.includes("text/event-stream") || !res.body) {
+      return await res.json().catch(() => ({}));
     }
-  }, [apiBaseUrl, t, displayCategoryName, refreshAfterCategoryMutation]);
 
-  const handleCategoryDisableAll = useCallback(async (name: string) => {
-    if (apiBaseUrl == null) return;
-    setCategoryBusy(name);
-    try {
-      const res = await safeFetch(`${apiBaseUrl}/api/skill-categories/${encodeURIComponent(name)}/disable`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-        signal: AbortSignal.timeout(15_000),
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let finalResult: CategoryMassActionResult | null = null;
+    const applyProgress = (event: CategoryMassProgressEvent) => {
+      if (event.result) finalResult = event.result;
+      const percent = Math.max(0, Math.min(100, Number(event.percent ?? 0)));
+      setCategoryMassProgress({
+        category: name,
+        action,
+        stage: String(event.stage || ""),
+        message: String(event.message || ""),
+        percent,
+        total: Number(event.total || event.result?.total || 0),
+        processed: Number(event.processed || event.result?.processed || 0),
       });
-      const data = await res.json().catch(() => ({}));
-      const count = data?.removed ?? -1;
+      if (event.error) throw new Error(event.error);
+    };
+
+    const parseBlock = (block: string) => {
+      const dataLines = block
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trimStart());
+      if (dataLines.length === 0) return;
+      const raw = dataLines.join("\n");
+      if (!raw) return;
+      const event = JSON.parse(raw) as CategoryMassProgressEvent;
+      applyProgress(event);
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const blocks = buffer.split(/\r?\n\r?\n/);
+      buffer = blocks.pop() || "";
+      for (const block of blocks) parseBlock(block);
+    }
+    buffer += decoder.decode();
+    if (buffer.trim()) parseBlock(buffer);
+    return finalResult || {};
+  }, [apiBaseUrl]);
+
+  const handleCategoryMassAction = useCallback(async (name: string, action: CategoryMassAction) => {
+    if (apiBaseUrl == null || categoryBusy) return;
+    setCategoryBusy(name);
+    setCategoryMassProgress({
+      category: name,
+      action,
+      stage: "starting",
+      message: t("skills.category.massStarting"),
+      percent: 5,
+      total: 0,
+      processed: 0,
+    });
+    try {
+      const data = await runCategoryMassAction(name, action);
+      const count = action === "enable" ? data?.added ?? -1 : data?.removed ?? -1;
       const sysCount = data?.system_count ?? 0;
       if (count === 0 && sysCount > 0) {
         toast.info(t("skills.category.allSystemSkills", { name: displayCategoryName(name), count: sysCount }));
       } else if (count === 0) {
         toast.warning(t("skills.category.noSkillsInCategory", { name: displayCategoryName(name) }));
+      } else if (action === "enable") {
+        toast.success(t("skills.category.enabledAll", { name: displayCategoryName(name) }));
       } else {
         toast.success(t("skills.category.disabledAll", { name: displayCategoryName(name) }));
       }
+      setCategoryMassProgress((prev) => prev && prev.category === name
+        ? { ...prev, stage: "syncing", message: t("skills.category.massSyncing"), percent: 95 }
+        : prev);
       await refreshAfterCategoryMutation();
     } catch (e) {
       toast.error(friendlyError(e, t, "save"));
     } finally {
       setCategoryBusy(null);
+      setCategoryMassProgress(null);
     }
-  }, [apiBaseUrl, t, displayCategoryName, refreshAfterCategoryMutation]);
+  }, [apiBaseUrl, categoryBusy, runCategoryMassAction, t, displayCategoryName, refreshAfterCategoryMutation]);
+
+  const handleCategoryEnableAll = useCallback(
+    (name: string) => handleCategoryMassAction(name, "enable"),
+    [handleCategoryMassAction],
+  );
+
+  const handleCategoryDisableAll = useCallback(
+    (name: string) => handleCategoryMassAction(name, "disable"),
+    [handleCategoryMassAction],
+  );
 
   const handleCategoryDialogSubmit = useCallback(async (
     mode: "create" | "edit",
@@ -2621,6 +2709,10 @@ export function SkillManager({
                   const readonly = meta?.system_readonly ?? false;
                   const total = items.length;
                   const enabled = items.filter(s => s.enabled).length;
+                  const massProgress = categoryMassProgress?.category === catName ? categoryMassProgress : null;
+                  const massProgressLabel = massProgress
+                    ? t(`skills.category.massStage.${massProgress.stage || "working"}`, massProgress.message || t("skills.category.massWorking"))
+                    : "";
                   const collapsed = !expandedCategories.has(catName);
                   const toggleCollapse = () => setExpandedCategories(prev => {
                     const next = new Set(prev);
@@ -2628,7 +2720,11 @@ export function SkillManager({
                     return next;
                   });
                   return (
-                    <div key={catName} className="flex flex-col rounded-md border border-border/60 bg-card/40 p-3">
+                    <div
+                      key={catName}
+                      className="flex flex-col rounded-md border border-border/60 bg-card/40 p-3"
+                      aria-busy={!!massProgress}
+                    >
                       <div
                         className="flex flex-wrap items-center gap-2 cursor-pointer select-none"
                         onClick={toggleCollapse}
@@ -2659,26 +2755,31 @@ export function SkillManager({
                           const massActionDisabled = readonly || isAllSystem;
                           const editable = meta ? (meta.declared ?? true) : false;
                           const editDeleteDisabled = massActionDisabled || !editable;
+                          const enableBusy = massProgress?.action === "enable";
+                          const disableBusy = massProgress?.action === "disable";
+                          const busyDisabled = !!categoryBusy;
                           return (
                             <div className="flex flex-wrap items-center gap-1" onClick={(e) => e.stopPropagation()}>
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="h-7 px-2 text-xs"
+                                className="h-7 min-w-[4.75rem] px-2 text-xs"
                                 onClick={() => handleCategoryEnableAll(catName)}
-                                disabled={massActionDisabled}
+                                disabled={massActionDisabled || busyDisabled}
                                 title={t("skills.category.enableAllTitle")}
                               >
+                                {enableBusy && <Loader2 className="animate-spin" size={12} />}
                                 {t("skills.category.enableAll")}
                               </Button>
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="h-7 px-2 text-xs"
+                                className="h-7 min-w-[4.75rem] px-2 text-xs"
                                 onClick={() => handleCategoryDisableAll(catName)}
-                                disabled={massActionDisabled}
+                                disabled={massActionDisabled || busyDisabled}
                                 title={t("skills.category.disableAllTitle")}
                               >
+                                {disableBusy && <Loader2 className="animate-spin" size={12} />}
                                 {t("skills.category.disableAll")}
                               </Button>
                               <Button
@@ -2690,7 +2791,7 @@ export function SkillManager({
                                   originalName: catName,
                                   currentDescription: meta?.description ?? null,
                                 })}
-                                disabled={editDeleteDisabled}
+                                disabled={editDeleteDisabled || busyDisabled}
                                 title={!editable ? t("skills.category.notDeclaredReadonly") : t("skills.category.edit")}
                               >
                                 {t("skills.category.edit")}
@@ -2700,7 +2801,7 @@ export function SkillManager({
                                 size="sm"
                                 className="h-7 px-2 text-xs text-destructive hover:text-destructive"
                                 onClick={() => requestCategoryDelete(catName)}
-                                disabled={editDeleteDisabled || categoryBusy === catName}
+                                disabled={editDeleteDisabled || busyDisabled}
                                 title={!editable ? t("skills.category.notDeclaredReadonly") : t("skills.category.deleteTitle")}
                               >
                                 {t("skills.category.delete")}
@@ -2709,6 +2810,32 @@ export function SkillManager({
                           );
                         })()}
                       </div>
+                      {massProgress && (
+                        <div className="mt-3 grid gap-1.5" aria-live="polite">
+                          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                            <Loader2 className="h-3 w-3 animate-spin shrink-0" />
+                            <span className="min-w-0 flex-1 truncate">{massProgressLabel}</span>
+                            {massProgress.total > 0 && (
+                              <span className="shrink-0 tabular-nums">
+                                {massProgress.processed}/{massProgress.total}
+                              </span>
+                            )}
+                            <span className="shrink-0 tabular-nums">{Math.round(massProgress.percent)}%</span>
+                          </div>
+                          <div
+                            className="h-1.5 overflow-hidden rounded-full bg-muted"
+                            role="progressbar"
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-valuenow={Math.round(massProgress.percent)}
+                          >
+                            <div
+                              className="h-full rounded-full bg-primary transition-[width] duration-300"
+                              style={{ width: `${Math.max(5, Math.min(100, massProgress.percent))}%` }}
+                            />
+                          </div>
+                        </div>
+                      )}
                       {!collapsed && (
                         <div className="flex flex-col gap-2 mt-2">
                           {items.map((skill) => (
@@ -2970,4 +3097,3 @@ export function SkillManager({
     </div>
   );
 }
-

--- a/src/openakita/api/routes/skill_categories.py
+++ b/src/openakita/api/routes/skill_categories.py
@@ -15,10 +15,12 @@ Skill categories route: /api/skill-categories
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 logger = logging.getLogger(__name__)
 
@@ -330,81 +332,104 @@ def _ensure_skills_cache_invalidated() -> None:
 @router.post("/api/skill-categories/{name:path}/enable")
 async def enable_category(name: str, request: Request):
     """批量启用：把该分类下所有外部技能 ID upsert 进 allowlist。"""
-    from openakita.skills.allowlist_io import (
-        overwrite_allowlist,
-        read_allowlist,
-        upsert_skill_ids,
-    )
-
-    target_ids, system_count = await _scan_external_ids_in_category(name)
-    logger.info(
-        "[category/enable] category=%r  external=%d  system=%d  ids=%s",
-        name,
-        len(target_ids),
-        system_count,
-        sorted(target_ids)[:5],
-    )
-    if not target_ids:
-        return {
-            "status": "ok",
-            "name": name,
-            "added": 0,
-            "system_count": system_count,
-        }
-
-    _, declared = read_allowlist()
-    if declared is None:
-        from openakita.skills.loader import SkillLoader
-
-        try:
-            from openakita.config import settings
-
-            base_path = Path(settings.project_root)
-        except Exception:
-            base_path = Path.cwd()
-        loader = SkillLoader()
-        await asyncio.to_thread(loader.load_all, base_path)
-        try:
-            effective = loader.compute_effective_allowlist(None) or set()
-        except Exception:
-            effective = set()
-        merged = set(effective) | target_ids
-        overwrite_allowlist(merged)
-    else:
-        upsert_skill_ids(target_ids)
-
-    _ensure_skills_cache_invalidated()
-    await _propagate(request, "category_enable", rescan=True)
-    _ensure_skills_cache_invalidated()
-    return {"status": "ok", "name": name, "added": len(target_ids)}
-
-
-# ── POST /api/skill-categories/{name:path}/disable ─────────────────────
+    if request.query_params.get("stream") in {"1", "true", "yes"}:
+        return _category_toggle_stream(name, request, enable=True)
+    return await _category_toggle_json(name, request, enable=True)
 
 
 @router.post("/api/skill-categories/{name:path}/disable")
 async def disable_category(name: str, request: Request):
     """批量禁用：把该分类下所有外部技能 ID 从 allowlist 中剔除。"""
+    if request.query_params.get("stream") in {"1", "true", "yes"}:
+        return _category_toggle_stream(name, request, enable=False)
+    return await _category_toggle_json(name, request, enable=False)
+
+
+def _category_progress_event(
+    *,
+    stage: str,
+    message: str,
+    percent: int,
+    total: int = 0,
+    processed: int = 0,
+    finished: bool = False,
+    error: str = "",
+    result: dict | None = None,
+) -> dict:
+    """Build a compact, user-facing progress payload for category mass actions."""
+    payload: dict = {
+        "stage": stage,
+        "message": message,
+        "percent": max(0, min(100, int(percent))),
+        "total": max(0, int(total)),
+        "processed": max(0, int(processed)),
+        "finished": bool(finished),
+        "error": error,
+    }
+    if result is not None:
+        payload["result"] = result
+    return payload
+
+
+async def _apply_category_toggle(
+    name: str,
+    request: Request,
+    *,
+    enable: bool,
+    progress: asyncio.Queue[dict] | None = None,
+) -> dict:
+    """Apply enable/disable for a category and optionally emit progress snapshots."""
     from openakita.skills.allowlist_io import (
         overwrite_allowlist,
         read_allowlist,
-        remove_skill_ids,
     )
 
+    if enable:
+        from openakita.skills.allowlist_io import upsert_skill_ids
+    else:
+        from openakita.skills.allowlist_io import remove_skill_ids
+
+    async def emit(payload: dict) -> None:
+        if progress is not None:
+            await progress.put(payload)
+
+    action_name = "enable" if enable else "disable"
+    action_past = "enabled" if enable else "disabled"
+
+    await emit(
+        _category_progress_event(
+            stage="scanning",
+            message="Scanning category skills",
+            percent=10,
+        )
+    )
     target_ids, system_count = await _scan_external_ids_in_category(name)
     logger.info(
-        "[category/disable] category=%r  external=%d  system=%d  ids=%s",
+        "[category/%s] category=%r  external=%d  system=%d  ids=%s",
+        action_name,
         name,
         len(target_ids),
         system_count,
         sorted(target_ids)[:5],
     )
+    await emit(
+        _category_progress_event(
+            stage="allowlist",
+            message="Updating enabled skill list",
+            percent=35,
+            total=len(target_ids),
+            processed=0,
+        )
+    )
     if not target_ids:
+        key = "added" if enable else "removed"
         return {
             "status": "ok",
             "name": name,
-            "removed": 0,
+            key: 0,
             "system_count": system_count,
+            "total": 0,
+            "processed": 0,
         }
 
     _, declared = read_allowlist()
@@ -423,15 +448,110 @@ async def disable_category(name: str, request: Request):
             effective = loader.compute_effective_allowlist(None) or set()
         except Exception:
             effective = set()
-        remaining = set(effective) - target_ids
-        overwrite_allowlist(remaining)
+        next_allowlist = set(effective) | target_ids if enable else set(effective) - target_ids
+        overwrite_allowlist(next_allowlist)
     else:
-        remove_skill_ids(target_ids)
+        if enable:
+            upsert_skill_ids(target_ids)
+        else:
+            remove_skill_ids(target_ids)
+
+    await emit(
+        _category_progress_event(
+            stage="propagating",
+            message="Reloading skill runtime",
+            percent=70,
+            total=len(target_ids),
+            processed=len(target_ids),
+        )
+    )
 
     _ensure_skills_cache_invalidated()
-    await _propagate(request, "category_disable", rescan=True)
+    await _propagate(request, f"category_{action_name}", rescan=True)
     _ensure_skills_cache_invalidated()
-    return {"status": "ok", "name": name, "removed": len(target_ids)}
+
+    key = "added" if enable else "removed"
+    return {
+        "status": "ok",
+        "name": name,
+        key: len(target_ids),
+        "system_count": system_count,
+        "total": len(target_ids),
+        "processed": len(target_ids),
+        "action": action_past,
+    }
+
+
+async def _category_toggle_json(name: str, request: Request, *, enable: bool) -> dict:
+    return await _apply_category_toggle(name, request, enable=enable)
+
+
+def _format_category_sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _category_toggle_stream(name: str, request: Request, *, enable: bool) -> StreamingResponse:
+    async def event_stream():
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+
+        async def run_action() -> dict:
+            return await _apply_category_toggle(name, request, enable=enable, progress=queue)
+
+        task = asyncio.create_task(run_action())
+        yield _format_category_sse(
+            _category_progress_event(
+                stage="starting",
+                message="Starting category update",
+                percent=5,
+            )
+        )
+        try:
+            while True:
+                if task.done() and queue.empty():
+                    break
+                try:
+                    payload = await asyncio.wait_for(queue.get(), timeout=0.5)
+                    yield _format_category_sse(payload)
+                except TimeoutError:
+                    yield ": keepalive\n\n"
+
+            result = await task
+            yield _format_category_sse(
+                _category_progress_event(
+                    stage="done",
+                    message="Category update complete",
+                    percent=100,
+                    total=int(result.get("total") or 0),
+                    processed=int(result.get("processed") or result.get("total") or 0),
+                    finished=True,
+                    result=result,
+                )
+            )
+        except Exception as e:
+            if not task.done():
+                task.cancel()
+            logger.error(
+                "Category %s stream failed for %r: %s",
+                "enable" if enable else "disable",
+                name,
+                e,
+                exc_info=True,
+            )
+            yield _format_category_sse(
+                _category_progress_event(
+                    stage="error",
+                    message=str(e),
+                    percent=100,
+                    finished=True,
+                    error=str(e),
+                )
+            )
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 # ── POST /api/skill-categories/move ────────────────────────────────────

--- a/tests/integration/test_skills_api_propagation.py
+++ b/tests/integration/test_skills_api_propagation.py
@@ -391,6 +391,68 @@ class TestConfigSkillsRoute:
 
 
 # ---------------------------------------------------------------------------
+# /api/skill-categories/{name}/enable?stream=1
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCategoryMassActionProgress:
+    async def test_enable_category_streams_progress_and_keeps_json_contract(
+        self, app_with_fake_agent, client, monkeypatch, tmp_path: Path
+    ):
+        """Category mass actions can stream progress without breaking the JSON endpoint."""
+        _, agent = app_with_fake_agent
+        skills_json = tmp_path / "data" / "skills.json"
+        skills_json.write_text(
+            json.dumps({"version": 1, "external_allowlist": []}),
+            encoding="utf-8",
+        )
+
+        async def fake_scan(name: str):
+            assert name == "Dev"
+            return {"alpha", "beta"}, 0
+
+        monkeypatch.setattr(
+            "openakita.api.routes.skill_categories._scan_external_ids_in_category",
+            fake_scan,
+        )
+
+        json_resp = await client.post("/api/skill-categories/Dev/enable", json={})
+        assert json_resp.status_code == 200
+        assert json_resp.json()["added"] == 2
+
+        agent.propagate_skill_change.reset_mock()
+        skills_json.write_text(
+            json.dumps({"version": 1, "external_allowlist": []}),
+            encoding="utf-8",
+        )
+
+        stream_resp = await client.post("/api/skill-categories/Dev/enable?stream=1", json={})
+
+        assert stream_resp.status_code == 200
+        assert "text/event-stream" in stream_resp.headers["content-type"]
+        frames = []
+        for block in stream_resp.text.split("\n\n"):
+            if not block.startswith("data: "):
+                continue
+            frames.append(json.loads(block.removeprefix("data: ")))
+
+        assert [f["stage"] for f in frames] == [
+            "starting",
+            "scanning",
+            "allowlist",
+            "propagating",
+            "done",
+        ]
+        assert frames[-1]["finished"] is True
+        assert frames[-1]["percent"] == 100
+        assert frames[-1]["result"]["added"] == 2
+        agent.propagate_skill_change.assert_called_once()
+        call = agent.propagate_skill_change.call_args
+        assert call.args[0] == "category_enable"
+        assert call.kwargs.get("rescan") is True
+
+
+# ---------------------------------------------------------------------------
 # 跨层缓存失效：notify_skills_changed 清空 GET /api/skills 缓存
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add SSE progress events for category enable/disable mass actions while keeping the existing JSON response path
- show per-category loading/progress UI and disable competing category actions during mass updates
- add integration coverage for streamed progress and JSON contract compatibility

## Tests
- .venv\\Scripts\\python.exe -m pytest tests/integration/test_skills_api_propagation.py -k SkillCategoryMassActionProgress -q

Fixed #632 