### PR TITLE
fix setup center to persist web search provider settings

### DIFF
--- a/apps/setup-center/src/App.tsx
+++ b/apps/setup-center/src/App.tsx
@@ -59,7 +59,7 @@ import logoUrl from "./assets/logo.png";
 import "highlight.js/styles/github.css";
 import { getThemePref, setThemePref, THEME_CHANGE_EVENT, type Theme } from "./theme";
 import { copyToClipboard } from "./utils/clipboard";
-import { BUILTIN_PROVIDERS, PIP_INDEX_PRESETS } from "./constants";
+import { BUILTIN_PROVIDERS, PIP_INDEX_PRESETS, WEB_SEARCH_ENV_KEYS } from "./constants";
 import { safeFetch } from "./providers";
 import {
   joinPath,
@@ -2241,6 +2241,7 @@ function MainApp() {
           "DESKTOP_VISION_ENABLED", "DESKTOP_VISION_MAX_RETRIES", "DESKTOP_VISION_TIMEOUT",
           "DESKTOP_CLICK_DELAY", "DESKTOP_TYPE_INTERVAL", "DESKTOP_MOVE_DURATION",
           "DESKTOP_FAILSAFE", "DESKTOP_PAUSE",
+          ...WEB_SEARCH_ENV_KEYS,
           "GITHUB_TOKEN",
         ];
       case "agent":
@@ -3467,8 +3468,7 @@ function MainApp() {
                 envDraft={envDraft}
                 onEnvChange={setEnvDraft}
                 onSaveEnv={async () => {
-                  const keys = ["WEB_SEARCH_PROVIDER", "BOCHA_API_KEY", "TAVILY_API_KEY", "JINA_API_KEY", "SEARXNG_BASE_URL"];
-                  await saveEnvKeys(keys);
+                  await saveEnvKeys(WEB_SEARCH_ENV_KEYS);
                 }}
                 busy={busy}
                 apiBaseUrl={apiBaseUrl}

--- a/apps/setup-center/src/constants.ts
+++ b/apps/setup-center/src/constants.ts
@@ -8,6 +8,14 @@ import SHARED_PROVIDERS from "@shared/providers.json";
 // registry_class 字段仅 Python 使用，前端忽略
 export const BUILTIN_PROVIDERS: ProviderInfo[] = SHARED_PROVIDERS as ProviderInfo[];
 
+export const WEB_SEARCH_ENV_KEYS = [
+  "WEB_SEARCH_PROVIDER",
+  "BOCHA_API_KEY",
+  "TAVILY_API_KEY",
+  "JINA_API_KEY",
+  "SEARXNG_BASE_URL",
+];
+
 /** STT 推荐模型（按 provider slug 索引） */
 export const STT_RECOMMENDED_MODELS: Record<string, { id: string; note: string }[]> = {
   "openai":          [{ id: "gpt-4o-transcribe", note: "推荐" }, { id: "whisper-1", note: "" }],
@@ -25,4 +33,3 @@ export const PIP_INDEX_PRESETS: { id: "official" | "tuna" | "ustc" | "aliyun" | 
   { id: "official", label: "官方 PyPI", url: "https://pypi.org/simple/" },
   { id: "custom", label: "自定义…", url: "" },
 ];
-


### PR DESCRIPTION
## Summary
- Share the web search provider env key list in setup-center constants.
- Include those keys in the Tools page save action so provider selection and API keys are persisted when users click Save Config / Apply and Restart.
- Reuse the same key list for the web search provider panel test-before-save path.

Closes #655

## Verification
- npm run build