### PR TITLE
Fix WeChat proactive delivery failures for scheduled tasks

### DIFF
--- a/src/openakita/channels/__init__.py
+++ b/src/openakita/channels/__init__.py
@@ -8,7 +8,7 @@
 - 媒体处理
 """
 
-from .base import ChannelAdapter
+from .base import ChannelAdapter, ChannelDeliveryUnavailable
 from .gateway import MessageGateway
 from .types import (
     MediaFile,
@@ -27,6 +27,7 @@ __all__ = [
     "OutgoingMessage",
     # 适配器
     "ChannelAdapter",
+    "ChannelDeliveryUnavailable",
     # 网关
     "MessageGateway",
 ]

--- a/src/openakita/channels/adapters/wechat.py
+++ b/src/openakita/channels/adapters/wechat.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 from urllib.parse import quote
 
-from ..base import ChannelAdapter
+from ..base import ChannelAdapter, ChannelDeliveryUnavailable
 from ..types import (
     MediaFile,
     MediaStatus,
@@ -103,13 +103,17 @@ BACKOFF_DELAY_S = 30.0
 RETRY_DELAY_S = 2.0
 SESSION_PAUSE_DURATION_S = 3600  # 1 hour
 SESSION_EXPIRED_ERRCODE = -14
+CONTEXT_REJECTED_RETCODE = -2
+CONTEXT_TOKEN_STALE_S = int(os.environ.get("WECHAT_CONTEXT_TOKEN_STALE_S", "1800"))
 
 # Permanent / non-retryable iLink Bot return codes. Re-trying these
 # only buys ~75s of delay (4 attempts × exponential 5+10+20+40 backoff)
 # without any chance of success — the server has already rejected the
 # request for a non-transient reason (e.g. chat_id unreachable, no
 # friend relationship, no fresh context_token, malformed param).
-NON_RETRYABLE_RET_CODES: frozenset[int] = frozenset({-2, SESSION_EXPIRED_ERRCODE})
+NON_RETRYABLE_RET_CODES: frozenset[int] = frozenset(
+    {CONTEXT_REJECTED_RETCODE, SESSION_EXPIRED_ERRCODE}
+)
 
 UPLOAD_MAX_RETRIES = 3
 CONFIG_CACHE_TTL_S = 86400  # 24h
@@ -501,6 +505,18 @@ class _TicketEntry:
     ever_succeeded: bool = False
 
 
+@dataclass
+class _ContextTokenEntry:
+    token: str
+    captured_at: float = 0.0
+    invalidated_at: float = 0.0
+    invalid_reason: str = ""
+
+    @property
+    def invalidated(self) -> bool:
+        return self.invalidated_at > 0
+
+
 # ---------------------------------------------------------------------------
 # WeChatAdapter
 # ---------------------------------------------------------------------------
@@ -558,8 +574,8 @@ class WeChatAdapter(ChannelAdapter):
         self._get_updates_buf: str = ""
         self._sync_buf_dir = Path("data/wechat_sync")
 
-        # context_token 缓存 (user_id → token)
-        self._context_tokens: dict[str, str] = {}
+        # context_token 缓存 (user_id → token state)
+        self._context_tokens: dict[str, _ContextTokenEntry] = {}
 
         # Typing ticket 缓存
         self._ticket_cache: dict[str, _TicketEntry] = {}
@@ -674,10 +690,30 @@ class WeChatAdapter(ChannelAdapter):
             f"pausing all API calls for {remaining_min} min"
         )
 
+    def _delivery_unavailable(
+        self,
+        chat_id: str,
+        reason: str,
+        *,
+        retryable: bool = False,
+    ) -> ChannelDeliveryUnavailable:
+        return ChannelDeliveryUnavailable(
+            "微信通道暂时不可投递：会话或 context_token 已失效，请在微信中发送一条新消息刷新会话，或重新扫码登录。",
+            channel=self.channel_name,
+            chat_id=chat_id,
+            reason=reason,
+            retryable=retryable,
+            requires_user_action=True,
+        )
+
     async def _api_post(self, endpoint: str, body: dict, *, timeout_s: float | None = None) -> dict:
         if self._is_session_paused():
             remaining = int(self._session_paused_until - time.time())
-            raise RuntimeError(f"session paused, {remaining}s remaining")
+            raise self._delivery_unavailable(
+                "",
+                f"WeChat session paused, {remaining}s remaining",
+                retryable=True,
+            )
 
         body.setdefault("base_info", {"channel_version": OPENCLAW_COMPAT_VERSION})
 
@@ -719,9 +755,11 @@ class WeChatAdapter(ChannelAdapter):
 
         if code == SESSION_EXPIRED_ERRCODE:
             self._pause_session()
-            raise RuntimeError(
+            raise self._delivery_unavailable(
+                "",
                 f"WeChat {action} failed: session expired "
-                f"(ret={ret}, errcode={errcode}, errmsg={errmsg})"
+                f"(ret={ret}, errcode={errcode}, errmsg={errmsg})",
+                retryable=True,
             )
 
         raise RuntimeError(f"WeChat {action} failed: ret={ret}, errcode={errcode}, errmsg={errmsg}")
@@ -986,8 +1024,7 @@ class WeChatAdapter(ChannelAdapter):
 
         ctx_token = msg.get("context_token")
         if ctx_token:
-            self._context_tokens[from_user] = ctx_token
-            self._save_context_tokens()
+            self._store_context_token(from_user, ctx_token)
 
         item_list = msg.get("item_list") or []
         text_body = self._extract_text_body(item_list)
@@ -1130,7 +1167,7 @@ class WeChatAdapter(ChannelAdapter):
 
     async def send_message(self, message: OutgoingMessage) -> str:
         if self._is_session_paused():
-            raise RuntimeError("WeChat session paused")
+            raise self._delivery_unavailable(message.chat_id, "WeChat session paused")
 
         chat_id = message.chat_id
         ctx_token = self._resolve_context_token(chat_id, message.metadata)
@@ -1154,6 +1191,8 @@ class WeChatAdapter(ChannelAdapter):
                         caption=text,
                         ctx_token=ctx_token,
                     )
+                except ChannelDeliveryUnavailable:
+                    raise
                 except Exception as exc:
                     logger.exception(
                         f"{self.channel_name}: media send failed, falling back to text"
@@ -1185,12 +1224,62 @@ class WeChatAdapter(ChannelAdapter):
         优先级: 最新缓存（来自最近一次 getUpdates） > 消息 metadata 中的原始 token。
         长耗时任务中原始 token 可能已过期，缓存中的更可能有效。
         """
