### PR TITLE
fix web search diagnostics for issue 619

### DIFF
--- a/src/openakita/tools/handlers/web_fetch.py
+++ b/src/openakita/tools/handlers/web_fetch.py
@@ -32,6 +32,16 @@ _REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 _BINARY_CONTENT_MARKERS = ("image/", "audio/", "video/", "application/pdf")
 
 
+def _unsafe_url_hint(reason: str) -> str:
+    if "198.18.0.0/15" in reason or "proxy/TUN/DNS interception" in reason:
+        return (
+            f"{reason}。该域名被本机 DNS/代理/TUN 解析到了保留测试网段，"
+            "web_fetch 出于 SSRF 防护不会直接访问。请检查代理、TUN 模式、DNS 分流或安全软件；"
+            "如确认需要人工打开页面，可改用浏览器工具。"
+        )
+    return f"{reason}。请使用浏览器工具访问本地/内网服务。"
+
+
 @dataclass(slots=True)
 class WebFetchMeta:
     requested_url: str
@@ -223,7 +233,7 @@ class WebFetchHandler:
                 redirect_chain=[url],
                 fetched_at=_utc_now_iso(),
                 error_code="unsafe_url",
-                hint=f"{reason}。请使用浏览器工具访问本地/内网服务。",
+                hint=_unsafe_url_hint(reason),
             )
             return _build_fetch_error_text(meta)
 

--- a/src/openakita/tools/handlers/web_search.py
+++ b/src/openakita/tools/handlers/web_search.py
@@ -34,6 +34,7 @@ from ..tool_hints import ConfigHintErrorCode, ToolConfigError
 from ..web_search import (
     AuthFailedError,
     ContentFilterError,
+    MissingCredentialError,
     NetworkUnreachableError,
     NoProviderAvailable,
     RateLimitedError,
@@ -201,6 +202,15 @@ def _raise_config_error(code: ConfigHintErrorCode, *, scope: str = "web_search")
     )
 
 
+def _explicit_provider_missing_message(provider_id: str | None) -> str:
+    if provider_id:
+        return (
+            f"搜索源 {provider_id!r} 已注册但当前不可用，通常是缺少 API Key 或该源未启用。"
+            "请在 OpenAkita 桌面端配置该搜索源，或去掉 provider 参数让系统自动尝试其他源。"
+        )
+    return _MESSAGE_BY_CODE["missing_credential"]
+
+
 # ---- Handler ------------------------------------------------------------------------
 
 
@@ -246,6 +256,16 @@ class WebSearchHandler:
             )
         except NoProviderAvailable as exc:
             _raise_config_error(exc.error_code)
+        except MissingCredentialError:
+            if provider_id:
+                raise ToolConfigError(
+                    scope="web_search",
+                    error_code="missing_credential",
+                    title="搜索源未配置",
+                    message=_explicit_provider_missing_message(provider_id),
+                    actions=_actions_for("missing_credential"),
+                )
+            _raise_config_error("missing_credential")
         except AuthFailedError:
             _raise_config_error("auth_failed")
         except RateLimitedError:
@@ -322,6 +342,16 @@ class WebSearchHandler:
                     actions=_actions_for("missing_credential"),
                 )
             _raise_config_error(exc.error_code)
+        except MissingCredentialError:
+            if provider_id:
+                raise ToolConfigError(
+                    scope="web_search",
+                    error_code="missing_credential",
+                    title="搜索源未配置",
+                    message=_explicit_provider_missing_message(provider_id),
+                    actions=_actions_for("missing_credential"),
+                )
+            _raise_config_error("missing_credential")
         except AuthFailedError:
             _raise_config_error("auth_failed")
         except RateLimitedError:
@@ -369,6 +399,10 @@ class WebSearchHandler:
         output = []
         if provider_id:
             output.append(f"[搜索源: {provider_id}]")
