### PR TITLE
Keep agent editor actions visible at the bottom of the drawer

### DIFF
--- a/apps/setup-center/src/views/AgentManagerView.tsx
+++ b/apps/setup-center/src/views/AgentManagerView.tsx
@@ -1035,15 +1035,16 @@ export function AgentManagerView({
 
       {/* Editor Sheet */}
       <Sheet open={editorOpen} onOpenChange={(open) => { if (!open) closeEditor(); }}>
-        <SheetContent side="right" className="w-[460px] max-w-[90vw] overflow-y-auto p-0" onOpenAutoFocus={(e) => e.preventDefault()}>
-          <SheetHeader className="px-6 pt-6 pb-2">
+        <SheetContent side="right" className="w-[460px] max-w-[90vw] overflow-hidden p-0" onOpenAutoFocus={(e) => e.preventDefault()}>
+          <SheetHeader className="shrink-0 px-6 pt-6 pb-2">
             <SheetTitle>{isCreating ? t("agentManager.create") : t("agentManager.edit")}</SheetTitle>
             <SheetDescription className="sr-only">
               {isCreating ? t("agentManager.create") : t("agentManager.edit")}
             </SheetDescription>
           </SheetHeader>
 
-          <div className="flex flex-col gap-4 px-6 pb-6">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6 pt-4">
+          <div className="flex flex-col gap-4">
             {/* ID */}
             <div className="space-y-1.5">
               <Label className="text-xs opacity-70">{t("agentManager.id")}</Label>
@@ -1415,19 +1416,21 @@ export function AgentManagerView({
             </div>
             )}
 
-            {/* Actions */}
-            <div className="flex gap-2 pt-2">
-              <Button variant="outline" className="flex-1" onClick={closeEditor}>
-                {t("agentManager.cancel")}
-              </Button>
-              <Button
-                className="flex-1"
-                onClick={handleSave}
-                disabled={saving || !editingProfile.name.trim() || (isCreating && !isIdValid)}
-              >
-                {saving ? t("common.loading") : t("agentManager.save")}
-              </Button>
-            </div>
+          </div>
+          </div>
+
+          {/* Actions */}
+          <div className="sticky bottom-0 z-10 flex shrink-0 gap-2 border-t bg-background/95 px-6 py-4 shadow-[0_-8px_24px_rgba(0,0,0,0.08)] backdrop-blur supports-[backdrop-filter]:bg-background/80">
+            <Button variant="outline" className="flex-1" onClick={closeEditor}>
+              {t("agentManager.cancel")}
+            </Button>
+            <Button
+              className="flex-1"
+              onClick={handleSave}
+              disabled={saving || !editingProfile.name.trim() || (isCreating && !isIdValid)}
+            >
+              {saving ? t("common.loading") : t("agentManager.save")}
+            </Button>
           </div>
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Summary
- Keep the agent editor drawer actions pinned to the bottom while the form content scrolls.

## Tests
- npm run build:web

Fixes #626