-        cached = self._context_tokens.get(chat_id, "")
+        cached = self._context_tokens.get(chat_id)
         meta_token = (metadata or {}).get("context_token", "")
 
         if cached:
-            return cached
+            if self._is_context_token_entry_usable(cached):
+                return cached.token
+            if not cached.invalidated:
+                self._invalidate_context_token(chat_id, "context_token stale")
+            return ""
         return meta_token
+
+    def _is_context_token_entry_usable(self, entry: _ContextTokenEntry) -> bool:
+        if not entry.token or entry.invalidated:
+            return False
+        if entry.captured_at <= 0:
+            return False
+        return (time.time() - entry.captured_at) <= CONTEXT_TOKEN_STALE_S
+
+    def _store_context_token(self, chat_id: str, token: str) -> None:
+        self._context_tokens[chat_id] = _ContextTokenEntry(token=token, captured_at=time.time())
+        self._save_context_tokens()
+
+    def _invalidate_context_token(self, chat_id: str, reason: str, token: str = "") -> None:
+        entry = self._context_tokens.get(chat_id)
+        if not entry and token:
+            entry = _ContextTokenEntry(token=token, captured_at=0.0)
+            self._context_tokens[chat_id] = entry
+        if entry:
+            entry.invalidated_at = time.time()
+            entry.invalid_reason = reason
+        logger.warning(
+            f"{self.channel_name}: context_token invalidated for {_redact_id(chat_id)}: {reason}"
+        )
+        self._save_context_tokens()
+
+    def _raise_context_delivery_unavailable(
+        self,
+        chat_id: str,
+        resp: dict,
+        exc: BaseException,
+        token: str = "",
+    ) -> None:
+        reason = (
+            f"WeChat sendmessage rejected context/session "
+            f"(ret={resp.get('ret')}, errcode={resp.get('errcode')}, "
+            f"errmsg={resp.get('errmsg', '')})"
+        )
+        self._invalidate_context_token(chat_id, reason, token=token)
+        raise self._delivery_unavailable(chat_id, reason) from exc
+
+    def _raise_session_delivery_unavailable(
+        self,
+        chat_id: str,
+        exc: ChannelDeliveryUnavailable,
+    ) -> None:
+        raise self._delivery_unavailable(chat_id, exc.reason, retryable=exc.retryable) from exc
 
     async def _send_text(self, to: str, text: str, ctx_token: str = "") -> str:
         client_id = f"openakita-wechat-{uuid.uuid4().hex[:12]}"
@@ -1208,12 +1297,19 @@ class WeChatAdapter(ChannelAdapter):
         token_hint = " (no context_token cached for this chat)" if not ctx_token else ""
         for attempt in range(1, SEND_RATE_LIMIT_RETRIES + 1):
             await self._rate_limit_wait(to)
-            resp = await self._api_post("ilink/bot/sendmessage", body)
+            try:
+                resp = await self._api_post("ilink/bot/sendmessage", body)
+            except ChannelDeliveryUnavailable as exc:
+                self._raise_session_delivery_unavailable(to, exc)
             try:
                 self._check_send_response(resp, action="sendmessage(text)")
                 break
+            except ChannelDeliveryUnavailable as exc:
+                self._raise_session_delivery_unavailable(to, exc)
             except RuntimeError as exc:
                 if resp.get("ret") in NON_RETRYABLE_RET_CODES:
+                    if resp.get("ret") == CONTEXT_REJECTED_RETCODE:
+                        self._raise_context_delivery_unavailable(to, resp, exc, token=ctx_token)
                     if token_hint and token_hint not in str(exc):
                         raise RuntimeError(str(exc) + token_hint) from exc
                     raise
