### PR TITLE
fix organization command console file attachments

### DIFF
--- a/apps/setup-center/src/components/OrgChatPanel.tsx
+++ b/apps/setup-center/src/components/OrgChatPanel.tsx
@@ -5,14 +5,16 @@
  */
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, ShieldAlert, Copy as IconCopy } from "lucide-react";
+import { Loader2, ShieldAlert, Copy as IconCopy, Paperclip } from "lucide-react";
 import { toast } from "sonner";
 import { safeFetch } from "../providers";
 import { copyToClipboard } from "../utils/clipboard";
 import { onWsEvent } from "../platform";
 import { useMdModules } from "../views/chat/hooks/useMdModules";
+import { AttachmentPreview } from "../views/chat/components/AttachmentPreview";
 import { FileAttachmentCard } from "./FileAttachmentCard";
 import type { FileAttachment } from "./FileAttachmentCard";
+import type { ChatAttachment } from "../types";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -31,6 +33,7 @@ interface ChatMsg {
   timestamp: number;
   streaming?: boolean;
   attachments?: FileAttachment[];
+  inputAttachments?: ChatAttachment[];
   /**
    * P11: 内容种类的细粒度标记，用于让样式（bubble 颜色 / class 名）跟"语义"
    * 解耦。例如 role="system" 同时被用于真正的错误通知（红色合理）和
@@ -339,9 +342,12 @@ function saveToLocalStorage(cid: string, msgs: ChatMsg[]): void {
       : msgs;
     const slim = windowed
       .filter(m => !m.streaming)
-      .map(({ id, role, content, timestamp, attachments, kind }) => {
+      .map(({ id, role, content, timestamp, attachments, inputAttachments, kind }) => {
         const o: Record<string, unknown> = { id, role, content, timestamp };
         if (attachments && attachments.length > 0) o.attachments = attachments;
+        if (inputAttachments && inputAttachments.length > 0) {
+          o.inputAttachments = cleanInputAttachments(inputAttachments);
+        }
         if (kind) o.kind = kind;
         return o;
       });
@@ -357,11 +363,88 @@ function loadFromLocalStorage(cid: string): ChatMsg[] {
   } catch { return []; }
 }
 
+function normalizeInputAttachments(raw: unknown): ChatAttachment[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ChatAttachment[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const name = String(obj.name || obj.filename || "").trim();
+    if (!name) continue;
+    const typeRaw = String(obj.type || "file");
+    const type: ChatAttachment["type"] =
+      typeRaw === "image" || typeRaw === "video" || typeRaw === "voice" || typeRaw === "document"
+        ? typeRaw
+        : "file";
+    const url = typeof obj.url === "string" ? obj.url : undefined;
+    const previewUrl = typeof obj.previewUrl === "string" ? obj.previewUrl : undefined;
+    out.push({
+      type,
+      name,
+      url,
+      localPath: typeof obj.localPath === "string" ? obj.localPath : typeof obj.local_path === "string" ? obj.local_path : undefined,
+      uploadId: typeof obj.uploadId === "string" ? obj.uploadId : typeof obj.upload_id === "string" ? obj.upload_id : undefined,
+      previewUrl: type === "image" ? (previewUrl && !previewUrl.startsWith("blob:") ? previewUrl : url) : undefined,
+      size: typeof obj.size === "number" ? obj.size : undefined,
+      mimeType: typeof obj.mimeType === "string" ? obj.mimeType : typeof obj.mime_type === "string" ? obj.mime_type : undefined,
+      uploadStatus: obj.uploadStatus === "failed" ? "failed" : obj.uploadStatus === "uploading" ? "uploading" : "uploaded",
+      uploadError: typeof obj.uploadError === "string" ? obj.uploadError : undefined,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function cleanInputAttachments(atts: ChatAttachment[]): ChatAttachment[] {
+  return atts.map((att) => ({
+    type: att.type,
+    name: att.name,
+    url: att.url,
+    localPath: att.localPath,
+    uploadId: att.uploadId,
+    previewUrl: att.type === "image"
+      ? (att.previewUrl && !att.previewUrl.startsWith("blob:") ? att.previewUrl : att.url)
+      : undefined,
+    size: att.size,
+    mimeType: att.mimeType,
+    uploadStatus: att.uploadStatus || "uploaded",
+    uploadError: att.uploadError,
+  }));
+}
+
+function toOrgCommandAttachments(atts: ChatAttachment[]): Record<string, unknown>[] {
+  return cleanInputAttachments(atts).map((att) => ({
+    type: att.type,
+    name: att.name,
+    url: att.url,
+    local_path: att.localPath,
+    upload_id: att.uploadId,
+    size: att.size,
+    mime_type: att.mimeType,
+  }));
+}
+
+function toPersistedMessage(m: ChatMsg): Record<string, unknown> {
+  const out: Record<string, unknown> = { role: m.role, content: m.content };
+  if (m.inputAttachments && m.inputAttachments.length > 0) {
+    out.input_attachments = cleanInputAttachments(m.inputAttachments);
+  }
+  return out;
+}
+
+function attachmentTypeFor(file: File): ChatAttachment["type"] {
+  if (file.type.startsWith("image/")) return "image";
+  if (file.type.startsWith("video/")) return "video";
+  if (file.type.startsWith("audio/")) return "voice";
+  if (file.type === "application/pdf") return "document";
+  return "file";
+}
+
 export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, title, onClose, nodeNames }: OrgChatPanelProps) {
   const { t } = useTranslation();
   const md = useMdModules();
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [input, setInput] = useState("");
+  const [inputAttachments, setInputAttachments] = useState<ChatAttachment[]>([]);
   const [sending, setSending] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [canContinuePrevious, setCanContinuePrevious] = useState(false);
@@ -379,6 +462,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
   const [forwardTargets, setForwardTargets] = useState<ForwardTargetOption[]>([]);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const mountedRef = useRef(true);
   const nodeNamesRef = useRef(nodeNames);
   nodeNamesRef.current = nodeNames;
@@ -462,12 +546,18 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         ]);
         const data = await res.json();
         if (cancelled) return;
-        const histMsgs: ChatMsg[] = (data.messages || []).map((m: any) => ({
-          id: m.id || genId(),
-          role: m.role || "assistant",
-          content: m.content || "",
-          timestamp: m.timestamp || Date.now(),
-        }));
+        const histMsgs: ChatMsg[] = (data.messages || []).map((m: any) => {
+          const inputAtts = normalizeInputAttachments(
+            m.input_attachments || m.inputAttachments || (m.role === "user" ? m.attachments : undefined),
+          );
+          return {
+            id: m.id || genId(),
+            role: m.role || "assistant",
+            content: m.content || "",
+            timestamp: m.timestamp || Date.now(),
+            inputAttachments: inputAtts,
+          };
+        });
         const merged = [...activityMsgs, ...histMsgs].sort(
           (a, b) => (a.timestamp || 0) - (b.timestamp || 0),
         );
@@ -539,12 +629,18 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
           : Promise.resolve({ items: [] });
         const [histData, actData] = await Promise.all([histPromise, activityPromise]);
         if (!mountedRef.current) return;
-        const histMsgs: ChatMsg[] = (histData.messages || []).map((m: any) => ({
-          id: m.id || genId(),
-          role: m.role || "assistant",
-          content: m.content || "",
-          timestamp: m.timestamp || Date.now(),
-        }));
+        const histMsgs: ChatMsg[] = (histData.messages || []).map((m: any) => {
+          const inputAtts = normalizeInputAttachments(
+            m.input_attachments || m.inputAttachments || (m.role === "user" ? m.attachments : undefined),
+          );
+          return {
+            id: m.id || genId(),
+            role: m.role || "assistant",
+            content: m.content || "",
+            timestamp: m.timestamp || Date.now(),
+            inputAttachments: inputAtts,
+          };
+        });
         const nameFmt2 = (id: string) => nodeNamesRef.current?.[id] || id;
         const actMsgs: ChatMsg[] = activityItemsToMessages(
           (Array.isArray(actData?.items) ? actData.items : []) as ActivityItem[],
@@ -697,7 +793,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
   // Push messages to backend session (explicit params to avoid stale-ref bugs)
   const persistToBackend = useCallback(async (
     base: string, cid: string,
-    msgs: { role: string; content: string }[],
+    msgs: Record<string, unknown>[],
     replace = false,
   ) => {
     const url = `${base}/api/sessions/${encodeURIComponent(cid)}/messages`;
@@ -716,6 +812,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
 
   const handleClear = useCallback(async () => {
     setMessages([]);
+    setInputAttachments([]);
     _pendingCmds.delete(convId);
     setPendingCmdId(null);
     setCanContinuePrevious(false);
@@ -755,17 +852,103 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
     }
   }, [apiBaseUrl, orgId, pendingCmdId]);
 
+  const uploadFile = useCallback(async (file: Blob, filename: string): Promise<{
+    url: string;
+    localPath?: string;
+    uploadId?: string;
+    size?: number;
+    mimeType?: string;
+  }> => {
+    const form = new FormData();
+    form.append("file", file, filename);
+    const res = await safeFetch(`${apiBaseUrl}/api/upload`, {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(15 * 60 * 1000),
+    });
+    if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
+    const data = await res.json();
+    return {
+      url: data.url as string,
+      localPath: data.local_path as string | undefined,
+      uploadId: data.upload_id as string | undefined,
+      size: data.size as number | undefined,
+      mimeType: (data.mime_type || data.content_type) as string | undefined,
+    };
+  }, [apiBaseUrl]);
+
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    for (const file of Array.from(files)) {
+      const uploadId = genId();
+      const type = attachmentTypeFor(file);
+      const att: ChatAttachment = {
+        type,
+        name: file.name,
+        size: file.size,
+        mimeType: file.type,
+        uploadStatus: "uploading",
+        _uploadId: uploadId,
+      };
+      setInputAttachments(prev => [...prev, att]);
+      uploadFile(file, file.name)
+        .then((uploaded) => {
+          const url = `${apiBaseUrl}${uploaded.url}`;
+          setInputAttachments(prev => prev.map(a => a._uploadId === uploadId
+            ? {
+              ...a,
+              url,
+              localPath: uploaded.localPath,
+              uploadId: uploaded.uploadId,
+              previewUrl: type === "image" ? url : undefined,
+              size: uploaded.size ?? a.size,
+              mimeType: uploaded.mimeType ?? a.mimeType,
+              uploadStatus: "uploaded",
+              uploadError: undefined,
+            }
+            : a));
+        })
+        .catch((err) => {
+          toast.error(`文件上传失败: ${file.name}`);
+          setInputAttachments(prev => prev.map(a => a._uploadId === uploadId
+            ? { ...a, uploadStatus: "failed", uploadError: String(err) }
+            : a));
+        });
+    }
+    e.target.value = "";
+  }, [apiBaseUrl, uploadFile]);
+
   const handleSend = useCallback(async (opts?: { continuePrevious?: boolean; text?: string }) => {
     const text = (opts?.text ?? input).trim();
-    if (!text || sending) return;
+    const attachmentsToSend = opts?.continuePrevious ? [] : inputAttachments;
+    if ((!text && attachmentsToSend.length === 0) || sending) return;
+    const pendingUploads = attachmentsToSend.filter(a => a.uploadStatus === "uploading" || (!a.url && !a.localPath));
+    if (pendingUploads.length > 0) {
+      toast.error(t("chat.uploadStillRunning", "附件还在上传，请稍等一下"));
+      return;
+    }
+    if (attachmentsToSend.some(a => a.uploadStatus === "failed")) {
+      toast.error(t("chat.uploadFailedRetry", "有附件上传失败，请重新选择或稍后重试"));
+      return;
+    }
 
-    const userMsg: ChatMsg = { id: genId(), role: "user", content: text, timestamp: Date.now() };
+    const commandText = text || t("org.chat.attachmentsOnlyCommand", "请处理这些附件。");
+    const displayAttachments = cleanInputAttachments(attachmentsToSend);
+    const userMsg: ChatMsg = {
+      id: genId(),
+      role: "user",
+      content: text,
+      inputAttachments: displayAttachments.length > 0 ? displayAttachments : undefined,
+      timestamp: Date.now(),
+    };
     const placeholderId = genId();
     const placeholder: ChatMsg = {
       id: placeholderId, role: "assistant", content: t("org.chat.thinking"), timestamp: Date.now(), streaming: true,
     };
     setMessages(prev => [...prev, userMsg, placeholder]);
     setInput("");
+    setInputAttachments([]);
     setCanContinuePrevious(false);
     setSending(true);
 
@@ -1119,7 +1302,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         const hasUser = existing.some(m => m.id === userMsg.id);
         const toSave = hasUser ? [...existing, msg] : [...existing, userMsg, msg];
         saveToLocalStorage(convId, toSave);
-        persistToBackend(apiBaseUrl, convId, toSave.map(m => ({ role: m.role, content: m.content })), true);
+        persistToBackend(apiBaseUrl, convId, toSave.map(toPersistedMessage), true);
       }
     };
 
@@ -1159,9 +1342,10 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          content: text,
+          content: commandText,
           target_node_id: nodeId || undefined,
           continue_previous: !!opts?.continuePrevious,
+          attachments: toOrgCommandAttachments(attachmentsToSend),
           forward_to: forwardTargets.map(ft => ({
             channel: ft.channel,
             chat_id: ft.chat_id,
@@ -1250,11 +1434,11 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
       if (mountedRef.current) {
         const all = messagesRef.current.filter(m => !m.streaming);
         if (all.length > 0) {
-          persistToBackend(apiBaseUrl, convId, all.map(m => ({ role: m.role, content: m.content })), true);
+          persistToBackend(apiBaseUrl, convId, all.map(toPersistedMessage), true);
         }
       }
     }
-  }, [input, sending, orgId, nodeId, apiBaseUrl, convId, persistToBackend, forwardTargets]);
+  }, [input, inputAttachments, sending, orgId, nodeId, apiBaseUrl, convId, persistToBackend, forwardTargets, t]);
 
   const handleContinuePrevious = useCallback(() => {
     handleSend({
@@ -1354,13 +1538,20 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
           >
             <div className={`ocp-msg-bubble ${m.role !== "user" ? "chatMdContent" : ""}`}>
               {m.role === "user" ? (
-                m.content
+                m.content || (m.inputAttachments && m.inputAttachments.length > 0 ? t("org.chat.attachmentsOnlyCommand", "请处理这些附件。") : "")
               ) : md ? (
                 <md.ReactMarkdown remarkPlugins={md.remarkPlugins} rehypePlugins={md.rehypePlugins}>
                   {m.content}
                 </md.ReactMarkdown>
               ) : (
                 m.content
+              )}
+              {m.inputAttachments && m.inputAttachments.length > 0 && (
+                <div className="ocp-input-attachments ocp-msg-input-attachments">
+                  {m.inputAttachments.map((att, i) => (
+                    <AttachmentPreview key={`${att.name}-${i}`} att={att} />
+                  ))}
+                </div>
               )}
               {m.streaming && <span className="ocp-typing">●</span>}
               {m.attachments && m.attachments.length > 0 && (
@@ -1446,7 +1637,39 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         </div>
       )}
 
+      {inputAttachments.length > 0 && (
+        <div className="ocp-input-attachments ocp-composer-attachments">
+          {inputAttachments.map((att, i) => (
+            <AttachmentPreview
+              key={att._uploadId || `${att.name}-${i}`}
+              att={att}
+              onRemove={() => {
+                setInputAttachments(prev => prev.filter((_, ix) => ix !== i));
+              }}
+            />
+          ))}
+        </div>
+      )}
+
       <div className={`ocp-input-area ${compact ? "ocp-compact" : ""}`}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          onChange={handleFileSelect}
+          style={{ display: "none" }}
+        />
+        <button
+          data-slot="ocp"
+          type="button"
+          className="ocp-attach"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={sending}
+          title={t("common.attach", "添加附件")}
+          aria-label={t("common.attach", "添加附件")}
+        >
+          <Paperclip size={16} />
+        </button>
         <textarea
           ref={inputRef}
           value={input}
@@ -1472,7 +1695,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         <button
           data-slot="ocp"
           onClick={() => handleSend()}
-          disabled={sending || !input.trim()}
+          disabled={sending || (!input.trim() && inputAttachments.length === 0)}
           className={`ocp-send ${sending ? "ocp-send-busy" : ""}`}
         >
           {sending ? (
@@ -1733,6 +1956,34 @@ const CHAT_CSS = `
   flex-shrink: 0;
 }
 .ocp-compact { padding: 8px 10px; }
+.ocp-input-attachments {
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+.ocp-msg-input-attachments {
+  margin-top: 8px; justify-content: flex-end;
+}
+.ocp-composer-attachments {
+  padding: 10px 12px 0 12px;
+  border-top: 1px solid var(--line, rgba(51,65,85,0.5));
+  background: var(--bg-app);
+  flex-shrink: 0;
+}
+.ocp-composer-attachments + .ocp-input-area { border-top: none; }
+.ocp-attach {
+  width: 36px; height: 36px; border-radius: 10px; flex-shrink: 0;
+  border: 1px solid var(--line, rgba(100,116,139,0.3));
+  background: transparent;
+  color: var(--muted, #64748b);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.ocp-attach:not(:disabled):hover {
+  background: rgba(99,102,241,0.10);
+  border-color: rgba(99,102,241,0.45);
+  color: var(--primary, #6366f1);
+}
+.ocp-attach:disabled { opacity: 0.35; cursor: not-allowed; }
 .ocp-textarea {
   flex: 1; resize: none; border: 1px solid var(--line, rgba(100,116,139,0.2));
   border-radius: 10px; padding: 10px 14px;

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -1683,6 +1683,17 @@ def _enrich_org_content_with_attachments(content: str, attachments: list | None)
     for att in attachments:
         local_path = getattr(att, "local_path", None) or ""
         if not local_path:
+            url = getattr(att, "url", None) or ""
+            if url:
+                try:
+                    from openakita.api.routes.upload import resolve_upload_path
+
+                    resolved = resolve_upload_path(url)
+                    if resolved:
+                        local_path = str(resolved)
+                except Exception:
+                    logger.debug("[OrgAttach] failed to resolve upload URL %s", url, exc_info=True)
+        if not local_path:
             continue
         fpath = Path(local_path)
         if not fpath.exists():

--- a/src/openakita/api/routes/orgs.py
+++ b/src/openakita/api/routes/orgs.py
@@ -106,6 +106,30 @@ def _get_command_service(request: Request):
     return svc
 
 
+def _coerce_attachment_info(raw: Any) -> Any | None:
+    """Normalize setup-center attachment JSON to the ChatRequest attachment shape."""
+    if not isinstance(raw, dict):
+        return None
+    name = str(raw.get("name") or raw.get("filename") or "").strip()
+    if not name:
+        return None
+    try:
+        from openakita.api.schemas import AttachmentInfo
+
+        return AttachmentInfo(
+            type=str(raw.get("type") or "file"),
+            name=name,
+            url=raw.get("url"),
+            local_path=raw.get("local_path") or raw.get("localPath"),
+            upload_id=raw.get("upload_id") or raw.get("uploadId"),
+            size=raw.get("size"),
+            mime_type=raw.get("mime_type") or raw.get("mimeType"),
+        )
+    except Exception:
+        logger.debug("[OrgAPI] failed to normalize attachment: %r", raw, exc_info=True)
+        return None
+
+
 def _require_org_running(rt, org_id: str):
     """校验组织处于可接受外部指令的状态。
 
@@ -682,10 +706,26 @@ async def send_command(request: Request, org_id: str):
     """
     svc = _get_command_service(request)
     body = await request.json()
-    content = body.get("content", "")
+    content = str(body.get("content") or "")
+    user_facing_content = content
     target_node = body.get("target_node_id")
     if not content:
         raise HTTPException(400, "content is required")
+    attachments: list[Any] = []
+    raw_attachments = body.get("attachments") or []
+    if isinstance(raw_attachments, list):
+        attachments = [
+            att
+            for att in (_coerce_attachment_info(item) for item in raw_attachments[:20])
+            if att is not None
+        ]
+    if attachments:
+        try:
+            from openakita.api.routes.chat import _enrich_org_content_with_attachments
+
+            content = _enrich_org_content_with_attachments(content, attachments)
+        except Exception:
+            logger.warning("[OrgAPI] failed to enrich org command attachments", exc_info=True)
     source = OrgCommandSource(
         channel=str(body.get("source_channel") or "desktop"),
         chat_id=str(body.get("source_chat_id") or svc.bridge_session_chat_id(org_id, target_node)),
@@ -709,6 +749,7 @@ async def send_command(request: Request, org_id: str):
             OrgCommandRequest(
                 org_id=org_id,
                 content=content,
+                user_facing_content=user_facing_content,
                 target_node_id=target_node,
                 source=source,
                 origin_surface=OrgCommandSurface.ORG_CONSOLE,
@@ -716,6 +757,19 @@ async def send_command(request: Request, org_id: str):
                 replace_existing=bool(body.get("replace_existing")),
                 continue_previous=bool(body.get("continue_previous")),
                 forward_to=forward_targets,
+                input_attachments=[
+                    {
+                        "type": getattr(att, "type", "file"),
+                        "name": getattr(att, "name", ""),
+                        "url": getattr(att, "url", None),
+                        "local_path": getattr(att, "local_path", None),
+                        "upload_id": getattr(att, "upload_id", None),
+                        "size": getattr(att, "size", None),
+                        "mime_type": getattr(att, "mime_type", None),
+                        "uploadStatus": "uploaded",
+                    }
+                    for att in attachments
+                ],
             )
         )
     except OrgCommandConflict as exc:

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -288,6 +288,9 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     attachments = msg.get("attachments")
     if attachments:
         entry["attachments"] = attachments
+    input_attachments = msg.get("input_attachments")
+    if input_attachments:
+        entry["input_attachments"] = input_attachments
     org_timeline = msg.get("org_timeline")
     if org_timeline:
         entry["org_timeline"] = org_timeline
@@ -603,6 +606,10 @@ def _cancel_tasks_for_session(request: Request, conversation_id: str, session_id
 class AppendMessageRequest(BaseModel):
     role: str = Field(..., description="user | assistant | system")
     content: str = Field(..., description="Message content")
+    input_attachments: list[dict] | None = Field(
+        None,
+        description="User-uploaded attachments shown in embedded chat UIs",
+    )
 
 
 class AppendBatchRequest(BaseModel):
@@ -644,7 +651,10 @@ async def append_session_messages(
         session.context.clear_messages()
 
     for msg in body.messages:
-        session.add_message(msg.role, msg.content)
+        meta: dict = {}
+        if msg.input_attachments:
+            meta["input_attachments"] = msg.input_attachments
+        session.add_message(msg.role, msg.content, **meta)
 
     session_manager.mark_dirty()
     return {"ok": True, "count": len(body.messages), "replaced": body.replace}

--- a/src/openakita/orgs/command_service.py
+++ b/src/openakita/orgs/command_service.py
@@ -160,6 +160,10 @@ class OrgCommandRequest:
     continue_previous: bool = False
     forward_to: list[ForwardTarget] = field(default_factory=list)
     """Extra IM destinations to mirror final result / cancellation to."""
+    user_facing_content: str | None = None
+    """Optional content to persist/render when run content contains hidden attachment text."""
+    input_attachments: list[dict[str, Any]] = field(default_factory=list)
+    """User-uploaded attachments shown in the command console history."""
 
 
 def set_command_service(service: OrgCommandService | None) -> None:
@@ -221,6 +225,7 @@ class OrgCommandService:
         content = (request.content or "").strip()
         if not content:
             raise OrgCommandError("content is required")
+        user_facing_content = (request.user_facing_content or content).strip()
 
         org = self._require_org_running(request.org_id)
         if request.target_node_id and not org.get_node(request.target_node_id):
@@ -274,16 +279,22 @@ class OrgCommandService:
             }
             self._running_by_root[root_key] = command_id
 
-        self._bridge_persist_user_message(request.org_id, request.target_node_id, content)
+        self._bridge_persist_user_message(
+            request.org_id,
+            request.target_node_id,
+            user_facing_content,
+            input_attachments=request.input_attachments,
+        )
         self._mirror_command_to_distributed_surfaces(
             request,
             command_id=command_id,
             root_node_id=root_node_id,
-            user_facing_content=content,
+            user_facing_content=user_facing_content,
         )
         run_request = OrgCommandRequest(
             org_id=request.org_id,
             content=run_content,
+            user_facing_content=user_facing_content,
             target_node_id=request.target_node_id,
             source=request.source,
             origin_surface=request.origin_surface,
@@ -291,6 +302,7 @@ class OrgCommandService:
             replace_existing=request.replace_existing,
             continue_previous=request.continue_previous,
             forward_to=list(request.forward_to),
+            input_attachments=list(request.input_attachments),
         )
         self._schedule_run(
             run_request,
@@ -713,10 +725,11 @@ class OrgCommandService:
             if not self._runtime._has_active_delegations(request.org_id, root_node_id):
                 inbox = self._runtime.get_inbox(request.org_id)
                 result_text = (result or {}).get("result", "")
+                task_preview = (request.user_facing_content or request.content)[:60]
                 inbox.push_task_complete(
                     request.org_id,
                     root_node_id,
-                    request.content[:60],
+                    task_preview,
                     result_text[:300] if result_text else "命令已完成",
                 )
         except Exception:
@@ -985,6 +998,8 @@ class OrgCommandService:
         org_id: str,
         target_node_id: str | None,
         content: str,
+        *,
+        input_attachments: list[dict[str, Any]] | None = None,
     ) -> None:
         sm = self._session_manager
         if not sm:
@@ -998,7 +1013,10 @@ class OrgCommandService:
                 create_if_missing=True,
             )
             if session:
-                session.add_message("user", content)
+                meta: dict[str, Any] = {}
+                if input_attachments:
+                    meta["input_attachments"] = list(input_attachments)
+                session.add_message("user", content, **meta)
                 sm.mark_dirty()
         except Exception as exc:
             logger.warning("[OrgCmd] failed to persist user message to session: %s", exc)

--- a/tests/orgs/test_command_service.py
+++ b/tests/orgs/test_command_service.py
@@ -186,6 +186,38 @@ def test_get_status_includes_scope_and_surface(persisted_org):
     assert status["output_scope"] == "chat_summary"
 
 
+def test_submit_persists_visible_content_and_runs_enriched_content(persisted_org):
+    persisted_org.status = OrgStatus.ACTIVE
+    rt = MagicMock()
+    rt.get_org.return_value = persisted_org
+    service = OrgCommandService(rt, None)
+    service._schedule_run = MagicMock()
+    service._bridge_persist_user_message = MagicMock()
+
+    service.submit(
+        OrgCommandRequest(
+            org_id=persisted_org.id,
+            content="请总结\n\n--- 文件: notes.txt ---\nsecret\n--- 文件结束 ---",
+            user_facing_content="请总结",
+            input_attachments=[
+                {
+                    "type": "file",
+                    "name": "notes.txt",
+                    "local_path": "D:/tmp/notes.txt",
+                    "uploadStatus": "uploaded",
+                }
+            ],
+        )
+    )
+
+    service._bridge_persist_user_message.assert_called_once()
+    assert service._bridge_persist_user_message.call_args.args[2] == "请总结"
+    assert service._bridge_persist_user_message.call_args.kwargs["input_attachments"][0]["name"] == "notes.txt"
+    run_request = service._schedule_run.call_args.args[0]
+    assert "secret" in run_request.content
+    assert run_request.user_facing_content == "请总结"
+
+
 @pytest.mark.asyncio
 async def test_summary_delivery_records_target(persisted_org):
     persisted_org.status = OrgStatus.ACTIVE

--- a/tests/unit/test_upload_audio_attachments.py
+++ b/tests/unit/test_upload_audio_attachments.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from openakita.api.routes import upload
+from openakita.api.routes.chat import _enrich_org_content_with_attachments
+from openakita.api.schemas import AttachmentInfo
 from openakita.core.agent import _format_desktop_attachment_reference
 
 
@@ -58,3 +60,24 @@ def test_desktop_uploaded_audio_reference_includes_local_path(tmp_path, monkeypa
     assert "[音频: meeting.wav (audio/wav)" in text
     assert str(saved) in text
     assert "请直接使用文件/音频处理工具打开该本地路径" in text
+
+
+def test_org_attachment_enrichment_resolves_uploaded_url(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload, "UPLOAD_DIR", tmp_path)
+    uploaded = tmp_path / "123_notes.txt"
+    uploaded.write_text("hello from upload", encoding="utf-8")
+
+    text = _enrich_org_content_with_attachments(
+        "请总结附件",
+        [
+            AttachmentInfo(
+                type="file",
+                name="notes.txt",
+                url="/api/uploads/123_notes.txt",
+                mime_type="text/plain",
+            )
+        ],
+    )
+
+    assert "--- 文件: notes.txt ---" in text
+    assert "hello from upload" in text


### PR DESCRIPTION
## Summary
- Add file attachment upload and preview support to the organization command console.
- Pass command attachments through /api/orgs/{org}/command and enrich organization execution content with text files or local file references.
- Persist command-console input attachment metadata so history reloads keep the visible attachment chips.

## Tests
- uv run pytest tests/orgs/test_command_service.py tests/unit/test_upload_audio_attachments.py
- npm run build