### PR TITLE
fix skill refresh timeout from duplicate full scans

### DIFF
--- a/apps/setup-center/src/views/SkillManager.tsx
+++ b/apps/setup-center/src/views/SkillManager.tsx
@@ -1376,6 +1376,7 @@ export function SkillManager({
   // 已安装技能加载的请求时序守卫：并发的 loadSkills 中只有"最新"那次允许写入
   // 状态，避免较早发出的请求晚到后用旧/坏数据覆盖较新成功结果（last-write-wins 倒灌）。
   const skillsRequestId = useRef(0);
+  const refreshingRef = useRef(false);
   const detailRequestNameRef = useRef<string | null>(null);
   const { t } = useTranslation();
 
@@ -1492,7 +1493,7 @@ export function SkillManager({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "{}",
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(180_000),
       });
       let data: Record<string, unknown> | null = null;
       try {
@@ -1542,8 +1543,12 @@ export function SkillManager({
   // 否则静默 reload 技能与分类列表
   const enabledDirtyRef = useRef(enabledDirty);
   useEffect(() => { enabledDirtyRef.current = enabledDirty; }, [enabledDirty]);
+  useEffect(() => { refreshingRef.current = refreshing; }, [refreshing]);
   useEffect(() => {
     const onChange = () => {
+      if (refreshingRef.current) {
+        return;
+      }
       if (enabledDirtyRef.current) {
         toast.info(t("skills.realtimeDirtyHint"));
         return;
@@ -2479,7 +2484,7 @@ export function SkillManager({
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({}),
-                  signal: AbortSignal.timeout(15_000),
+                  signal: AbortSignal.timeout(180_000),
                 });
                 const data = await res.json();
                 if (data.error) { setError(friendlyError(data.error, t, "reload")); return; }

--- a/src/openakita/api/routes/skills.py
+++ b/src/openakita/api/routes/skills.py
@@ -43,14 +43,19 @@ registered at the bottom of this module."""
 
 _organize_cache: dict | None = None
 _organize_cache_hash: str | None = None
+_skills_list_task: asyncio.Task[dict] | None = None
+_skills_list_task_revision = 0
+_skills_reload_task: asyncio.Task[dict] | None = None
+_skills_cache_revision = 0
 
 
 def _invalidate_skills_cache() -> None:
     """Clear the cached skill list so the next GET /api/skills re-scans disk."""
-    global _skills_cache, _organize_cache, _organize_cache_hash
+    global _skills_cache, _organize_cache, _organize_cache_hash, _skills_cache_revision
     _skills_cache = None
     _organize_cache = None
     _organize_cache_hash = None
+    _skills_cache_revision += 1
 
 
 def _resolve_agent(request: Request):
@@ -131,6 +136,36 @@ async def _propagate(request: Request, action: str, *, rescan: bool = True) -> N
         logger.warning("propagate_skill_change(%s) failed: %s", action, e)
 
 
+async def _coalesce_task(name: str, task: asyncio.Task[dict]) -> dict:
+    """Await an in-flight task and log when this request joins existing work."""
+    logger.info("%s already in progress; joining existing task", name)
+    return await asyncio.shield(task)
+
+
+async def _reload_all_skills_response(request: Request, loader, registry) -> dict:
+    """Run the expensive full reload path and return the public API response."""
+    await _propagate(request, "reload", rescan=True)
+    total = len(registry.list_all())
+    issues = _skill_load_issues(loader)
+    result: dict = {
+        "status": "ok",
+        "reloaded": "all",
+        "total": total,
+    }
+    if issues:
+        result.update(
+            {
+                "partial": True,
+                "skipped_count": len(issues),
+                "skipped_skills": issues,
+                "warning": (
+                    f"已刷新可用技能，但有 {len(issues)} 个技能未加载。其他技能可正常使用。"
+                ),
+            }
+        )
+    return result
+
+
 def _skill_load_issues(loader, *, limit: int = 20) -> list[dict[str, str]]:
     """Return concise non-fatal skill load diagnostics from the active loader."""
     raw = getattr(loader, "last_load_issues", []) or []
@@ -183,21 +218,10 @@ async def _auto_translate_new_skills(request: Request, install_url: str) -> None
         logger.warning(f"Auto-translate after install failed: {e}")
 
 
-@router.get("/api/skills")
-async def list_skills(request: Request):
-    """List all available skills with their config schemas.
-
-    Returns ALL discovered skills (including disabled ones) with correct
-    ``enabled`` status derived from ``data/skills.json`` allowlist.
-
-    Uses a module-level cache to avoid re-scanning disk on every request.
-    The cache is invalidated by install/uninstall/reload/edit operations via
-    the cross-layer on-change callback.
-    """
+async def _build_skills_list_response(request: Request) -> dict:
+    """Build the complete skills list response and populate the module cache."""
     global _skills_cache
-    if _skills_cache is not None:
-        return _skills_cache
-
+    started_revision = _skills_cache_revision
     from openakita.skills.allowlist_io import read_allowlist
 
     skills_json_path, external_allowlist = read_allowlist()
@@ -299,8 +323,40 @@ async def list_skills(request: Request):
     skills.sort(key=_sort_key)
 
     result = {"skills": skills}
-    _skills_cache = result
+    if started_revision == _skills_cache_revision:
+        _skills_cache = result
     return result
+
+
+@router.get("/api/skills")
+async def list_skills(request: Request):
+    """List all available skills with their config schemas.
+
+    Returns ALL discovered skills (including disabled ones) with correct
+    ``enabled`` status derived from ``data/skills.json`` allowlist.
+
+    Uses a module-level cache to avoid re-scanning disk on every request.
+    The cache is invalidated by install/uninstall/reload/edit operations via
+    the cross-layer on-change callback.
+    """
+    global _skills_list_task, _skills_list_task_revision
+    if _skills_cache is not None:
+        return _skills_cache
+    if (
+        _skills_list_task is not None
+        and not _skills_list_task.done()
+        and _skills_list_task_revision == _skills_cache_revision
+    ):
+        return await _coalesce_task("skills list build", _skills_list_task)
+
+    task = asyncio.create_task(_build_skills_list_response(request))
+    _skills_list_task = task
+    _skills_list_task_revision = _skills_cache_revision
+    try:
+        return await asyncio.shield(task)
+    finally:
+        if _skills_list_task is task and task.done():
+            _skills_list_task = None
 
 
 _ORGANIZE_BATCH_SIZE = 50
@@ -953,6 +1009,7 @@ async def reload_skills(request: Request):
     POST body: { "skill_name": "optional-name" }
     如果 skill_name 为空或未提供，则重新扫描并加载所有技能。
     """
+    global _skills_reload_task
     agent = _resolve_agent(request)
     if agent is None:
         return {"error": "Agent not initialized"}
@@ -977,26 +1034,16 @@ async def reload_skills(request: Request):
             await _propagate(request, "reload", rescan=False)
             return {"status": "ok", "reloaded": [skill_name]}
 
-        await _propagate(request, "reload", rescan=True)
-        total = len(registry.list_all())
-        issues = _skill_load_issues(loader)
-        result = {
-            "status": "ok",
-            "reloaded": "all",
-            "total": total,
-        }
-        if issues:
-            result.update(
-                {
-                    "partial": True,
-                    "skipped_count": len(issues),
-                    "skipped_skills": issues,
-                    "warning": (
-                        f"已刷新可用技能，但有 {len(issues)} 个技能未加载。其他技能可正常使用。"
-                    ),
-                }
-            )
-        return result
+        if _skills_reload_task is not None and not _skills_reload_task.done():
+            return await _coalesce_task("skills reload", _skills_reload_task)
+
+        task = asyncio.create_task(_reload_all_skills_response(request, loader, registry))
+        _skills_reload_task = task
+        try:
+            return await asyncio.shield(task)
+        finally:
+            if _skills_reload_task is task and task.done():
+                _skills_reload_task = None
     except Exception as e:
         logger.error(f"Skill reload failed: {e}")
         return {"error": str(e)}

--- a/tests/integration/test_skills_api_propagation.py
+++ b/tests/integration/test_skills_api_propagation.py
@@ -15,7 +15,9 @@ parser / shutil）都被 monkeypatch 屏蔽，保证测试不依赖网络与真�
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -50,9 +52,15 @@ def _make_fake_agent(tmp_path: Path) -> SimpleNamespace:
 @pytest.fixture
 async def app_with_fake_agent(tmp_path: Path, monkeypatch):
     """创建 app 并绑定 fake agent + 把 project_root 重定向到 tmp_path。"""
+    from openakita.api.routes import skills as skills_route
     from openakita.config import settings as real_settings
 
     monkeypatch.setattr(real_settings, "project_root", tmp_path, raising=False)
+    skills_route._skills_cache = None
+    skills_route._skills_list_task = None
+    skills_route._skills_list_task_revision = 0
+    skills_route._skills_reload_task = None
+    skills_route._skills_cache_revision = 0
     (tmp_path / "data").mkdir(exist_ok=True)
 
     app = create_app()
@@ -271,6 +279,46 @@ class TestReloadRoute:
         assert "error" not in data
         agent.propagate_skill_change.assert_called_once()
 
+    async def test_reload_all_coalesces_concurrent_requests(
+        self, app_with_fake_agent, client, monkeypatch
+    ):
+        from openakita.api.routes import skills as skills_route
+
+        _, agent = app_with_fake_agent
+        entered = threading.Event()
+        release = threading.Event()
+        joined = asyncio.Event()
+
+        def slow_propagate(*args, **kwargs):
+            entered.set()
+            release.wait(timeout=2)
+            agent.propagate_calls.append((args, kwargs))
+
+        async def mark_joined(_name, task):
+            joined.set()
+            return await asyncio.shield(task)
+
+        agent.propagate_calls = []
+        agent.propagate_skill_change = slow_propagate
+        monkeypatch.setattr(skills_route, "_coalesce_task", mark_joined)
+
+        first = asyncio.create_task(client.post("/api/skills/reload", json={}))
+        assert await asyncio.to_thread(entered.wait, 2)
+        second = asyncio.create_task(client.post("/api/skills/reload", json={}))
+        await asyncio.wait_for(joined.wait(), timeout=2)
+        release.set()
+
+        first_resp, second_resp = await asyncio.gather(first, second)
+
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+        assert first_resp.json()["status"] == "ok"
+        assert second_resp.json()["status"] == "ok"
+        assert len(agent.propagate_calls) == 1
+        args, kwargs = agent.propagate_calls[0]
+        assert args[0] == "reload"
+        assert kwargs.get("rescan") is True
+
     async def test_reload_single_uses_rescan_false(self, app_with_fake_agent, client):
         _, agent = app_with_fake_agent
         agent.skill_loader.reload_skill.return_value = True
@@ -458,6 +506,44 @@ class TestSkillCategoryMassActionProgress:
 
 
 class TestGetSkillsCacheInvalidation:
+    async def test_concurrent_get_skills_coalesces_list_build(
+        self, app_with_fake_agent, client, monkeypatch
+    ):
+        from openakita.api.routes import skills as skills_route
+
+        entered = threading.Event()
+        release = asyncio.Event()
+        joined = asyncio.Event()
+        calls = 0
+
+        async def slow_build(_request):
+            nonlocal calls
+            calls += 1
+            entered.set()
+            await release.wait()
+            return {"skills": [{"skill_id": "one"}]}
+
+        async def mark_joined(_name, task):
+            joined.set()
+            return await asyncio.shield(task)
+
+        monkeypatch.setattr(skills_route, "_build_skills_list_response", slow_build)
+        monkeypatch.setattr(skills_route, "_coalesce_task", mark_joined)
+
+        first = asyncio.create_task(client.get("/api/skills"))
+        assert await asyncio.to_thread(entered.wait, 2)
+        second = asyncio.create_task(client.get("/api/skills"))
+        await asyncio.wait_for(joined.wait(), timeout=2)
+        release.set()
+
+        first_resp, second_resp = await asyncio.gather(first, second)
+
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+        assert first_resp.json() == {"skills": [{"skill_id": "one"}]}
+        assert second_resp.json() == {"skills": [{"skill_id": "one"}]}
+        assert calls == 1
+
     async def test_cache_cleared_on_notify(self, app_with_fake_agent, client):
         """直接触发 notify_skills_changed，应清空 _skills_cache。"""
         from openakita.api.routes import skills as skills_route


### PR DESCRIPTION
## Summary
- Coalesce concurrent full skill reload requests so repeated refreshes share the same in-flight scan.
- Coalesce concurrent `/api/skills` list builds to avoid duplicate recursive disk scans after cache invalidation.
- Increase skill refresh frontend timeouts and skip WebSocket-triggered list reloads while a manual refresh is already running.

Fixes #631.

## Tests
- `uv run --frozen pytest tests/integration/test_skills_api_propagation.py -q`
- `uv run --frozen ruff check src/openakita/api/routes/skills.py tests/integration/test_skills_api_propagation.py`
- `npm exec tsc -b`
- `git diff --check`