### PR TITLE
fix session persistence to serialize concurrent sessions.json saves

### DIFF
--- a/src/openakita/sessions/manager.py
+++ b/src/openakita/sessions/manager.py
@@ -94,6 +94,7 @@ class SessionManager:
         # 活跃会话缓存 {session_key: Session}
         self._sessions: dict[str, Session] = {}
         self._sessions_lock = threading.RLock()
+        self._save_sessions_lock = threading.RLock()
 
         # 通道注册表：记录每个 IM 通道最后已知的 chat_id / user_id
         # 不受 session 过期清理影响，用于定时任务等场景回溯通道目标
@@ -999,21 +1000,25 @@ class SessionManager:
         使用临时文件 + 重命名的方式，确保写入过程中断不会损坏原文件。
         返回 True 表示保存成功，False 表示失败（调用方应重试）。
         """
-        sessions_file = self.storage_path / "sessions.json"
-        try:
-            data = [session.to_dict() for session in self._sessions.values()]
-            atomic_json_write(
-                sessions_file,
-                data,
-                fsync=True,
-                allow_fallback=False,
-            )
-            logger.debug(f"Saved {len(data)} sessions to storage (atomic fsync)")
-            return True
+        with self._save_sessions_lock:
+            sessions_file = self.storage_path / "sessions.json"
+            try:
+                with self._sessions_lock:
+                    sessions = list(self._sessions.values())
+                data = [session.to_dict() for session in sessions]
+                atomic_json_write(
+                    sessions_file,
+                    data,
+                    indent=None,
+                    fsync=True,
+                    allow_fallback=False,
+                )
+                logger.debug(f"Saved {len(data)} sessions to storage (atomic fsync)")
+                return True
 
-        except Exception as e:
-            logger.error(f"Failed to save sessions: {e}", exc_info=True)
-            return False
+            except Exception as e:
+                logger.error(f"Failed to save sessions: {e}", exc_info=True)
+                return False
 
     async def _save_sessions_async(self) -> None:
         """异步保存会话（在线程池中执行同步 I/O）"""

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -12,6 +12,7 @@ import logging
 import re
 import threading
 import uuid
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -369,26 +370,29 @@ class SessionContext:
 
     def to_dict(self) -> dict:
         """序列化"""
-        return {
-            "messages": self.messages,
-            "variables": self.variables,
-            "current_task": self.current_task,
-            "memory_scope": self.memory_scope,
-            "summary": self.summary,
-            "topic_boundaries": self.topic_boundaries,
-            "current_topic_start": self.current_topic_start,
-            "agent_profile_id": self.agent_profile_id,
-            "agent_switch_history": self.agent_switch_history,
-            "working_facts": self.working_facts,
-            "handoff_events": self.handoff_events,
-            "active_agents": self.active_agents,
-            "delegation_chain": self.delegation_chain,
-            "sub_agent_records": self.sub_agent_records,
-            "task_checkpoints": self.task_checkpoints,
-            "focus_terms": self.focus_terms,
-            "focus_updated_at": self.focus_updated_at,
-            "precompact_snapshot": self.precompact_snapshot,
-        }
+        with self._msg_lock:
+            return deepcopy(
+                {
+                    "messages": self.messages,
+                    "variables": self.variables,
+                    "current_task": self.current_task,
+                    "memory_scope": self.memory_scope,
+                    "summary": self.summary,
+                    "topic_boundaries": self.topic_boundaries,
+                    "current_topic_start": self.current_topic_start,
+                    "agent_profile_id": self.agent_profile_id,
+                    "agent_switch_history": self.agent_switch_history,
+                    "working_facts": self.working_facts,
+                    "handoff_events": self.handoff_events,
+                    "active_agents": self.active_agents,
+                    "delegation_chain": self.delegation_chain,
+                    "sub_agent_records": self.sub_agent_records,
+                    "task_checkpoints": self.task_checkpoints,
+                    "focus_terms": self.focus_terms,
+                    "focus_updated_at": self.focus_updated_at,
+                    "precompact_snapshot": self.precompact_snapshot,
+                }
+            )
 
     @classmethod
     def from_dict(cls, data: dict) -> "SessionContext":

--- a/src/openakita/utils/atomic_io.py
+++ b/src/openakita/utils/atomic_io.py
@@ -117,7 +117,7 @@ def atomic_json_write(
     path: Path,
     data: Any,
     *,
-    indent: int = 2,
+    indent: int | str | None = 2,
     backup: bool = True,
     fsync: bool = False,
     allow_fallback: bool = True,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,5 +1,8 @@
 """L1 Unit Tests: Session state machine, message management."""
 
+import json
+import threading
+import time
 from datetime import datetime
 
 import pytest
@@ -104,9 +107,59 @@ class TestSessionPersistence:
         assert manager._save_sessions() is True
 
         assert calls["path"] == tmp_path / "sessions" / "sessions.json"
+        assert calls["kwargs"]["indent"] is None
         assert calls["kwargs"]["fsync"] is True
         assert calls["kwargs"]["allow_fallback"] is False
         assert calls["data"][0]["context"]["messages"][0]["content"] == "hello"
+
+    def test_save_sessions_serializes_concurrent_writes(self, tmp_path, monkeypatch):
+        from openakita.utils.atomic_io import atomic_json_write as real_atomic_json_write
+
+        manager = SessionManager(storage_path=tmp_path / "sessions")
+        session = manager.get_session("cli", "chat-1", "user-1")
+        session.add_message("user", "hello")
+
+        failures = []
+        start = threading.Barrier(8)
+        counter_lock = threading.Lock()
+        active_writes = 0
+        max_active_writes = 0
+
+        def spy(path, data, **kwargs):
+            nonlocal active_writes, max_active_writes
+            with counter_lock:
+                active_writes += 1
+                max_active_writes = max(max_active_writes, active_writes)
+            try:
+                time.sleep(0.001)
+                real_atomic_json_write(path, data, **kwargs)
+            finally:
+                with counter_lock:
+                    active_writes -= 1
+
+        def worker(worker_id: int) -> None:
+            start.wait()
+            for i in range(20):
+                if not manager._save_sessions():
+                    failures.append((worker_id, i))
+
+        from openakita.sessions import manager as manager_module
+
+        monkeypatch.setattr(manager_module, "atomic_json_write", spy)
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        sessions_file = tmp_path / "sessions" / "sessions.json"
+        data = json.loads(sessions_file.read_text(encoding="utf-8"))
+
+        assert failures == []
+        assert max_active_writes == 1
+        assert len(data) == 1
+        assert data[0]["context"]["messages"][0]["content"] == "hello"
+        assert not sessions_file.with_suffix(sessions_file.suffix + ".tmp").exists()
 
     def test_persist_keeps_dirty_on_atomic_write_failure(self, tmp_path, monkeypatch):
         manager = SessionManager(storage_path=tmp_path / "sessions")
@@ -144,6 +197,15 @@ class TestSessionContext:
         ctx = SessionContext()
         ctx.variables["key"] = "value"
         assert ctx.variables["key"] == "value"
+
+    def test_to_dict_returns_independent_snapshot(self):
+        ctx = SessionContext()
+        ctx.messages.append({"role": "user", "content": {"text": "hello"}})
+        snapshot = ctx.to_dict()
+
+        ctx.messages[0]["content"]["text"] = "changed"
+
+        assert snapshot["messages"][0]["content"]["text"] == "hello"
 
     def test_task_lifecycle(self):
         ctx = SessionContext()


### PR DESCRIPTION
## Summary
- serialize `SessionManager._save_sessions()` with a manager-level reentrant lock so concurrent persist/debounce/threadpool saves cannot overlap
- write `sessions.json` with compact JSON to reduce the size and duration of each critical write
- snapshot `SessionContext.to_dict()` under the message lock with a deep copy so JSON encoding does not observe live mutable state
- add regression coverage for concurrent saves and snapshot isolation

## Tests
- `uv run ruff check src\openakita\utils\atomic_io.py src\openakita\sessions\manager.py src\openakita\sessions\session.py tests\unit\test_session.py`
- `uv run pytest tests\unit\test_session.py tests\unit\test_json_atomic_migration.py tests\component\test_session_persistence.py -q`

Fixes #663