@@ -1320,12 +1416,21 @@ class WeChatAdapter(ChannelAdapter):
         }
         for attempt in range(1, SEND_RATE_LIMIT_RETRIES + 1):
             await self._rate_limit_wait(chat_id)
-            resp = await self._api_post("ilink/bot/sendmessage", body)
+            try:
+                resp = await self._api_post("ilink/bot/sendmessage", body)
+            except ChannelDeliveryUnavailable as exc:
+                self._raise_session_delivery_unavailable(chat_id, exc)
             try:
                 self._check_send_response(resp, action="sendmessage(media)")
                 break
-            except RuntimeError:
+            except ChannelDeliveryUnavailable as exc:
+                self._raise_session_delivery_unavailable(chat_id, exc)
+            except RuntimeError as exc:
                 if resp.get("ret") in NON_RETRYABLE_RET_CODES:
+                    if resp.get("ret") == CONTEXT_REJECTED_RETCODE:
+                        self._raise_context_delivery_unavailable(
+                            chat_id, resp, exc, token=ctx_token
+                        )
                     raise
                 if attempt < SEND_RATE_LIMIT_RETRIES:
                     delay = SEND_RATE_LIMIT_BASE_DELAY_S * (2 ** (attempt - 1))
@@ -1489,7 +1594,7 @@ class WeChatAdapter(ChannelAdapter):
         if entry and now < entry.next_fetch_at:
             return entry.ticket
 
-        ctx_token = self._context_tokens.get(user_id, "")
+        ctx_token = self._resolve_context_token(user_id)
         try:
             resp = await self._api_post(
                 "ilink/bot/getconfig",
@@ -1581,8 +1686,18 @@ class WeChatAdapter(ChannelAdapter):
         }
         if context_token:
             upload_body["context_token"] = context_token
-        upload_resp = await self._api_post("ilink/bot/getuploadurl", upload_body)
-        self._check_send_response(upload_resp, action="getuploadurl")
+        upload_resp: dict = {}
+        try:
+            upload_resp = await self._api_post("ilink/bot/getuploadurl", upload_body)
+            self._check_send_response(upload_resp, action="getuploadurl")
+        except ChannelDeliveryUnavailable as exc:
+            self._raise_session_delivery_unavailable(to_user_id, exc)
+        except RuntimeError as exc:
+            if upload_resp.get("ret") == CONTEXT_REJECTED_RETCODE:
+                self._raise_context_delivery_unavailable(
+                    to_user_id, upload_resp, exc, token=context_token
+                )
+            raise
         upload_full_url = (upload_resp.get("upload_full_url") or "").strip()
         upload_param = upload_resp.get("upload_param")
         if not upload_full_url and not upload_param:
@@ -1715,8 +1830,18 @@ class WeChatAdapter(ChannelAdapter):
         if not self._context_tokens:
             return
         try:
+            payload = {
+                chat_id: {
+                    "token": entry.token,
+                    "captured_at": entry.captured_at,
+                    "invalidated_at": entry.invalidated_at,
+                    "invalid_reason": entry.invalid_reason,
+                }
+                for chat_id, entry in self._context_tokens.items()
+                if entry.token
+            }
             self._context_tokens_path().write_text(
-                json.dumps(self._context_tokens), encoding="utf-8"
+                json.dumps(payload, ensure_ascii=False), encoding="utf-8"
             )
         except Exception:
             logger.debug(f"{self.channel_name}: failed to save context tokens")
@@ -1727,7 +1852,41 @@ class WeChatAdapter(ChannelAdapter):
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
                 if isinstance(data, dict):
-                    self._context_tokens = data
-                    logger.info(f"{self.channel_name}: loaded {len(data)} context tokens from disk")
+                    loaded: dict[str, _ContextTokenEntry] = {}
+                    for chat_id, raw in data.items():
+                        if not isinstance(chat_id, str):
+                            continue
+                        if isinstance(raw, str):
+                            loaded[chat_id] = _ContextTokenEntry(
+                                token=raw,
+                                captured_at=0.0,
+                                invalidated_at=time.time(),
+                                invalid_reason="legacy token without capture timestamp",
+                            )
+                            continue
+                        if not isinstance(raw, dict):
+                            continue
+                        token = str(raw.get("token") or "")
+                        if not token:
+                            continue
+                        try:
+                            captured_at = float(raw.get("captured_at") or 0.0)
+                        except (TypeError, ValueError):
+                            captured_at = 0.0
+                        try:
+                            invalidated_at = float(raw.get("invalidated_at") or 0.0)
+                        except (TypeError, ValueError):
+                            invalidated_at = 0.0
+                        invalid_reason = str(raw.get("invalid_reason") or "")
+                        loaded[chat_id] = _ContextTokenEntry(
+                            token=token,
+                            captured_at=captured_at,
+                            invalidated_at=invalidated_at,
+                            invalid_reason=invalid_reason,
+                        )
+                    self._context_tokens = loaded
+                    logger.info(
+                        f"{self.channel_name}: loaded {len(loaded)} context tokens from disk"
+                    )
             except Exception:
                 logger.debug(f"{self.channel_name}: failed to load context tokens")