+        output.append(
+            "[系统提示] 本次 web_search 已返回可用结果。后续其他搜索源、web_fetch 或网页抓取"
+            "如果失败，只能说明那些源或页面不可用；最终回答不得概括为“所有搜索源不可用”。"
+        )
         if hidden_count:
             output.append(
                 f"[系统提示] 已隐藏 {hidden_count} 条明显垃圾或可能触发平台安全审核的搜索结果。"
@@ -396,6 +430,10 @@ class WebSearchHandler:
         output = []
         if provider_id:
             output.append(f"[搜索源: {provider_id}]")
+        output.append(
+            "[系统提示] 本次 news_search 已返回可用结果。后续其他搜索源、web_fetch 或网页抓取"
+            "如果失败，只能说明那些源或页面不可用；最终回答不得概括为“所有搜索源不可用”。"
+        )
         if hidden_count:
             output.append(
                 f"[系统提示] 已隐藏 {hidden_count} 条明显垃圾或可能触发平台安全审核的新闻搜索结果。"

--- a/src/openakita/tools/web_search/runtime.py
+++ b/src/openakita/tools/web_search/runtime.py
@@ -55,6 +55,13 @@ _FALLBACK_ERRORS = (
 )
 
 
+def _provider_unavailable_message(provider_id: str) -> str:
+    return (
+        f"Provider {provider_id!r} is registered but not available. "
+        "Configure its API key or choose another search provider."
+    )
+
+
 async def run_web_search(
     query: str,
     *,
@@ -69,7 +76,7 @@ async def run_web_search(
         provider = get_provider(provider_id)
         if not provider.is_available():
             raise MissingCredentialError(
-                f"Provider {provider_id!r} is configured but unavailable",
+                _provider_unavailable_message(provider_id),
                 provider_id=provider_id,
             )
         results = await provider.search(
@@ -107,7 +114,7 @@ async def run_news_search(
         provider = get_provider(provider_id)
         if not provider.is_available():
             raise MissingCredentialError(
-                f"Provider {provider_id!r} is configured but unavailable",
+                _provider_unavailable_message(provider_id),
                 provider_id=provider_id,
             )
         results = await provider.news_search(

--- a/src/openakita/utils/url_safety.py
+++ b/src/openakita/utils/url_safety.py
@@ -56,35 +56,48 @@ _METADATA_IPS = frozenset(
     }
 )
 
+_PROXY_INTERCEPT_NET = ipaddress.ip_network("198.18.0.0/15")
 
-def _is_blocked_ip(ip_str: str) -> bool:
-    """Check if IP address belongs to a blocked range."""
+
+def _blocked_ip_reason(ip_str: str) -> str:
+    """Return the blocked-IP category, or an empty string when allowed."""
     try:
         addr = ipaddress.ip_address(ip_str)
     except ValueError:
-        return True
+        return "invalid IP address"
+
+    if isinstance(addr, ipaddress.IPv4Address) and addr in _PROXY_INTERCEPT_NET:
+        return (
+            "reserved benchmark range 198.18.0.0/15, often caused by proxy/TUN/DNS "
+            "interception"
+        )
 
     if addr.is_loopback:
-        return True
+        return "loopback address"
     if addr.is_private:
-        return True
+        return "private address"
     if addr.is_link_local:
-        return True
+        return "link-local address"
     if addr.is_reserved:
-        return True
+        return "reserved address"
     if addr.is_multicast:
-        return True
+        return "multicast address"
 
     if isinstance(addr, ipaddress.IPv4Address):
         first_octet = int(ip_str.split(".")[0])
         second_octet = int(ip_str.split(".")[1]) if "." in ip_str else 0
         if first_octet == 100 and 64 <= second_octet <= 127:
-            return True
+            return "CGNAT address"
 
     if ip_str in _METADATA_IPS:
-        return True
+        return "cloud metadata endpoint"
 
-    return False
+    return ""
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    """Check if IP address belongs to a blocked range."""
+    return bool(_blocked_ip_reason(ip_str))
 
 
 def _resolve_and_check(hostname: str) -> tuple[bool, str]:
@@ -93,8 +106,9 @@ def _resolve_and_check(hostname: str) -> tuple[bool, str]:
         results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         for _family, _, _, _, sockaddr in results:
             ip_str = sockaddr[0]
-            if _is_blocked_ip(ip_str):
-                return False, f"DNS resolved to blocked IP: {hostname} → {ip_str}"
+            reason = _blocked_ip_reason(ip_str)
+            if reason:
+                return False, f"DNS resolved to blocked IP: {hostname} → {ip_str} ({reason})"
     except socket.gaierror:
         return False, f"DNS resolution failed: {hostname}"
     return True, ""

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -156,6 +156,31 @@ async def test_web_fetch_reports_binary_content(_fake_httpx):
 
 
 @pytest.mark.asyncio
+async def test_web_fetch_reserved_benchmark_dns_hint_does_not_fetch(monkeypatch, _fake_httpx):
+    async def _unsafe_19818(_url: str):
+        return (
+            False,
+            "DNS resolved to blocked IP: www.weather.com.cn -> 198.18.0.13 "
+            "(reserved benchmark range 198.18.0.0/15, often caused by proxy/TUN/DNS "
+            "interception)",
+        )
+
+    monkeypatch.setattr("openakita.utils.url_safety.is_safe_url", _unsafe_19818)
+
+    result = await WebFetchHandler(agent=None)._web_fetch(
+        {"url": "https://www.weather.com.cn/weather/101230101.shtml"}
+    )
+
+    assert "unsafe_url" in result
+    assert "198.18.0.0/15" in result
+    assert "代理" in result
+    assert "DNS" in result
+    assert "TUN" in result
+    assert "本地/内网服务" not in result
+    assert _fake_httpx.calls == []
+
+
+@pytest.mark.asyncio
 async def test_web_fetch_respects_session_domain_block(_fake_httpx):
     """Once a user blocks a host in this conversation, web_fetch must refuse it."""
 

--- a/tests/unit/test_web_search_provider_panel.py
+++ b/tests/unit/test_web_search_provider_panel.py
@@ -133,6 +133,10 @@ class TestWebSearchHandlerErrorMapping:
 
         monkeypatch.setattr(reg, "_PROVIDERS", {}, raising=False)
         monkeypatch.setattr(reg, "_LOADED", True, raising=False)
+        monkeypatch.setattr(
+            "openakita.tools.handlers.web_search.settings.web_search_provider",
+            "",
+        )
         yield
 
     async def _run_handler(self) -> tuple[str | None, ConfigHint | None]:
@@ -154,6 +158,22 @@ class TestWebSearchHandlerErrorMapping:
         labels = [a.get("label", "") for a in hint.actions]
         assert any("前往配置" in lb for lb in labels)
         assert any("博查" in lb for lb in labels)  # signup link present
+
+    async def test_explicit_unavailable_provider_maps_to_missing_credential_hint(self) -> None:
+        from openakita.tools.handlers.web_search import WebSearchHandler
+
+        register(_FakeProvider("bocha", available=False))
+
+        with pytest.raises(ToolConfigError) as excinfo:
+            await WebSearchHandler()._web_search(
+                {"query": "test", "provider": "bocha", "timeout_seconds": 1}
+            )
+
+        hint = excinfo.value.hint
+        assert hint.error_code == "missing_credential"
+        assert "bocha" in hint.message
+        assert "API Key" in hint.message
+        assert "自动尝试其他源" in hint.message
 
     async def test_auth_failed_maps_to_auth_failed(self) -> None:
         register(_FakeProvider("p1", raise_on_search=AuthFailedError("bad key")))
@@ -248,6 +268,17 @@ class TestRuntimeAutoDetect:
         register(_FakeProvider("p1", raise_on_search=NetworkUnreachableError("oops")))
         with pytest.raises(NetworkUnreachableError):
             await run_web_search("q", provider_id="p1", timeout_seconds=1)
+
+    async def test_explicit_unavailable_provider_message_names_configuration(self) -> None:
+        register(_FakeProvider("bocha", available=False))
+
+        with pytest.raises(MissingCredentialError) as excinfo:
+            await run_web_search("q", provider_id="bocha", timeout_seconds=1)
+
+        message = str(excinfo.value)
+        assert "Provider 'bocha' is registered but not available" in message
+        assert "Configure its API key" in message
+        assert "configured but unavailable" not in message
 
     async def test_news_skips_providers_returning_none(self) -> None:
         # p1 returns None (no news), p2 returns results

--- a/tests/unit/test_web_search_safety_filter.py
+++ b/tests/unit/test_web_search_safety_filter.py
@@ -3,12 +3,12 @@ import pytest
 from openakita.core.reasoning_engine import ReasoningEngine
 from openakita.tools.handlers.web_search import WebSearchHandler
 from openakita.tools.tool_hints import ToolConfigError
+from openakita.tools.web_search import runtime as web_search_runtime
 from openakita.tools.web_search.base import (
     NetworkUnreachableError,
     SearchBundle,
     SearchResult,
 )
-from openakita.tools.web_search import runtime as web_search_runtime
 
 
 def test_web_search_hides_obviously_unsafe_results_but_keeps_safe_results():
@@ -34,6 +34,8 @@ def test_web_search_hides_obviously_unsafe_results_but_keeps_safe_results():
     assert "weather.com.cn" in formatted
     assert "noduown" not in formatted
     assert "网黄" not in formatted
+    assert "本次 web_search 已返回可用结果" in formatted
+    assert "不得概括为“所有搜索源不可用”" in formatted
     assert "已隐藏 1 条" in formatted
     assert "权威来源继续验证" in formatted
 


### PR DESCRIPTION
## Summary
- map explicit unavailable web search providers to missing credential hints instead of unexpected errors
- keep successful web_search/news_search evidence from being summarized as all sources unavailable after later failures
- clarify 198.18.0.0/15 DNS interception in web_fetch unsafe URL guidance while preserving SSRF blocking

## Tests
- uv run ruff check src/openakita/tools/web_search/runtime.py src/openakita/tools/handlers/web_search.py src/openakita/utils/url_safety.py src/openakita/tools/handlers/web_fetch.py tests/unit/test_web_search_provider_panel.py tests/unit/test_web_search_safety_filter.py tests/unit/test_web_fetch_handler.py
- uv run pytest tests/unit/test_web_search_provider_panel.py tests/unit/test_web_search_safety_filter.py tests/unit/test_web_fetch_handler.py

Fixes openakita/openakita#619