### PR TITLE
improve startup performance and setup center backend dev mode

### DIFF
--- a/apps/setup-center/README.md
+++ b/apps/setup-center/README.md
@@ -22,7 +22,15 @@ npm install
 npm run tauri dev
 ```
 
+如果后端已通过 `openakita serve` 单独启动，优先使用外部后端开发模式：
+
+```bash
+npm run tauri:dev:external-backend
+```
+
+该模式不会把 `src-tauri/resources/openakita-server` 和 `src-tauri/resources/bootstrap`
+复制到 Tauri debug 资源目录；桌面端只连接已经运行的 `http://127.0.0.1:18900`。
+
 ### 说明
 
 - **Windows 图标**：为避免开发环境因缺少 `src-tauri/icons/icon.ico` 导致构建失败，`src-tauri/build.rs` 会在缺失时自动生成一个透明占位 `icon.ico`。正式发布请用 `tauri icon` 生成完整图标集。
-

--- a/apps/setup-center/package.json
+++ b/apps/setup-center/package.json
@@ -18,6 +18,7 @@
     "lint:hooks": "eslint --rule \"react-hooks/rules-of-hooks: error\" --no-eslintrc --config eslint.config.js \"src/**/*.{ts,tsx}\"",
     "audit:tauri-lifecycle": "uv run --no-sync python ../../tools/audit_tauri_lifecycle.py",
     "tauri": "tauri",
+    "tauri:dev:external-backend": "cross-env OPENAKITA_EXTERNAL_BACKEND_DEV=1 tauri dev --config src-tauri/tauri.external-backend.dev.conf.json",
     "cap:sync": "npx cap sync",
     "cap:android": "npx cap open android",
     "cap:ios": "npx cap open ios"

--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -127,6 +127,7 @@ const SERVICE_START_DEDUPE_MS: u64 = 3_000;
 static SERVICE_START_LAST_AT: Lazy<Mutex<HashMap<String, u64>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 const OPENAKITA_ROOT_MARKER: &str = ".openakita-root";
+const EXTERNAL_BACKEND_DEV_ENV: &str = "OPENAKITA_EXTERNAL_BACKEND_DEV";
 
 const PIP_INSTALL_LOG_MAX_CHUNKS: usize = 512;
 const PIP_INSTALL_DEFAULT_ID: &str = "default";
@@ -1362,6 +1363,13 @@ fn save_log_export(filename: String, content: String) -> Result<String, String> 
 
 fn modules_dir() -> PathBuf {
     openakita_root_dir().join("modules")
+}
+
+fn external_backend_dev_mode() -> bool {
+    matches!(
+        std::env::var(EXTERNAL_BACKEND_DEV_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES")
+    )
 }
 
 /// 获取内嵌 PyInstaller 打包后端的目录
@@ -5297,6 +5305,7 @@ fn healthy_backend_pid(port: u16) -> Option<u32> {
 /// 此函数合并了「是否有后端在运行」和「版本是否匹配」两个检查，
 /// 只发一次 HTTP 请求，避免 setup 阶段重复探测。
 fn startup_version_check(workspace_id: &str, app_version: &str, port: u16) -> VersionCheckResult {
+    let external_dev = external_backend_dev_mode();
     let client = match reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .no_proxy()
@@ -5319,10 +5328,18 @@ fn startup_version_check(workspace_id: &str, app_version: &str, port: u16) -> Ve
                 "[version_check] health check non-success: {}",
                 r.status()
             ));
+            if external_dev {
+                log_to_file("[version_check] external-backend dev mode: backend is not healthy; skip bundled auto-start");
+                return VersionCheckResult::RunningOk;
+            }
             return VersionCheckResult::NotRunning;
         }
         Err(e) => {
             log_to_file(&format!("[version_check] health check failed: {e}"));
+            if external_dev {
+                log_to_file("[version_check] external-backend dev mode: backend is not running; skip bundled auto-start");
+                return VersionCheckResult::RunningOk;
+            }
             return VersionCheckResult::NotRunning;
         }
     };
@@ -5338,6 +5355,18 @@ fn startup_version_check(workspace_id: &str, app_version: &str, port: u16) -> Ve
         .unwrap_or("")
         .trim_start_matches('v');
     let desktop_version = app_version.trim_start_matches('v');