--- a/src/openakita/channels/base.py
+++ b/src/openakita/channels/base.py
@@ -45,6 +45,27 @@ EventCallback = Callable[[str, dict], Awaitable[None]]
 FailureCallback = Callable[[str, str], None]  # (adapter_name, reason)
 
 
+class ChannelDeliveryUnavailable(RuntimeError):
+    """Raised when an IM channel is known to be unable to deliver messages."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        channel: str = "",
+        chat_id: str = "",
+        reason: str = "",
+        retryable: bool = False,
+        requires_user_action: bool = True,
+    ) -> None:
+        super().__init__(message)
+        self.channel = channel
+        self.chat_id = chat_id
+        self.reason = reason or message
+        self.retryable = retryable
+        self.requires_user_action = requires_user_action
+
+
 class ChannelAdapter(ABC):
     """
     IM 通道适配器基类

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from ..sessions import Session, SessionManager
 from ..utils.errors import format_user_friendly_error as format_user_friendly_error  # re-export
-from .base import ChannelAdapter
+from .base import ChannelAdapter, ChannelDeliveryUnavailable
 from .group_response import GroupResponseMode, SmartModeThrottle
 from .types import MediaStatus, MessageContent, OutgoingMessage, UnifiedMessage
 
@@ -5293,6 +5293,16 @@ class MessageGateway:
                     )
                     failed_at = i
                     break
+            except ChannelDeliveryUnavailable:
+                logger.warning(
+                    "Channel unavailable while sending response part %s/%s "
+                    "(channel=%s, chat_id=%s)",
+                    i + 1,
+                    len(messages),
+                    original.channel,
+                    original.chat_id,
+                )
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to send response part {i + 1}/{len(messages)} after retries: {e}"
@@ -5325,6 +5335,8 @@ class MessageGateway:
                 plain_result = await adapter.send_message(plain_out)
                 if not self._is_im_send_delivered(plain_result):
                     raise RuntimeError("adapter did not confirm immediate delivery")
+            except ChannelDeliveryUnavailable:
+                raise
             except Exception as e2:
                 logger.error(f"Plain-text fallback also failed for part {failed_at + j + 1}: {e2}")
                 _sent_count = failed_at + j
@@ -5675,6 +5687,8 @@ class MessageGateway:
                     logger.warning(f"Failed to record message to session: {e}")
 
             return result
+        except ChannelDeliveryUnavailable:
+            raise
         except Exception as e:
             logger.error(f"Failed to send message: {e}")
             return None

--- a/src/openakita/scheduler/executor.py
+++ b/src/openakita/scheduler/executor.py
@@ -16,10 +16,16 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from ..channels.base import ChannelDeliveryUnavailable
 from ..memory.json_utils import coerce_text
 from .task import ScheduledTask
 
 logger = logging.getLogger(__name__)
+
+CHANNEL_UNAVAILABLE_MARKER = "[channel_unavailable]"
+CHANNEL_UNAVAILABLE_MESSAGE = (
+    "IM 通道不可投递：微信会话或 context_token 已失效，请在微信中发送一条新消息刷新会话，或重新扫码登录。"
+)
 
 
 class TaskExecutor:
@@ -48,6 +54,12 @@ class TaskExecutor:
         self.persona_manager = None
         self.memory_manager = None
         self.proactive_engine = None  # 复用 agent 上的实例，保留 _last_user_interaction 状态
+
+    @staticmethod
+    def _format_channel_unavailable_error(exc: ChannelDeliveryUnavailable) -> str:
+        if exc.channel.startswith("wechat"):
+            return CHANNEL_UNAVAILABLE_MESSAGE
+        return f"IM 通道不可投递：{exc.reason or str(exc)}"
 
     @staticmethod
     def _metadata_bool(task: ScheduledTask, key: str, default: bool) -> bool:
@@ -130,10 +142,19 @@ class TaskExecutor:
                     )
 
         # 根据任务类型选择执行策略
