### PR TITLE
update SignPath workflow configuration for the new organization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1166,11 +1166,11 @@ jobs:
             exit 1
           }
 
-          $organizationId = "fbb6fb8c-4af2-4876-903e-a4b878e40b84"
+          $organizationId = "30d23f0d-92e9-4732-b944-3d9e62c8ef45"
           $projectSlug = "openakita"
-          $policySlug = "openakita-test-sign-policy"
+          $policySlug = "test-signing"
           $artifactConfigurationSlug = "initial"
-          $certificateSlug = "openakita-test-cert"
+          $certificateSlug = "test_certificate_2026"
           $baseUrl = "https://app.signpath.io/api/v1/$organizationId"
           $headers = @{ Authorization = "Bearer $env:SIGNPATH_API_TOKEN" }
 
@@ -1202,9 +1202,9 @@ jobs:
 
           Write-Host "SignPath configuration is present."
           Write-Host "Project slug: openakita"
-          Write-Host "Signing policy slug: openakita-test-sign-policy"
+          Write-Host "Signing policy slug: test-signing"
           Write-Host "Artifact configuration slug: initial"
-          Write-Host "Certificate slug in SignPath: openakita-test-cert"
+          Write-Host "Certificate slug in SignPath: test_certificate_2026"
 
       - name: Sign Windows installer with SignPath
         if: runner.os == 'Windows'
@@ -1212,9 +1212,9 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: fbb6fb8c-4af2-4876-903e-a4b878e40b84
+          organization-id: 30d23f0d-92e9-4732-b944-3d9e62c8ef45
           project-slug: openakita
-          signing-policy-slug: openakita-test-sign-policy
+          signing-policy-slug: test-signing
           artifact-configuration-slug: initial
           github-artifact-id: ${{ steps.upload_unsigned_windows_installer.outputs.artifact-id }}
           wait-for-completion: true

--- a/.github/workflows/signpath-smoke.yml
+++ b/.github/workflows/signpath-smoke.yml
@@ -122,11 +122,11 @@ jobs:
             exit 1
           }
 
-          $organizationId = "fbb6fb8c-4af2-4876-903e-a4b878e40b84"
+          $organizationId = "30d23f0d-92e9-4732-b944-3d9e62c8ef45"
           $projectSlug = "openakita"
-          $policySlug = "openakita-test-sign-policy"
+          $policySlug = "test-signing"
           $artifactConfigurationSlug = "initial"
-          $certificateSlug = "openakita-test-cert"
+          $certificateSlug = "test_certificate_2026"
           $baseUrl = "https://app.signpath.io/api/v1/$organizationId"
           $headers = @{ Authorization = "Bearer $env:SIGNPATH_API_TOKEN" }
 
@@ -161,9 +161,9 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: fbb6fb8c-4af2-4876-903e-a4b878e40b84
+          organization-id: 30d23f0d-92e9-4732-b944-3d9e62c8ef45
           project-slug: openakita
-          signing-policy-slug: openakita-test-sign-policy
+          signing-policy-slug: test-signing
           artifact-configuration-slug: initial
           github-artifact-id: ${{ steps.upload_unsigned_fixture.outputs.artifact-id }}
           wait-for-completion: true


### PR DESCRIPTION
## Summary
- Update the SignPath organization ID used by the release and smoke workflows.
- Point both workflows at the new `test-signing` policy and `test_certificate_2026` certificate.

## Validation
- `git diff --check -- .github/workflows/release.yml .github/workflows/signpath-smoke.yml`