+
+    if external_dev {
+        if let Some(pid) = json.get("pid").and_then(|v| v.as_u64()).map(|p| p as u32) {
+            let _ = write_pid_file(workspace_id, pid, "external");
+        }
+        log_to_file(&format!(
+            "[version_check] external-backend dev mode: keeping running backend version={} for ws={}",
+            if backend_version.is_empty() { "unknown" } else { backend_version },
+            workspace_id
+        ));
+        return VersionCheckResult::RunningOk;
+    }
 
     // 版本无法判断或 dev 后端 → 保守保持现有后端。
     if backend_version.is_empty() || backend_version == "0.0.0-dev" {
@@ -5821,7 +5850,7 @@ fn main() {
             let state = read_state_file();
             if let Some(ref ws_id) = state.current_workspace_id {
                 let port = read_workspace_api_port(ws_id).unwrap_or(18900);
-                if cfg!(debug_assertions) {
+                if cfg!(debug_assertions) || external_backend_dev_mode() {
                     if let Some(pid) = healthy_backend_pid(port) {
                         let should_adopt = read_pid_file(ws_id)
                             .map(|data| !is_pid_file_valid(&data))
@@ -5847,7 +5876,9 @@ fn main() {
                     "[auto-start] app_version={}, ws_id={}, port={}, need_start={}",
                     app_version, ws_id, port, need_start
                 ));
-                if need_start {
+                if need_start && external_backend_dev_mode() {
+                    log_to_file("[auto-start] external-backend dev mode: skip bundled auto-start");
+                } else if need_start {
                     AUTO_START_IN_PROGRESS.store(true, Ordering::SeqCst);
                     AUTO_START_STARTED_AT_MS.store(now_ms(), Ordering::SeqCst);
                     let venv_dir = openakita_root_dir().join("venv").to_string_lossy().to_string();
@@ -5983,6 +6014,15 @@ fn main() {
                             return;
                         }
                         if AUTO_START_IN_PROGRESS.load(Ordering::SeqCst) || pip_install_is_running() {
+                            continue;
+                        }
+                        if external_backend_dev_mode() {
+                            let now = now_epoch_secs();
+                            if now.saturating_sub(last_starting_log_at) >= 30 {
+                                log_to_file("[heartbeat] external-backend dev mode: backend is down; skip auto-spawn");
+                                last_starting_log_at = now;
+                            }
+                            consecutive_failures = 0;
                             continue;
                         }
                         let venv_dir = openakita_root_dir().join("venv");
@@ -6718,6 +6758,30 @@ fn openakita_service_start_impl(
         "[service_start] called: ws={}, venv={}",
         workspace_id, venv_dir
     ));
+    if external_backend_dev_mode() {
+        let port = read_workspace_api_port(&workspace_id).unwrap_or(18900);
+        if let Some(pid) = healthy_backend_pid(port) {
+            write_pid_file(&workspace_id, pid, "external")?;
+            let pid_file = service_pid_file(&workspace_id).to_string_lossy().to_string();
+            log_to_file(&format!(
+                "[service_start] external-backend dev mode: adopted running backend pid={} for ws={}",
+                pid, workspace_id
+            ));
+            return Ok(build_service_status(
+                &workspace_id,
+                true,
+                Some(pid),
+                pid_file,
+                "external",
+                false,
+            ));
+        }
+        log_to_file("[service_start] external-backend dev mode: backend is not running; refusing bundled start");
+        return Err(format!(
+            "外部后端开发模式已启用，请先在另一个终端启动 `openakita serve` 并确认 http://127.0.0.1:{}/api/health 可访问。",
+            port
+        ));
+    }
     if pip_install_is_running() {
         log_to_file("[service_start] rejected: pip install is still running");
         return Err("后端环境仍在安装中，请稍候再启动后端".to_string());

--- a/apps/setup-center/src-tauri/tauri.external-backend.dev.conf.json
+++ b/apps/setup-center/src-tauri/tauri.external-backend.dev.conf.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "devUrl": "http://localhost:5173"
+  },
+  "bundle": {
+    "resources": []
+  }
+}

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -324,6 +324,33 @@ def _has_web_frontend_mount(app: FastAPI) -> bool:
     return any(getattr(route, "name", None) == "web-frontend" for route in app.routes)
 
 
+def _attach_agent_to_app(app: FastAPI, agent: Any) -> None:
+    app.state.agent = agent
+
+    pm = getattr(agent, "_plugin_manager", None)
+    if pm is None:
+        return
+
+    # Writes go to the shared backing dict; ``_host_refs`` is a filtered
+    # read-only view for plugins (no ``__setitem__`` / ``pop``).
+    ext = pm._external_host_refs
+    ext["api_app"] = app
+    pending = ext.pop("_pending_plugin_routers", [])
+    for plugin_id, router in pending:
+        try:
+            app.include_router(router, prefix=f"/api/plugins/{plugin_id}")
+            logger.info("Mounted pending plugin routes for '%s'", plugin_id)
+        except Exception as e:
+            logger.warning("Failed to mount pending routes for plugin '%s': %s", plugin_id, e)
+
+    pending_ui = ext.pop("_pending_plugin_ui_mounts", [])
+    for plugin_id, ui_dist_dir in pending_ui:
+        try:
+            pm._do_mount_plugin_ui(app, plugin_id, ui_dist_dir)
+        except Exception as e:
+            logger.warning("Failed to mount pending UI for plugin '%s': %s", plugin_id, e)
+
+
 def _startup_health_check_clients(app_state: Any) -> tuple[Any | None, Any | None, Any | None]:
     _agent = getattr(app_state, "agent", None)
     _brain = getattr(_agent, "brain", None) if _agent else None
@@ -545,28 +572,7 @@ def create_app(
     }
 
     if agent is not None:
-        pm = getattr(agent, "_plugin_manager", None)
-        if pm is not None:
-            # Writes go to the shared backing dict; ``_host_refs`` is a filtered
-            # read-only view for plugins (no ``__setitem__`` / ``pop``).
-            ext = pm._external_host_refs
-            ext["api_app"] = app
-            pending = ext.pop("_pending_plugin_routers", [])
-            for plugin_id, router in pending:
-                try:
-                    app.include_router(router, prefix=f"/api/plugins/{plugin_id}")
-                    logger.info("Mounted pending plugin routes for '%s'", plugin_id)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to mount pending routes for plugin '%s': %s", plugin_id, e
-                    )
-
-            pending_ui = ext.pop("_pending_plugin_ui_mounts", [])
-            for plugin_id, ui_dist_dir in pending_ui:
-                try:
-                    pm._do_mount_plugin_ui(app, plugin_id, ui_dist_dir)
-                except Exception as e:
-                    logger.warning("Failed to mount pending UI for plugin '%s': %s", plugin_id, e)
+        _attach_agent_to_app(app, agent)
 
     # Initialize OrgManager & OrgRuntime
     from openakita.orgs.manager import OrgManager
@@ -1116,7 +1122,7 @@ async def start_api_server(
 
 def update_agent(app: FastAPI, agent: Any) -> None:
     """Update the agent reference in the running app (e.g. after initialization)."""
-    app.state.agent = agent
+    _attach_agent_to_app(app, agent)
 
 
 def update_runtime_refs(
@@ -1140,9 +1146,12 @@ def update_runtime_refs(
     if app is None:
         return False
     if agent is not None:
-        app.state.agent = agent
+        _attach_agent_to_app(app, agent)
     if session_manager is not None:
         app.state.session_manager = session_manager
+        org_command_service = getattr(app.state, "org_command_service", None)
+        if org_command_service is not None and hasattr(org_command_service, "_session_manager"):
+            org_command_service._session_manager = session_manager
     if gateway is not None:
         app.state.gateway = gateway
     if orchestrator is not None:

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -324,6 +324,102 @@ def _has_web_frontend_mount(app: FastAPI) -> bool:
     return any(getattr(route, "name", None) == "web-frontend" for route in app.routes)
 
 
+def _startup_health_check_clients(app_state: Any) -> tuple[Any | None, Any | None, Any | None]:
+    _agent = getattr(app_state, "agent", None)
+    _brain = getattr(_agent, "brain", None) if _agent else None
+    _llm_client = getattr(_brain, "_llm_client", None) if _brain else None
+    _compiler_client = getattr(_brain, "_compiler_client", None) if _brain else None
+
+    if not (_llm_client and hasattr(_llm_client, "startup_health_check")):
+        _llm_client = None
+    if not (_compiler_client and hasattr(_compiler_client, "startup_health_check")):
+        _compiler_client = None
+
+    return _brain, _llm_client, _compiler_client
+
+
+async def _run_startup_llm_health_checks(app_state: Any) -> None:
+    try:
+        _brain, _llm_client, _compiler_client = _startup_health_check_clients(app_state)
+    except Exception as e:
+        logger.debug(f"[Startup] Endpoint health check skipped: {e}")
+        return
+
+    # Endpoint health check: detect stale/broken endpoints early.
+    try:
+        if _llm_client:
+            _results = await _llm_client.startup_health_check()
+            _ok = sum(1 for v in _results.values() if v == "ok")
+            _fail = len(_results) - _ok
+            if _fail:
+                logger.warning(
+                    f"[Startup] Endpoint health check: {_ok} ok, {_fail} failed — "
+                    f"{', '.join(f'{k}={v}' for k, v in _results.items() if v != 'ok')}"
+                )
+            else:
+                logger.info(f"[Startup] All {_ok} endpoints healthy")
+    except Exception as e:
+        logger.debug(f"[Startup] Endpoint health check skipped: {e}")
+
+    # Compiler endpoint health check.
+    try:
+        if _compiler_client:
+            comp_result = await _compiler_client.startup_health_check()
+            comp_failed = {k: v for k, v in comp_result.items() if v != "ok"}
+            if comp_failed:
+                for ep_name, status in comp_failed.items():
+                    _brain._compiler_on_failure(f"startup: {ep_name}={status}")
+                logger.warning(
+                    f"[Startup] Compiler health check failed: "
+                    f"{', '.join(f'{k}={v}' for k, v in comp_failed.items())}. "
+                    f"Compiler tasks will use main model."
+                )
+            else:
+                logger.info(f"[Startup] Compiler endpoints all healthy: {list(comp_result.keys())}")
+    except Exception as e:
+        logger.debug(f"[Startup] Compiler health check skipped: {e}")
+
+
+def _schedule_startup_llm_health_check(app_state: Any) -> asyncio.Task[None] | None:
+    existing = getattr(app_state, "llm_startup_health_check_task", None)
+    if existing is not None and not existing.done():
+        return existing
+
+    try:
+        _, _llm_client, _compiler_client = _startup_health_check_clients(app_state)
+    except Exception as e:
+        logger.debug(f"[Startup] Endpoint health check skipped: {e}")
+        app_state.llm_startup_health_check_task = None
+        return None
+
+    if _llm_client is None and _compiler_client is None:
+        app_state.llm_startup_health_check_task = None
+        return None
+
+    task = asyncio.create_task(
+        _run_startup_llm_health_checks(app_state),
+        name="openakita-startup-llm-health-check",
+    )
+    app_state.llm_startup_health_check_task = task
+    logger.info("[Startup] LLM endpoint health check scheduled in background")
+    return task
+
+
+async def _cancel_startup_llm_health_check(app_state: Any) -> None:
+    task = getattr(app_state, "llm_startup_health_check_task", None)
+    if task is None or task.done():
+        app_state.llm_startup_health_check_task = None
+        return
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        logger.debug("[Shutdown] Startup LLM health check cancelled")
+    finally:
+        app_state.llm_startup_health_check_task = None
+
+
 def create_app(
     agent: Any = None,
     shutdown_event: asyncio.Event | None = None,
@@ -766,47 +862,7 @@ def create_app(
             except Exception as e:
                 logger.warning(f"OrgRuntime startup error (non-fatal): {e}")
 
-        # Endpoint health check: detect stale/broken endpoints early
-        try:
-            _agent = getattr(app.state, "agent", None)
-            _brain = getattr(_agent, "brain", None) if _agent else None
-            _llm_client = getattr(_brain, "_llm_client", None) if _brain else None
-            if _llm_client and hasattr(_llm_client, "startup_health_check"):
-                _results = await _llm_client.startup_health_check()
-                _ok = sum(1 for v in _results.values() if v == "ok")
-                _fail = len(_results) - _ok
-                if _fail:
-                    logger.warning(
-                        f"[Startup] Endpoint health check: {_ok} ok, {_fail} failed — "
-                        f"{', '.join(f'{k}={v}' for k, v in _results.items() if v != 'ok')}"
-                    )
-                else:
-                    logger.info(f"[Startup] All {_ok} endpoints healthy")
-        except Exception as e:
-            logger.debug(f"[Startup] Endpoint health check skipped: {e}")
-
-        # Compiler endpoint health check
-        try:
-            _agent = getattr(app.state, "agent", None)
-            _brain = getattr(_agent, "brain", None) if _agent else None
-            _compiler_client = getattr(_brain, "_compiler_client", None) if _brain else None
-            if _compiler_client and hasattr(_compiler_client, "startup_health_check"):
-                comp_result = await _compiler_client.startup_health_check()
-                comp_failed = {k: v for k, v in comp_result.items() if v != "ok"}
-                if comp_failed:
-                    for ep_name, status in comp_failed.items():
-                        _brain._compiler_on_failure(f"startup: {ep_name}={status}")
-                    logger.warning(
-                        f"[Startup] Compiler health check failed: "
-                        f"{', '.join(f'{k}={v}' for k, v in comp_failed.items())}. "
-                        f"Compiler tasks will use main model."
-                    )
-                else:
-                    logger.info(
-                        f"[Startup] Compiler endpoints all healthy: {list(comp_result.keys())}"
-                    )
-        except Exception as e:
-            logger.debug(f"[Startup] Compiler health check skipped: {e}")
+        _schedule_startup_llm_health_check(app.state)
 
     @app.on_event("shutdown")
     async def _shutdown_org_runtime():
@@ -817,6 +873,10 @@ def create_app(
                 await to_engine(app.state.org_runtime.shutdown())
             except Exception as e:
                 logger.warning(f"OrgRuntime shutdown error: {e}")
+
+    @app.on_event("shutdown")
+    async def _shutdown_startup_llm_health_check():
+        await _cancel_startup_llm_health_check(app.state)
 
     @app.on_event("shutdown")
     async def _shutdown_policy_hot_reloader():

--- a/src/openakita/core/agent.py
+++ b/src/openakita/core/agent.py
@@ -1449,6 +1449,7 @@ class Agent:
 
         # 状态
         self._initialized = False
+        self._initialize_lock = asyncio.Lock()
         self._running = False
 
         self._last_finalized_trace: list[dict] = []
@@ -2084,6 +2085,21 @@ class Agent:
         if self._initialized:
             return
 
+        async with self._initialize_lock:
+            if self._initialized:
+                return
+            await self._initialize_unlocked(
+                start_scheduler=start_scheduler,
+                lightweight=lightweight,
+                share_from=share_from,
+            )
+
+    async def _initialize_unlocked(
+        self,
+        start_scheduler: bool = True,
+        lightweight: bool = False,
+        share_from: "Agent | None" = None,
+    ) -> None:
         if share_from is not None and not lightweight:
             # share_from 隐含 lightweight：full-init 路径会再次跑一遍
             # _load_plugins，等于白白浪费 share_from 的缓存。这里直接报错让

--- a/src/openakita/core/agent.py
+++ b/src/openakita/core/agent.py
@@ -2836,19 +2836,33 @@ class Agent:
 
         clear_all_skill_caches()
 
-        if rescan:
-            try:
-                self.skill_loader.load_all(settings.project_root)
-            except Exception as e:
-                logger.warning("propagate_skill_change: load_all failed: %s", e)
-
+        external_allowlist = None
+        effective = None
+        agent_skills: set[str] = set()
         try:
             from ..skills.allowlist_io import read_allowlist
             from ..skills.preset_utils import collect_preset_referenced_skills
 
             _, external_allowlist = read_allowlist()
-            effective = self.skill_loader.compute_effective_allowlist(external_allowlist)
             agent_skills = collect_preset_referenced_skills()
+            if external_allowlist is not None:
+                effective = self.skill_loader.compute_effective_allowlist(external_allowlist)
+        except Exception as e:
+            logger.warning("propagate_skill_change: allowlist pre-read failed: %s", e)
+
+        if rescan:
+            try:
+                load_filter = self.skill_loader.build_preparse_allowlist_filter(
+                    effective,
+                    agent_referenced_skills=agent_skills,
+                )
+                self.skill_loader.load_all(settings.project_root, load_filter=load_filter)
+            except Exception as e:
+                logger.warning("propagate_skill_change: load_all failed: %s", e)
+
+        try:
+            if effective is None:
+                effective = self.skill_loader.compute_effective_allowlist(external_allowlist)
             self.skill_loader.prune_external_by_allowlist(
                 effective, agent_referenced_skills=agent_skills
             )

--- a/src/openakita/core/skill_manager.py
+++ b/src/openakita/core/skill_manager.py
@@ -88,10 +88,11 @@ class SkillManager:
         - skills/ (项目级别)
         - .cursor/skills/ (Cursor 兼容)
         """
-        loaded = self._loader.load_all(settings.project_root)
-        logger.info(f"Loaded {loaded} skills from standard directories")
-
-        # 外部技能 allowlist 过滤（支持 DEFAULT_DISABLED_SKILLS 默认禁用）
+        # 外部技能 allowlist 过滤（支持 DEFAULT_DISABLED_SKILLS 默认禁用）。
+        # 先读取 allowlist，并在扫描阶段跳过未启用的外部技能，避免启动时
+        # 解析/注册几百个随后会被 prune 掉的 SKILL.md。
+        agent_skills: set[str] = set()
+        effective: set[str] | None = None
         try:
             cfg_path = settings.project_root / "data" / "skills.json"
             external_allowlist: set[str] | None = None
@@ -101,10 +102,24 @@ class SkillManager:
                 al = cfg.get("external_allowlist", None)
                 if isinstance(al, list):
                     external_allowlist = {str(x).strip() for x in al if str(x).strip()}
-            effective = self._loader.compute_effective_allowlist(external_allowlist)
             from openakita.skills.preset_utils import collect_preset_referenced_skills
 
             agent_skills = collect_preset_referenced_skills()
+            if external_allowlist is not None:
+                effective = self._loader.compute_effective_allowlist(external_allowlist)
+        except Exception as e:
+            logger.warning(f"Failed to read skills allowlist before scan: {e}")
+
+        load_filter = self._loader.build_preparse_allowlist_filter(
+            effective,
+            agent_referenced_skills=agent_skills,
+        )
+        loaded = self._loader.load_all(settings.project_root, load_filter=load_filter)
+        logger.info(f"Loaded {loaded} skills from standard directories")
+
+        try:
+            if effective is None:
+                effective = self._loader.compute_effective_allowlist(None)
             removed = self._loader.prune_external_by_allowlist(
                 effective,
                 agent_referenced_skills=agent_skills,
@@ -112,7 +127,7 @@ class SkillManager:
             if removed:
                 logger.info(f"External skills filtered: {removed} disabled")
         except Exception as e:
-            logger.warning(f"Failed to apply skills allowlist: {e}")
+            logger.warning(f"Failed to apply skills allowlist after scan: {e}")
 
         self._catalog_text = self._catalog.generate_catalog()
         logger.info(f"Generated skill catalog with {self._catalog.skill_count} skills")

--- a/src/openakita/main.py
+++ b/src/openakita/main.py
@@ -1973,20 +1973,10 @@ def serve(
         )
 
         agent = get_agent()
-
-        console.print("[bold green]正在初始化 Agent...[/bold green]")
-        await agent.initialize()
-        console.print(f"[green]✓[/green] Agent 已初始化 (技能: {agent.skill_registry.count})")
-
         agent_or_master = agent
 
-        # 初始化核心服务（SessionManager、Agent Pool、Orchestrator）
-        console.print("[bold green]正在初始化核心服务...[/bold green]")
-        await init_core_services(agent_or_master)
-        console.print("[green]✓[/green] 核心服务已就绪")
-
-        # 先启动 HTTP API（供 Setup Center/桌面端使用）。
-        # IM 通道依赖安装可能很慢，不能阻塞 /api/health 就绪。
+        # 先启动 HTTP API（供 Setup Center/桌面端使用）。Agent 初始化、
+        # 核心服务和 IM 通道可能很慢，不能阻塞 /api/health 与 Web UI 就绪。
         api_task = None
         _api_fatal = False
         try:
@@ -2023,12 +2013,12 @@ def serve(
                     )
 
             api_task = await start_api_server(
-                agent=agent_or_master,
+                agent=None,
                 shutdown_event=shutdown_event,
-                session_manager=_session_manager,
-                gateway=_message_gateway,
-                orchestrator=_orchestrator,
-                agent_pool=_desktop_pool,
+                session_manager=None,
+                gateway=None,
+                orchestrator=None,
+                agent_pool=None,
                 host=_api_host,
                 port=_api_port,
             )
@@ -2037,14 +2027,31 @@ def serve(
                 f"[green]✓[/green] HTTP API 已启动: http://{_display_host}:{_api_port}"
                 + ("  [dim](lan_mode: 0.0.0.0)[/dim]" if _api_host == "0.0.0.0" else "")
             )
-            # HTTP API 已可访问，但 IM 通道、晚绑定 gateway、部分后台服务可能仍在启动。
+            # HTTP API 已可访问，但 Agent、核心服务、IM 通道仍在启动。
             # 不要在这里把 phase 标成 running，否则前端会把"HTTP ready"误解为
-            # "整个后端已完成启动"，这正是状态面板反复出现假运行/未知 IM 的根因。
-            _heartbeat_phase = "http_ready"
+            # "整个后端已完成启动"。
+            _heartbeat_phase = "agent_initializing"
             _heartbeat_http_ready = True
             _heartbeat_im_ready = False
             _heartbeat_ready = False
             _write_heartbeat()  # 立即刷新心跳，标记 HTTP 就绪
+            try:
+                from openakita.api.server import update_runtime_refs
+
+                update_runtime_refs(
+                    api_task,
+                    startup_phase="agent_initializing",
+                    readiness={
+                        "phase": "agent_initializing",
+                        "http_ready": True,
+                        "agent_ready": False,
+                        "core_ready": False,
+                        "im_ready": False,
+                        "ready": False,
+                    },
+                )
+            except Exception:
+                logger.debug("Failed to update API startup readiness", exc_info=True)
         except ImportError:
             console.print("[yellow]⚠[/yellow] HTTP API 未启动（缺少 fastapi/uvicorn 依赖）")
         except Exception as e:
@@ -2061,6 +2068,57 @@ def serve(
             shutdown_event.set()
 
         if not _api_fatal:
+            console.print("[bold green]正在初始化 Agent...[/bold green]")
+            await agent.initialize()
+            console.print(f"[green]✓[/green] Agent 已初始化 (技能: {agent.skill_registry.count})")
+
+            if api_task is not None:
+                try:
+                    from openakita.api.server import update_runtime_refs
+
+                    update_runtime_refs(
+                        api_task,
+                        agent=agent_or_master,
+                        startup_phase="core_initializing",
+                        readiness={
+                            "phase": "core_initializing",
+                            "http_ready": True,
+                            "agent_ready": True,
+                            "core_ready": False,
+                            "im_ready": False,
+                            "ready": False,
+                        },
+                    )
+                except Exception:
+                    logger.debug("Failed to update API agent readiness", exc_info=True)
+
+            # 初始化核心服务（SessionManager、Agent Pool、Orchestrator）
+            console.print("[bold green]正在初始化核心服务...[/bold green]")
+            await init_core_services(agent_or_master)
+            console.print("[green]✓[/green] 核心服务已就绪")
+
+            if api_task is not None:
+                try:
+                    from openakita.api.server import update_runtime_refs
+
+                    update_runtime_refs(
+                        api_task,
+                        session_manager=_session_manager,
+                        orchestrator=_orchestrator,
+                        agent_pool=_desktop_pool,
+                        startup_phase="http_ready",
+                        readiness={
+                            "phase": "http_ready",
+                            "http_ready": True,
+                            "agent_ready": True,
+                            "core_ready": True,
+                            "im_ready": False,
+                            "ready": False,
+                        },
+                    )
+                except Exception:
+                    logger.debug("Failed to update API core readiness", exc_info=True)
+
             # 启动 IM 通道（可选）。放在 HTTP API 之后，避免首次安装通道依赖时
             # 桌面端长时间无法访问本地健康检查。
             _heartbeat_phase = "starting_im"

--- a/src/openakita/skills/loader.py
+++ b/src/openakita/skills/loader.py
@@ -26,6 +26,8 @@ _CURRENT_PLATFORM = sys.platform  # "win32", "darwin", "linux"
 
 logger = logging.getLogger(__name__)
 
+_RuntimeRegistryRecord = dict[str, object]
+
 
 @dataclass
 class SkillLoadIssue:
@@ -297,6 +299,7 @@ class SkillLoader:
 
         directories = self.discover_skill_directories(base_path)
         loaded = 0
+        runtime_records: list[_RuntimeRegistryRecord] = []
 
         for skill_dir in directories:
             # __builtin__ / skills/system/ 等只读源以及被识别为 system 的根
@@ -311,13 +314,19 @@ class SkillLoader:
             loaded += self.load_from_directory(
                 skill_dir,
                 _readonly=is_readonly_root,
+                _runtime_registry_records=runtime_records,
             )
 
-        loaded += self._load_cli_anything_skills()
+        loaded += self._load_cli_anything_skills(_runtime_registry_records=runtime_records)
+        self._flush_runtime_registry_records(runtime_records)
 
         return loaded
 
-    def _load_cli_anything_skills(self) -> int:
+    def _load_cli_anything_skills(
+        self,
+        *,
+        _runtime_registry_records: list[_RuntimeRegistryRecord] | None = None,
+    ) -> int:
         """Discover and load SKILL.md files from pip-installed cli-anything-* packages.
 
         CLI-Anything generates SKILL.md alongside each CLI harness. When installed
@@ -351,7 +360,11 @@ class SkillLoader:
                         full_path = rel_path.locate()
                         if isinstance(full_path, Path) and full_path.exists():
                             skill_dir = full_path.parent
-                            skill = self.load_skill(skill_dir, force=True)
+                            skill = self.load_skill(
+                                skill_dir,
+                                force=True,
+                                _runtime_registry_records=_runtime_registry_records,
+                            )
                             if skill:
                                 loaded += 1
                                 logger.info(
@@ -364,12 +377,24 @@ class SkillLoader:
             logger.info(f"Loaded {loaded} cli-anything skills from pip packages")
         return loaded
 
+    @staticmethod
+    def _flush_runtime_registry_records(records: list[_RuntimeRegistryRecord]) -> None:
+        if not records:
+            return
+        try:
+            from .runtime_registry import mark_skills_loaded
+
+            mark_skills_loaded(records)
+        except Exception:
+            logger.debug("Failed to update skill runtime registry batch", exc_info=True)
+
     def load_from_directory(
         self,
         directory: Path,
         *,
         force: bool = True,
         _readonly: bool = False,
+        _runtime_registry_records: list[_RuntimeRegistryRecord] | None = None,
     ) -> int:
         """从目录递归加载所有技能。
 
@@ -396,6 +421,8 @@ class SkillLoader:
             return 0
 
         loaded = 0
+        runtime_records = _runtime_registry_records if _runtime_registry_records is not None else []
+        flush_runtime_records = _runtime_registry_records is None
 
         for item in directory.iterdir():
             if not item.is_dir():
@@ -404,7 +431,11 @@ class SkillLoader:
             skill_md = item / "SKILL.md"
             if skill_md.exists():
                 try:
-                    skill = self.load_skill(item, force=force)
+                    skill = self.load_skill(
+                        item,
+                        force=force,
+                        _runtime_registry_records=runtime_records,
+                    )
                     if skill:
                         loaded += 1
                         cat = skill.metadata.category
@@ -429,6 +460,7 @@ class SkillLoader:
                     item,
                     force=force,
                     _readonly=child_readonly,
+                    _runtime_registry_records=runtime_records,
                 )
             elif item.name.startswith(".") or item.name.startswith("_"):
                 continue
@@ -437,8 +469,11 @@ class SkillLoader:
                     item,
                     force=force,
                     _readonly=_readonly,
+                    _runtime_registry_records=runtime_records,
                 )
 
+        if flush_runtime_records:
+            self._flush_runtime_registry_records(runtime_records)
         logger.info(f"Loaded {loaded} skills from {directory}")
         return loaded
 
@@ -458,6 +493,7 @@ class SkillLoader:
         *,
         plugin_source: str | None = None,
         force: bool = False,
+        _runtime_registry_records: list[_RuntimeRegistryRecord] | None = None,
     ) -> ParsedSkill | None:
         """加载单个技能。
 
@@ -543,15 +579,19 @@ class SkillLoader:
 
             self._loaded_skills[sid] = skill
             try:
-                from .runtime_registry import mark_skill_loaded
-
                 deps = getattr(skill.metadata, "python_dependencies", []) or []
-                mark_skill_loaded(
-                    sid,
-                    source_path=str(skill_dir),
-                    enabled=True,
-                    dependencies=deps,
-                )
+                record: _RuntimeRegistryRecord = {
+                    "skill_id": sid,
+                    "source_path": str(skill_dir),
+                    "enabled": True,
+                    "dependencies": list(deps),
+                }
+                if _runtime_registry_records is not None:
+                    _runtime_registry_records.append(record)
+                else:
+                    from .runtime_registry import mark_skills_loaded
+
+                    mark_skills_loaded([record])
             except Exception:
                 logger.debug("Failed to update skill runtime registry for %s", sid, exc_info=True)
             logger.info(f"Loaded skill: {sid} (name={skill.metadata.name})")

--- a/src/openakita/skills/loader.py
+++ b/src/openakita/skills/loader.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +28,7 @@ _CURRENT_PLATFORM = sys.platform  # "win32", "darwin", "linux"
 logger = logging.getLogger(__name__)
 
 _RuntimeRegistryRecord = dict[str, object]
+SkillLoadFilter = Callable[[Path], bool]
 
 
 @dataclass
@@ -275,7 +277,12 @@ class SkillLoader:
 
         return directories
 
-    def load_all(self, base_path: Path | None = None) -> int:
+    def load_all(
+        self,
+        base_path: Path | None = None,
+        *,
+        load_filter: SkillLoadFilter | None = None,
+    ) -> int:
         """
         从所有标准目录加载技能
 
@@ -314,6 +321,7 @@ class SkillLoader:
             loaded += self.load_from_directory(
                 skill_dir,
                 _readonly=is_readonly_root,
+                load_filter=load_filter,
                 _runtime_registry_records=runtime_records,
             )
 
@@ -394,6 +402,7 @@ class SkillLoader:
         *,
         force: bool = True,
         _readonly: bool = False,
+        load_filter: SkillLoadFilter | None = None,
         _runtime_registry_records: list[_RuntimeRegistryRecord] | None = None,
     ) -> int:
         """从目录递归加载所有技能。
@@ -430,6 +439,9 @@ class SkillLoader:
 
             skill_md = item / "SKILL.md"
             if skill_md.exists():
+                if load_filter is not None and not load_filter(item):
+                    logger.debug("Skipped skill before parse by load filter: %s", item)
+                    continue
                 try:
                     skill = self.load_skill(
                         item,
@@ -460,6 +472,7 @@ class SkillLoader:
                     item,
                     force=force,
                     _readonly=child_readonly,
+                    load_filter=load_filter,
                     _runtime_registry_records=runtime_records,
                 )
             elif item.name.startswith(".") or item.name.startswith("_"):
@@ -469,6 +482,7 @@ class SkillLoader:
                     item,
                     force=force,
                     _readonly=_readonly,
+                    load_filter=load_filter,
                     _runtime_registry_records=runtime_records,
                 )
 
@@ -476,6 +490,69 @@ class SkillLoader:
             self._flush_runtime_registry_records(runtime_records)
         logger.info(f"Loaded {loaded} skills from {directory}")
         return loaded
+
+    @staticmethod
+    def _cheap_skill_id_candidates(skill_dir: Path) -> set[str]:
+        """Return allowlist keys for a skill directory without parsing SKILL.md."""
+        candidates = {skill_dir.name}
+        parts = list(skill_dir.parts)
+
+        for index, part in enumerate(parts):
+            if part in RESERVED_NAMESPACE_DIRS and index < len(parts) - 1:
+                rel = Path(*parts[index + 1 :]).as_posix()
+                if rel:
+                    candidates.add(rel)
+
+        # Most bundled external skills use namespaced metadata in the form
+        # ``openakita/skills@<dir>``. Preset profiles and default allowlists use
+        # that key, so matching it here avoids reading SKILL.md just to learn it.
+        candidates.add(f"openakita/skills@{skill_dir.name}")
+        candidates.add(f"jimliu/baoyu-skills@{skill_dir.name}")
+        candidates.add(f"obra/superpowers@{skill_dir.name.removeprefix('superpowers-')}")
+
+        try:
+            skill_md = skill_dir / "SKILL.md"
+            with skill_md.open("r", encoding="utf-8") as handle:
+                for _ in range(24):
+                    line = handle.readline()
+                    if not line or line.strip() == "---" and _ > 0:
+                        break
+                    if line.lstrip().startswith("name:"):
+                        raw_name = line.split(":", 1)[1].strip().strip("\"'")
+                        if raw_name:
+                            candidates.add(raw_name)
+                        break
+        except Exception:
+            pass
+
+        return {c for c in candidates if c}
+
+    @staticmethod
+    def build_preparse_allowlist_filter(
+        external_allowlist: set[str] | None,
+        *,
+        agent_referenced_skills: set[str] | None = None,
+    ) -> SkillLoadFilter | None:
+        """Build a filter that skips disabled external skills before parsing.
+
+        ``None`` preserves legacy all-external loading. When a set is provided,
+        system skills are always kept, explicitly allowed skills are loaded, and
+        preset-referenced skills are loaded so the later prune step can mark
+        them disabled instead of removing them from sub-agent discovery.
+        """
+        if external_allowlist is None:
+            return None
+
+        allowed = {str(s).strip() for s in external_allowlist if str(s).strip()}
+        keep_extra = {str(s).strip() for s in agent_referenced_skills or set() if str(s).strip()}
+
+        def _filter(skill_dir: Path) -> bool:
+            if "system" in skill_dir.parts:
+                return True
+            candidates = SkillLoader._cheap_skill_id_candidates(skill_dir)
+            return bool(candidates & allowed) or bool(candidates & keep_extra)
+
+        return _filter
 
     @staticmethod
     def _is_os_compatible(supported_os: list[str]) -> bool:

--- a/src/openakita/skills/runtime_registry.py
+++ b/src/openakita/skills/runtime_registry.py
@@ -42,23 +42,21 @@ def _deps_hash(deps: list[str] | tuple[str, ...] | None) -> str:
     return hashlib.sha256("\n".join(deps_t).encode("utf-8")).hexdigest()[:16]
 
 
-def mark_skill_loaded(
-    skill_id: str,
-    *,
-    source_path: str,
-    enabled: bool = True,
-    dependencies: list[str] | tuple[str, ...] | None = None,
-) -> None:
-    data = _read()
-    skills = data.setdefault("skills", {})
+def _apply_loaded_record(skills: dict[str, Any], record: dict[str, Any], now: int) -> None:
+    skill_id = str(record.get("skill_id") or "").strip()
+    if not skill_id:
+        return
+
     current = skills.get(skill_id) if isinstance(skills.get(skill_id), dict) else {}
-    now = int(time.time())
+    dependencies = record.get("dependencies")
+    if not isinstance(dependencies, (list, tuple)):
+        dependencies = []
     current.update(
         {
             "skill_id": skill_id,
-            "source_path": source_path,
+            "source_path": str(record.get("source_path") or ""),
             "installed": True,
-            "enabled": enabled,
+            "enabled": bool(record.get("enabled", True)),
             "loaded": True,
             "dependencies": list(dependencies or []),
             "deps_hash": _deps_hash(dependencies),
@@ -71,7 +69,40 @@ def mark_skill_loaded(
     current.setdefault("installed_at", now)
     current.setdefault("update_policy", "disk-only")
     skills[skill_id] = current
+
+
+def mark_skills_loaded(records: list[dict[str, Any]]) -> None:
+    """Mark many skills loaded with a single registry read/write."""
+    if not records:
+        return
+    data = _read()
+    skills = data.setdefault("skills", {})
+    if not isinstance(skills, dict):
+        skills = {}
+        data["skills"] = skills
+    now = int(time.time())
+    for record in records:
+        _apply_loaded_record(skills, record, now)
     _write(data)
+
+
+def mark_skill_loaded(
+    skill_id: str,
+    *,
+    source_path: str,
+    enabled: bool = True,
+    dependencies: list[str] | tuple[str, ...] | None = None,
+) -> None:
+    mark_skills_loaded(
+        [
+            {
+                "skill_id": skill_id,
+                "source_path": source_path,
+                "enabled": enabled,
+                "dependencies": list(dependencies or []),
+            }
+        ]
+    )
 
 
 def mark_skill_pending_update(

--- a/tests/integration/test_skill_hot_reload.py
+++ b/tests/integration/test_skill_hot_reload.py
@@ -14,9 +14,6 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
-import pytest
-
-
 # ---------------------------------------------------------------------------
 # 工具：生成合法的外部技能目录
 # ---------------------------------------------------------------------------
@@ -156,6 +153,51 @@ class TestScenarioEnableDisable:
         assert loader.get_skill("a") is None
         assert loader.get_skill("b") is None
 
+    def test_preparse_allowlist_filter_skips_disabled_external_before_yaml_parse(
+        self, tmp_path: Path
+    ):
+        """启动过滤应在解析 SKILL.md 前跳过未允许的外部技能。"""
+        from openakita.skills.loader import SkillLoader
+
+        skills_root = tmp_path / "skills"
+        _write_skill(skills_root / "keep-me", "keep-me", "Allowed")
+
+        bad_dir = skills_root / "bad-disabled"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "SKILL.md").write_text(
+            "---\nname: Bad Disabled\ndescription: invalid name\n---\nBroken.",
+            encoding="utf-8",
+        )
+
+        loader = SkillLoader()
+        load_filter = loader.build_preparse_allowlist_filter({"keep-me"})
+
+        assert loader.load_from_directory(skills_root, load_filter=load_filter) == 1
+        assert loader.get_skill("keep-me") is not None
+        assert loader.get_skill("bad-disabled") is None
+        assert loader.last_load_issues == []
+
+    def test_preparse_allowlist_filter_keeps_preset_referenced_skills_disabled_later(
+        self, tmp_path: Path
+    ):
+        """预设引用的外部技能仍需加载，后续 prune 才能标记 disabled。"""
+        from openakita.skills.loader import SkillLoader
+
+        skills_root = tmp_path / "skills"
+        _write_skill(skills_root / "agent-only", "agent-only", "Used by preset")
+
+        loader = SkillLoader()
+        load_filter = loader.build_preparse_allowlist_filter(
+            set(),
+            agent_referenced_skills={"agent-only"},
+        )
+
+        assert loader.load_from_directory(skills_root, load_filter=load_filter) == 1
+        loader.prune_external_by_allowlist(set(), agent_referenced_skills={"agent-only"})
+        entry = loader.registry.get("agent-only")
+        assert entry is not None
+        assert entry.disabled is True
+
     def test_allowlist_io_round_trip(self, tmp_path: Path, monkeypatch):
         """综合：通过 allowlist_io 写入 → read_allowlist 读出 → 用于 prune。"""
         from openakita.config import settings as real_settings
@@ -230,7 +272,7 @@ class TestScenarioContentHotReload:
         assert first.metadata.description == "v1"
 
         _write_skill(skills_root / "cached", "cached", "v2", body="B2")
-        second = parser.parse_directory(skills_root / "cached")
+        parser.parse_directory(skills_root / "cached")
 
         # 若内部有缓存，second 可能仍是 v1——但这里我们只需断言 clear 之后能拿到 v2。
         from openakita.skills.watcher import clear_all_skill_caches

--- a/tests/unit/test_runtime_env_isolation.py
+++ b/tests/unit/test_runtime_env_isolation.py
@@ -13,6 +13,7 @@ from openakita.skills.parser import parse_skill
 from openakita.skills.runtime_registry import (
     mark_skill_loaded,
     mark_skill_pending_update,
+    mark_skills_loaded,
     read_skill_runtime_registry,
 )
 
@@ -132,6 +133,47 @@ def test_skill_runtime_registry_tracks_loaded_and_pending_update(monkeypatch, tm
     assert state["reload_required"] is True
     assert state["update_policy"] == "disk-only"
     assert state["deps_hash"]
+
+
+def test_skill_runtime_registry_batches_loaded_records(monkeypatch, tmp_path):
+    monkeypatch.setattr("openakita.skills.runtime_registry._get_openakita_root", lambda: tmp_path)
+
+    mark_skill_loaded(
+        "existing-skill",
+        source_path=str(tmp_path / "skills" / "existing-skill"),
+        dependencies=["requests"],
+    )
+    first_state = read_skill_runtime_registry()["skills"]["existing-skill"]
+    first_installed_at = first_state["installed_at"]
+
+    mark_skills_loaded(
+        [
+            {
+                "skill_id": "existing-skill",
+                "source_path": str(tmp_path / "skills" / "existing-skill-v2"),
+                "dependencies": ["requests", "pandas==2.2.0"],
+            },
+            {
+                "skill_id": "new-skill",
+                "source_path": str(tmp_path / "skills" / "new-skill"),
+                "enabled": False,
+                "dependencies": [],
+            },
+        ]
+    )
+
+    skills = read_skill_runtime_registry()["skills"]
+    existing = skills["existing-skill"]
+    assert existing["installed_at"] == first_installed_at
+    assert existing["source_path"].endswith("existing-skill-v2")
+    assert existing["dependencies"] == ["requests", "pandas==2.2.0"]
+    assert existing["reload_required"] is False
+
+    new_skill = skills["new-skill"]
+    assert new_skill["installed"] is True
+    assert new_skill["loaded"] is True
+    assert new_skill["enabled"] is False
+    assert new_skill["update_policy"] == "disk-only"
 
 
 def test_tool_experience_redacts_secrets(tmp_path):

--- a/tests/unit/test_serve_startup_order.py
+++ b/tests/unit/test_serve_startup_order.py
@@ -1,0 +1,82 @@
+import asyncio
+from types import SimpleNamespace
+
+from fastapi import APIRouter
+from httpx import ASGITransport, AsyncClient
+
+from openakita.api.server import create_app, update_runtime_refs
+from openakita.core.agent import Agent
+
+
+async def test_update_runtime_refs_attaches_late_agent_plugin_routes() -> None:
+    app = create_app(agent=None)
+
+    router = APIRouter()
+
+    @router.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    plugin_manager = SimpleNamespace(
+        _external_host_refs={"_pending_plugin_routers": [("late_plugin", router)]}
+    )
+    agent = SimpleNamespace(_plugin_manager=plugin_manager)
+    api_task = SimpleNamespace(_openakita_api_app=app)
+
+    assert update_runtime_refs(api_task, agent=agent) is True
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        resp = await client.get("/api/plugins/late_plugin/ping")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert app.state.agent is agent
+    assert plugin_manager._external_host_refs["api_app"] is app
+    assert "_pending_plugin_routers" not in plugin_manager._external_host_refs
+
+
+def test_update_runtime_refs_rebinds_org_command_session_manager() -> None:
+    app = create_app(agent=None, session_manager=None)
+    api_task = SimpleNamespace(_openakita_api_app=app)
+    session_manager = object()
+
+    assert app.state.org_command_service._session_manager is None
+    assert update_runtime_refs(api_task, session_manager=session_manager) is True
+
+    assert app.state.session_manager is session_manager
+    assert app.state.org_command_service._session_manager is session_manager
+
+
+async def test_agent_initialize_is_single_flight(monkeypatch) -> None:
+    agent = Agent.__new__(Agent)
+    agent._initialized = False
+    agent._initialize_lock = asyncio.Lock()
+
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_initialize_unlocked(self, **kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        self._initialized = True
+
+    monkeypatch.setattr(Agent, "_initialize_unlocked", fake_initialize_unlocked)
+
+    first = asyncio.create_task(agent.initialize())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    second = asyncio.create_task(agent.initialize())
+
+    await asyncio.sleep(0)
+    assert calls == 1
+
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert calls == 1
+    assert agent._initialized is True

--- a/tests/unit/test_skill_manager_allowlist_filter.py
+++ b/tests/unit/test_skill_manager_allowlist_filter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class _FakeLoader:
+    def __init__(self) -> None:
+        self.load_filter = None
+        self.pruned = None
+
+    def compute_effective_allowlist(self, external_allowlist):
+        return external_allowlist
+
+    def build_preparse_allowlist_filter(self, external_allowlist, *, agent_referenced_skills=None):
+        def _filter(_path: Path) -> bool:
+            return True
+
+        self.filter_args = (external_allowlist, agent_referenced_skills)
+        return _filter
+
+    def load_all(self, _root, *, load_filter=None):
+        self.load_filter = load_filter
+        return 3
+
+    def prune_external_by_allowlist(self, external_allowlist, agent_referenced_skills=None):
+        self.pruned = (external_allowlist, agent_referenced_skills)
+        return 0
+
+
+class _FakeCatalog:
+    skill_count = 3
+
+    def generate_catalog(self):
+        return "catalog"
+
+
+@pytest.mark.asyncio
+async def test_skill_manager_passes_allowlist_filter_before_loading(tmp_path, monkeypatch):
+    from openakita.config import settings
+    from openakita.core.skill_manager import SkillManager
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "skills.json").write_text(
+        json.dumps({"version": 1, "external_allowlist": ["keep-me"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings, "project_root", tmp_path, raising=False)
+    monkeypatch.setattr(
+        "openakita.skills.preset_utils.collect_preset_referenced_skills",
+        lambda: {"preset-only"},
+    )
+
+    loader = _FakeLoader()
+    manager = SkillManager(None, loader, _FakeCatalog(), None)
+
+    await manager.load_installed_skills()
+
+    assert loader.filter_args == ({"keep-me"}, {"preset-only"})
+    assert loader.load_filter is not None
+    assert loader.pruned == ({"keep-me"}, {"preset-only"})
+    assert manager.catalog_text == "catalog"

--- a/tests/unit/test_startup_llm_health_check_background.py
+++ b/tests/unit/test_startup_llm_health_check_background.py
@@ -1,0 +1,67 @@
+import asyncio
+from types import SimpleNamespace
+
+from openakita.api.server import (
+    _cancel_startup_llm_health_check,
+    _schedule_startup_llm_health_check,
+    create_app,
+)
+
+
+class BlockingHealthClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.cancelled = False
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def startup_health_check(self) -> dict[str, str]:
+        self.calls += 1
+        self.started.set()
+        try:
+            await self.release.wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        return {"main": "ok"}
+
+
+async def test_startup_hook_schedules_llm_health_check_without_waiting() -> None:
+    client = BlockingHealthClient()
+    brain = SimpleNamespace(_llm_client=client, _compiler_client=None)
+    app = create_app(agent=SimpleNamespace(brain=brain))
+    app.state.org_runtime = None
+
+    startup_hook = next(
+        hook for hook in app.router.on_startup if hook.__name__ == "_startup_org_runtime"
+    )
+
+    await startup_hook()
+
+    task = app.state.llm_startup_health_check_task
+    assert task is not None
+    assert not task.done()
+    assert client.calls == 0
+
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+    await _cancel_startup_llm_health_check(app.state)
+
+    assert client.cancelled is True
+    assert app.state.llm_startup_health_check_task is None
+
+
+async def test_shutdown_cancel_stops_pending_startup_llm_health_check() -> None:
+    client = BlockingHealthClient()
+    brain = SimpleNamespace(_llm_client=client, _compiler_client=None)
+    state = SimpleNamespace(agent=SimpleNamespace(brain=brain))
+
+    task = _schedule_startup_llm_health_check(state)
+    assert task is not None
+
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+    await _cancel_startup_llm_health_check(state)
+
+    assert task.cancelled()
+    assert client.cancelled is True
+    assert state.llm_startup_health_check_task is None
+


### PR DESCRIPTION
## Summary

- Start the HTTP API before serve-agent initialization so the server becomes reachable sooner.
- Move startup LLM health checks into the background and add regression coverage for the startup order.
- Reduce startup skill-registry overhead by skipping disabled external skills earlier and batching runtime registry writes.
- Add an external-backend development mode for the Setup Center Tauri app.

## Tests

- Not run as part of this push/PR step.