-        if task.is_reminder:
-            return await self._execute_reminder(task)
-        else:
-            return await self._execute_complex_task(task)
+        try:
+            if task.is_reminder:
+                return await self._execute_reminder(task)
+            else:
+                return await self._execute_complex_task(task)
+        except ChannelDeliveryUnavailable as exc:
+            error_msg = self._format_channel_unavailable_error(exc)
+            logger.warning(
+                "TaskExecutor: task %s skipped because channel is unavailable: %s",
+                task.id,
+                error_msg,
+            )
+            return False, f"{CHANNEL_UNAVAILABLE_MARKER} {error_msg}"
 
     async def _execute_reminder(self, task: ScheduledTask) -> tuple[bool, str]:
         """
@@ -214,6 +235,8 @@ class TaskExecutor:
                 chat_id=chat_id,
                 text=message,
             )
+        except ChannelDeliveryUnavailable:
+            raise
         except Exception as e:
             logger.warning(f"TaskExecutor: reminder {task.id} primary send error: {e}")
             msg_id = None
@@ -263,6 +286,8 @@ class TaskExecutor:
                         f"{channel}/{chat_id} (msg_id={msg_id})"
                     )
                     return True
+            except ChannelDeliveryUnavailable:
+                raise
             except Exception as e:
                 logger.warning(f"TaskExecutor: fallback send failed for {channel}/{chat_id}: {e}")
                 continue
@@ -355,7 +380,16 @@ class TaskExecutor:
         logger.info(f"TaskExecutor: executing complex task {task.id}")
 
         if not task.silent:
-            await self._send_start_notification(task)
+            try:
+                await self._send_start_notification(task)
+            except ChannelDeliveryUnavailable as exc:
+                error_msg = self._format_channel_unavailable_error(exc)
+                logger.warning(
+                    "TaskExecutor: task %s skipped before execution because channel is unavailable: %s",
+                    task.id,
+                    error_msg,
+                )
+                return False, f"{CHANNEL_UNAVAILABLE_MARKER} {error_msg}"
 
         return await self._execute_complex_task_core(task, skip_end_notification=task.silent)
 
@@ -378,11 +412,15 @@ class TaskExecutor:
             if task.action and task.action.startswith("system:"):
                 system_success, system_result = await self._execute_system_task(task)
                 if not skip_end_notification:
-                    delivered = await self._send_end_notification(
+                    delivered, unavailable_marker = await self._send_end_notification_or_marker(
                         task,
                         success=system_success,
                         message=system_result,
                     )
+                    if unavailable_marker and system_success:
+                        return False, unavailable_marker
+                    if unavailable_marker:
+                        return system_success, system_result
                     if not delivered:
                         error_msg = "任务已完成，但结果通知发送失败，请检查 IM 通道连接状态。"
                         logger.warning(
@@ -533,7 +571,8 @@ class TaskExecutor:
                 error_msg = f"任务执行超时（超过 {timeout_display} 未完成）"
                 logger.error(f"TaskExecutor: task {task.id} timed out after {task_timeout}s")
                 if not skip_end_notification:
-                    await self._send_end_notification(task, success=False, message=error_msg)
+                    with contextlib.suppress(ChannelDeliveryUnavailable):
+                        await self._send_end_notification(task, success=False, message=error_msg)
                 return False, error_msg
             except Exception as exc:  # noqa: BLE001
                 # C12 §14.5: catch DeferredApprovalRequired before the generic
@@ -565,13 +604,18 @@ class TaskExecutor:
             # 5. 发送结果通知（如果需要）
             if not agent_success:
                 if not skip_end_notification:
-                    await self._send_end_notification(task, success=False, message=result)
+                    with contextlib.suppress(ChannelDeliveryUnavailable):
+                        await self._send_end_notification(task, success=False, message=result)
                 logger.warning(f"TaskExecutor: task {task.id} failed via agent result: {result}")
                 return False, result
 
             agent_sent = getattr(agent, "_task_message_sent", False)
             if not agent_sent and not skip_end_notification:
-                delivered = await self._send_end_notification(task, success=True, message=result)
+                delivered, unavailable_marker = await self._send_end_notification_or_marker(
+                    task, success=True, message=result
+                )
+                if unavailable_marker:
+                    return False, unavailable_marker
                 if not delivered:
                     error_msg = "任务已完成，但结果通知发送失败，请检查 IM 通道连接状态。"
                     logger.warning(f"TaskExecutor: task {task.id} result delivery failed")
@@ -584,7 +628,8 @@ class TaskExecutor:
             error_msg = str(e)
             logger.error(f"TaskExecutor: task {task.id} failed: {error_msg}", exc_info=True)
             if not skip_end_notification:
-                await self._send_end_notification(task, success=False, message=error_msg)
+                with contextlib.suppress(ChannelDeliveryUnavailable):
+                    await self._send_end_notification(task, success=False, message=error_msg)
             return False, error_msg
         finally:
             # 清理 IM 上下文
@@ -595,15 +640,15 @@ class TaskExecutor:
                 with contextlib.suppress(Exception):
                     await self._cleanup_agent(agent)
 
-    async def _send_start_notification(self, task: ScheduledTask) -> None:
+    async def _send_start_notification(self, task: ScheduledTask) -> bool:
         """发送任务开始通知"""
         if not task.channel_id or not task.chat_id or not self.gateway:
-            return
+            return True
 
         # 检查是否启用开始通知
         if not self._metadata_bool(task, "notify_on_start", True):
             logger.debug(f"Task {task.id} has start notification disabled")
-            return
+            return True
 
         try:
             notification = f"🚀 开始执行任务: {task.name}\n\n请稍候，我正在处理中..."
@@ -618,9 +663,31 @@ class TaskExecutor:
                 logger.info(f"Sent start notification for task {task.id}")
             else:
                 logger.info(f"Start notification for task {task.id} was not immediately delivered")
+            return delivered
 
+        except ChannelDeliveryUnavailable:
+            raise
         except Exception as e:
             logger.error(f"Failed to send start notification: {e}")
+            return False
+
+    async def _send_end_notification_or_marker(
+        self,
+        task: ScheduledTask,
+        success: bool,
+        message: str,
+    ) -> tuple[bool, str | None]:
+        try:
+            delivered = await self._send_end_notification(task, success=success, message=message)
+            return delivered, None
+        except ChannelDeliveryUnavailable as exc:
+            error_msg = self._format_channel_unavailable_error(exc)
+            logger.warning(
+                "TaskExecutor: task %s notification skipped because channel is unavailable: %s",
+                task.id,
+                error_msg,
+            )
+            return False, f"{CHANNEL_UNAVAILABLE_MARKER} {error_msg}"
 
     async def _send_end_notification(
         self,
@@ -683,25 +750,35 @@ class TaskExecutor:
     async def _deliver_task_notification(self, task: ScheduledTask, text: str) -> bool:
         """投递任务通知；主通道失败时尝试已知 IM 目标，保持单一通知入口。"""
         primary = (task.channel_id, task.chat_id)
+        last_unavailable: ChannelDeliveryUnavailable | None = None
         if task.channel_id and task.chat_id:
-            if await self._send_gateway_text(
-                channel=task.channel_id,
-                chat_id=task.chat_id,
-                text=text,
-                user_id=task.user_id or "system",
-            ):
-                return True
+            try:
+                if await self._send_gateway_text(
+                    channel=task.channel_id,
+                    chat_id=task.chat_id,
+                    text=text,
+                    user_id=task.user_id or "system",
+                ):
+                    return True
+            except ChannelDeliveryUnavailable as exc:
+                last_unavailable = exc
 
         for channel, chat_id in self._find_all_im_targets():
             if (channel, chat_id) == primary:
                 continue
-            if await self._send_gateway_text(channel=channel, chat_id=chat_id, text=text):
-                logger.info(
-                    f"TaskExecutor: notification for {task.id} delivered via fallback "
-                    f"{channel}/{chat_id}"
-                )
-                return True
+            try:
+                if await self._send_gateway_text(channel=channel, chat_id=chat_id, text=text):
+                    logger.info(
+                        f"TaskExecutor: notification for {task.id} delivered via fallback "
+                        f"{channel}/{chat_id}"
+                    )
+                    return True
+            except ChannelDeliveryUnavailable as exc:
+                last_unavailable = exc
+                continue
 
+        if last_unavailable is not None:
+            raise last_unavailable
         return False
 
     async def _send_gateway_text(
@@ -731,6 +808,8 @@ class TaskExecutor:
             if isinstance(result, str):
                 return bool(result)
             return result is not None
+        except ChannelDeliveryUnavailable:
+            raise
         except Exception as e:
             logger.warning(f"TaskExecutor: send failed for {channel}/{chat_id}: {e}")
             return False

--- a/src/openakita/scheduler/scheduler.py
+++ b/src/openakita/scheduler/scheduler.py
@@ -37,6 +37,7 @@ from .task import ScheduledTask, TaskDurability, TaskExecution, TaskStatus, Trig
 from .triggers import Trigger
 
 logger = logging.getLogger(__name__)
+CHANNEL_UNAVAILABLE_MARKER = "[channel_unavailable]"
 
 # 执行器类型定义
 TaskExecutorFunc = Callable[[ScheduledTask], Awaitable[tuple[bool, str]]]
@@ -903,6 +904,9 @@ class TaskScheduler:
             _is_deferred = isinstance(_err_or_res, str) and _err_or_res.startswith(
                 "[awaiting_approval]"
             )
+            _is_channel_unavailable = isinstance(_err_or_res, str) and _err_or_res.startswith(
+                CHANNEL_UNAVAILABLE_MARKER
+            )
 
             if execution.status == "success":
                 # Fix: 使用"实际预定时间"而非 datetime.now() 作为基准。
@@ -939,6 +943,11 @@ class TaskScheduler:
                     task.id,
                     _err_or_res,
                 )
+            elif _is_channel_unavailable:
+                execution.error = (
+                    _err_or_res.removeprefix(CHANNEL_UNAVAILABLE_MARKER).strip() or _err_or_res
+                )
+                self._handle_channel_unavailable(task, _err_or_res)
             else:
                 self._handle_task_failure(task, execution.error or "Unknown error")
 
@@ -989,6 +998,27 @@ class TaskScheduler:
         # 检测是否刚被自动禁用（mark_failed 内部会在 fail_count>=5 时禁用）
         if was_enabled and not task.enabled and self.on_task_auto_disabled:
             asyncio.ensure_future(self._notify_auto_disabled(task))
+
+    def _handle_channel_unavailable(self, task: ScheduledTask, marker: str) -> None:
+        """Skip this run without counting it as task logic failure."""
+        if task.status != TaskStatus.RUNNING:
+            logger.warning(
+                "Task %s: channel-unavailable skip from %s, expected RUNNING",
+                task.id,
+                task.status.value,
+            )
+            return
+
+        message = marker.removeprefix(CHANNEL_UNAVAILABLE_MARKER).strip() or marker
+        task.last_run = datetime.now()
+        task.updated_at = task.last_run
+        if not task.metadata:
+            task.metadata = {}
+        task.metadata["last_channel_unavailable"] = message
+        task.metadata["last_channel_unavailable_at"] = task.last_run.isoformat()
+        task.status = TaskStatus.SCHEDULED
+        self._advance_next_run(task)
+        logger.warning("Task %s skipped because IM channel is unavailable: %s", task.id, message)
 
     async def _notify_auto_disabled(self, task: ScheduledTask) -> None:
         """安全调用 on_task_auto_disabled 回调"""

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import openakita.channels.gateway as gateway_module
+from openakita.channels.base import ChannelDeliveryUnavailable
 from openakita.channels.gateway import MessageGateway
 from openakita.channels.types import (
     MediaFile,
@@ -151,6 +152,45 @@ class TestMessageGatewayBroadcast:
 
         assert delivered is False
         session_manager.add_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_text_reliably_propagates_channel_unavailable(self):
+        session_manager = MagicMock()
+        session_manager.add_message = MagicMock()
+        gateway = MessageGateway(session_manager=session_manager)
+        adapter = MagicMock()
+        adapter.format_final_footer = MagicMock(return_value=None)
+        adapter.send_message = AsyncMock(
+            side_effect=ChannelDeliveryUnavailable(
+                "unavailable",
+                channel="wechat:test",
+                chat_id="chat-1",
+                reason="context rejected",
+            )
+        )
+        gateway._adapters["wechat:test"] = adapter
+
+        with pytest.raises(ChannelDeliveryUnavailable):
+            await gateway.send_text_reliably("wechat:test", "chat-1", "hello")
+
+        session_manager.add_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_propagates_channel_unavailable(self):
+        gateway = MessageGateway(session_manager=MagicMock())
+        adapter = MagicMock()
+        adapter.send_text = AsyncMock(
+            side_effect=ChannelDeliveryUnavailable(
+                "unavailable",
+                channel="wechat:test",
+                chat_id="chat-1",
+                reason="session expired",
+            )
+        )
+        gateway._adapters["wechat:test"] = adapter
+
+        with pytest.raises(ChannelDeliveryUnavailable):
+            await gateway.send("wechat:test", "chat-1", "hello")
 
     @pytest.mark.asyncio
     async def test_broadcast_rejects_non_text_payload_before_listing_sessions(self):

--- a/tests/unit/test_scheduler_executor_status.py
+++ b/tests/unit/test_scheduler_executor_status.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from openakita.channels.base import ChannelDeliveryUnavailable
 from openakita.scheduler.executor import TaskExecutor
 from openakita.scheduler.scheduler import TaskScheduler
 from openakita.scheduler.task import ScheduledTask
@@ -75,6 +76,43 @@ class _FallbackGateway:
         return pair == ("feishu:bot", "chat-2")
 
 
+class _UnavailableGateway:
+    async def send(self, **kwargs):
+        raise ChannelDeliveryUnavailable(
+            "unavailable",
+            channel=kwargs["channel"],
+            chat_id=kwargs["chat_id"],
+            reason="context rejected",
+        )
+
+    async def send_text_reliably(self, **kwargs):
+        raise ChannelDeliveryUnavailable(
+            "unavailable",
+            channel=kwargs["channel"],
+            chat_id=kwargs["chat_id"],
+            reason="context rejected",
+        )
+
+
+class _EndUnavailableGateway:
+    def __init__(self):
+        self.start_calls = 0
+        self.reliable_calls = 0
+
+    async def send(self, **kwargs):
+        self.start_calls += 1
+        return "start-msg"
+
+    async def send_text_reliably(self, **kwargs):
+        self.reliable_calls += 1
+        raise ChannelDeliveryUnavailable(
+            "unavailable",
+            channel=kwargs["channel"],
+            chat_id=kwargs["chat_id"],
+            reason="context rejected",
+        )
+
+
 async def _make_scheduler(tmp_path, executor) -> TaskScheduler:
     scheduler = TaskScheduler(
         storage_path=tmp_path,
@@ -129,6 +167,55 @@ async def test_result_delivery_failure_marks_scheduled_task_failed(tmp_path):
     stored = scheduler.get_task(task_id)
     assert stored is not None
     assert stored.fail_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_notification_channel_unavailable_skips_before_agent_creation(tmp_path):
+    factory_calls = 0
+
+    def factory():
+        nonlocal factory_calls
+        factory_calls += 1
+        return _SuccessfulAgent()
+
+    executor = TaskExecutor(agent_factory=factory, gateway=_UnavailableGateway())
+    scheduler = await _make_scheduler(tmp_path, executor=executor.execute)
+    task = _make_task(channel_id="wechat:test", chat_id="chat-1")
+    task_id = await scheduler.add_task(task)
+
+    execution = await scheduler.trigger_now(task_id)
+
+    assert execution is not None
+    assert execution.status == "failed"
+    assert execution.error == "IM 通道不可投递：微信会话或 context_token 已失效，请在微信中发送一条新消息刷新会话，或重新扫码登录。"
+    assert factory_calls == 0
+    stored = scheduler.get_task(task_id)
+    assert stored is not None
+    assert stored.fail_count == 0
+    assert stored.metadata["last_channel_unavailable"] == execution.error
+
+
+@pytest.mark.asyncio
+async def test_successful_task_with_channel_unavailable_result_does_not_increment_fail_count(
+    tmp_path,
+):
+    gateway = _EndUnavailableGateway()
+    executor = TaskExecutor(agent_factory=lambda: _SuccessfulAgent(), gateway=gateway)
+    scheduler = await _make_scheduler(tmp_path, executor=executor.execute)
+    task = _make_task(channel_id="wechat:test", chat_id="chat-1")
+    task_id = await scheduler.add_task(task)
+
+    execution = await scheduler.trigger_now(task_id)
+
+    assert execution is not None
+    assert execution.status == "failed"
+    assert execution.error == "IM 通道不可投递：微信会话或 context_token 已失效，请在微信中发送一条新消息刷新会话，或重新扫码登录。"
+    assert gateway.start_calls == 1
+    assert gateway.reliable_calls == 1
+    stored = scheduler.get_task(task_id)
+    assert stored is not None
+    assert stored.fail_count == 0
+    assert stored.metadata["last_channel_unavailable"] == execution.error
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_wechat_adapter_context_token.py
+++ b/tests/unit/test_wechat_adapter_context_token.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from openakita.channels.adapters.wechat import (
+    CONTEXT_TOKEN_STALE_S,
+    WeChatAdapter,
+    _ContextTokenEntry,
+)
+from openakita.channels.base import ChannelDeliveryUnavailable
+
+
+def _make_adapter(tmp_path) -> WeChatAdapter:
+    adapter = WeChatAdapter(token="token", channel_name="wechat:test", bot_id="test")
+    adapter._sync_buf_dir = tmp_path
+    return adapter
+
+
+def test_stale_context_token_is_not_reused(tmp_path):
+    adapter = _make_adapter(tmp_path)
+    adapter._context_tokens["chat-1"] = _ContextTokenEntry(
+        token="old-token",
+        captured_at=time.time() - CONTEXT_TOKEN_STALE_S - 1,
+    )
+
+    assert adapter._resolve_context_token("chat-1", {"context_token": "old-token"}) == ""
+
+    entry = adapter._context_tokens["chat-1"]
+    assert entry.invalidated
+    assert entry.invalid_reason == "context_token stale"
+
+
+def test_legacy_context_token_file_loads_as_invalidated(tmp_path):
+    adapter = _make_adapter(tmp_path)
+    adapter._context_tokens_path().write_text(
+        json.dumps({"chat-1": "legacy-token"}),
+        encoding="utf-8",
+    )
+
+    adapter._load_context_tokens()
+
+    assert adapter._resolve_context_token("chat-1", {"context_token": "legacy-token"}) == ""
+    entry = adapter._context_tokens["chat-1"]
+    assert entry.invalidated
+    assert entry.invalid_reason == "legacy token without capture timestamp"
+
+
+@pytest.mark.asyncio
+async def test_send_text_ret_minus_two_invalidates_context_token(tmp_path, monkeypatch):
+    adapter = _make_adapter(tmp_path)
+    adapter._context_tokens["chat-1"] = _ContextTokenEntry(
+        token="fresh-token",
+        captured_at=time.time(),
+    )
+
+    async def fake_api_post(endpoint, body, *, timeout_s=None):
+        assert endpoint == "ilink/bot/sendmessage"
+        return {"ret": -2, "errmsg": "context rejected"}
+
+    async def no_wait(chat_id):
+        return None
+
+    monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+    monkeypatch.setattr(adapter, "_rate_limit_wait", no_wait)
+
+    with pytest.raises(ChannelDeliveryUnavailable) as exc_info:
+        await adapter._send_text("chat-1", "hello", "fresh-token")
+
+    assert exc_info.value.channel == "wechat:test"
+    assert exc_info.value.chat_id == "chat-1"
+    entry = adapter._context_tokens["chat-1"]
+    assert entry.invalidated
+    assert "ret=-2" in entry.invalid_reason


### PR DESCRIPTION
## Summary
- Fix 629 by tracking WeChat context_token freshness and invalidating rejected tokens when iLink returns ret=-2.
- Propagate explicit channel-unavailable errors through the gateway so scheduled IM tasks can short-circuit before LLM execution when WeChat delivery is already unavailable.
- Avoid increasing scheduler fail_count when a task succeeds but final IM delivery is blocked by an unavailable WeChat session.

## Tests
- uv run --frozen ruff check src/openakita/channels/base.py src/openakita/channels/__init__.py src/openakita/channels/adapters/wechat.py src/openakita/channels/gateway.py src/openakita/scheduler/executor.py src/openakita/scheduler/scheduler.py tests/unit/test_wechat_adapter_context_token.py tests/unit/test_scheduler_executor_status.py tests/integration/test_gateway.py
- uv run --frozen pytest tests/unit/test_wechat_adapter_context_token.py tests/unit/test_scheduler_executor_status.py tests/integration/test_gateway.py -q

Fixes #629 
