### PR TITLE
Add sidebar release notes dialog for version clicks

### DIFF
--- a/apps/setup-center/src/components/Sidebar.tsx
+++ b/apps/setup-center/src/components/Sidebar.tsx
@@ -10,7 +10,9 @@ import {
   IconShield, IconRadar, IconBuilding, IconBarChart,
 } from "../icons";
 import logoUrl from "../assets/logo.png";
-import { openExternalUrl } from "../platform";
+import { openExternalUrl, proxyFetch } from "../platform";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
+import { useMdModules } from "../views/chat/hooks/useMdModules";
 
 export type SidebarProps = {
   collapsed: boolean;
@@ -52,6 +54,158 @@ type NavGroupId = "capabilities" | "apps" | "monitor" | "multiAgent" | "store";
 const GROUP_ICON_SIZE = 16;
 
 const BETA_SUP = <sup style={{ fontSize: 9, color: "var(--primary, #3b82f6)", fontWeight: 600 }}>Beta</sup>;
+const RELEASE_NOTES_BASE_URL = "https://dl-openakita.fzstack.com/api/releases";
+
+type ReleaseNotesJson = {
+  version: string;
+  pub_date: string;
+  notes: string;
+  notes_zh?: string;
+  notes_en?: string;
+  channel?: string;
+};
+
+function normalizeReleaseVersion(version: string): string {
+  return String(version || "").trim().replace(/^v/i, "");
+}
+
+function formatReleaseTime(value?: string): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+  ].join("-") + ` ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function pickReleaseNotes(data: ReleaseNotesJson, lang: string): string {
+  const base = lang.split("-")[0];
+  if (base === "zh" && data.notes_zh?.trim()) return data.notes_zh;
+  if (base === "en" && data.notes_en?.trim()) return data.notes_en;
+  return data.notes || data.notes_zh || data.notes_en || "";
+}
+
+function coerceReleaseNotesJson(data: unknown): ReleaseNotesJson {
+  const obj = data && typeof data === "object" ? data as Record<string, unknown> : {};
+  return {
+    version: typeof obj.version === "string" ? obj.version : "",
+    pub_date: typeof obj.pub_date === "string" ? obj.pub_date : "",
+    notes: typeof obj.notes === "string" ? obj.notes : "",
+    notes_zh: typeof obj.notes_zh === "string" ? obj.notes_zh : undefined,
+    notes_en: typeof obj.notes_en === "string" ? obj.notes_en : undefined,
+    channel: typeof obj.channel === "string" ? obj.channel : undefined,
+  };
+}
+
+async function fetchReleaseNotesJson(url: string, defaultVersion = ""): Promise<ReleaseNotesJson> {
+  const response = await proxyFetch(url, {
+    timeoutSecs: 12,
+    headers: { Accept: "application/json" },
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const data = coerceReleaseNotesJson(JSON.parse(response.body));
+  if (!data.version && defaultVersion) data.version = defaultVersion;
+  return data;
+}
+
+function ReleaseNotesDialog({
+  version,
+  onClose,
+}: {
+  version: string;
+  onClose: () => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const mdModules = useMdModules();
+  const [release, setRelease] = useState<ReleaseNotesJson | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const normalizedVersion = normalizeReleaseVersion(version);
+
+  const loadReleaseNotes = useCallback(async () => {
+    if (!normalizedVersion) {
+      setRelease(null);
+      setError("Missing version");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${RELEASE_NOTES_BASE_URL}/v${encodeURIComponent(normalizedVersion)}.json`;
+      const data = await fetchReleaseNotesJson(url, normalizedVersion);
+      setRelease(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setRelease(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [normalizedVersion]);
+
+  useEffect(() => {
+    void loadReleaseNotes();
+  }, [loadReleaseNotes]);
+
+  const notes = release ? pickReleaseNotes(release, i18n.language) : "";
+  const releaseVersion = release?.version || normalizedVersion;
+  const releaseTime = formatReleaseTime(release?.pub_date);
+  const versionLabel = `v${normalizeReleaseVersion(releaseVersion)}`;
+  const releaseSubtitle = releaseTime
+    ? `${versionLabel} · ${t("version.releasePubDate", { date: releaseTime })}`
+    : versionLabel;
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="releaseNotesDialogContent" onOpenAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>{t("version.releaseNotesTitle")}</DialogTitle>
+          <DialogDescription>{releaseSubtitle}</DialogDescription>
+        </DialogHeader>
+        <div className="releaseNotesView">
+          <div className="inboxHeader releaseNotesHeader">
+            <div className="min-w-0">
+              <h1 className="inboxTitle">{t("version.releaseNotesTitle")}</h1>
+              <p className="inboxSubtitle">{releaseSubtitle}</p>
+            </div>
+          </div>
+          <div className="releaseNotesBody">
+            {loading && (
+              <div className="releaseNotesState">
+                <div className="spinner" style={{ width: 18, height: 18 }} />
+                <span>{t("common.loading")}</span>
+              </div>
+            )}
+            {!loading && error && (
+              <div className="releaseNotesState releaseNotesError">
+                <span>{t("version.releaseNotesLoadFailed", { error })}</span>
+                <button type="button" className="btnSmall" onClick={loadReleaseNotes}>{t("common.retry")}</button>
+              </div>
+            )}
+            {!loading && !error && release && (
+              mdModules ? (
+                <div className="feedbackMdContent inboxMarkdown releaseNotesMarkdown">
+                  <mdModules.ReactMarkdown
+                    remarkPlugins={mdModules.remarkPlugins}
+                    rehypePlugins={mdModules.rehypePlugins}
+                  >
+                    {notes || t("version.releaseNotesEmpty")}
+                  </mdModules.ReactMarkdown>
+                </div>
+              ) : (
+                <div className="releaseNotesPlain">{notes || t("version.releaseNotesEmpty")}</div>
+              )
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 function NavGroupHeader({
   collapsed: sidebarCollapsed,
@@ -127,6 +281,8 @@ export function Sidebar({
   }, []);
 
   const [pluginApps, setPluginApps] = useState<PluginUIApp[]>([]);
+  const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
+  const releaseNotesVersion = normalizeReleaseVersion(desktopVersion);
 
   // Refetch the Apps sidebar list. Triggered initially, when backend
   // availability changes, and on the global "openakita:plugin-apps-changed"
@@ -422,7 +578,13 @@ export function Sidebar({
           lineHeight: 1.6,
           flexShrink: 0,
         }}>
-          <div>{isWeb ? "Web" : "Desktop"} v{desktopVersion}{import.meta.env.VITE_PREVIEW_BUILD === "true" && <span style={{ marginLeft: 6, color: "#e8a735", fontWeight: 600, opacity: 1 }}>预览版</span>}</div>
+          <div
+            onClick={() => setReleaseNotesOpen(true)}
+            title={t("version.releaseNotesButton")}
+            style={{ cursor: "pointer" }}
+          >
+            {isWeb ? "Web" : "Desktop"} v{desktopVersion}{import.meta.env.VITE_PREVIEW_BUILD === "true" && <span style={{ marginLeft: 6, color: "#e8a735", fontWeight: 600, opacity: 1 }}>预览版</span>}
+          </div>
           {backendVersion && <div>Backend v{backendVersion}</div>}
           {!backendVersion && serviceRunning && <div>Backend: -</div>}
           <div style={{ marginTop: 4, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
@@ -480,6 +642,12 @@ export function Sidebar({
             </span>
           </div>
         </div>
+      )}
+      {releaseNotesOpen && (
+        <ReleaseNotesDialog
+          version={releaseNotesVersion}
+          onClose={() => setReleaseNotesOpen(false)}
+        />
       )}
       {collapsed && (
         <div style={{

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -1755,7 +1755,12 @@
     "updateReady": "Update Ready",
     "updateFailed": "Update Failed",
     "restartNow": "Restart Now",
-    "retry": "Retry"
+    "retry": "Retry",
+    "releaseNotesTitle": "Release Notes",
+    "releaseNotesButton": "View release notes",
+    "releasePubDate": "Published {{date}}",
+    "releaseNotesLoadFailed": "Failed to load release notes: {{error}}",
+    "releaseNotesEmpty": "No release notes available."
   },
   "onboarding": {
     "defaultWorkspace": "Default Workspace",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -1755,7 +1755,12 @@
     "updateReady": "更新已就绪",
     "updateFailed": "更新失败",
     "restartNow": "立即重启",
-    "retry": "重试"
+    "retry": "重试",
+    "releaseNotesTitle": "更新日志",
+    "releaseNotesButton": "查看更新日志",
+    "releasePubDate": "发布时间 {{date}}",
+    "releaseNotesLoadFailed": "更新日志加载失败：{{error}}",
+    "releaseNotesEmpty": "暂无更新日志。"
   },
   "onboarding": {
     "defaultWorkspace": "默认工作区",

--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -2600,6 +2600,97 @@ button.btnApplyRestart:hover {
   color: var(--text);
 }
 
+.releaseNotesDialogContent {
+  width: min(720px, calc(100vw - 32px));
+  max-width: 720px;
+  max-height: calc(100vh - 48px);
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+}
+
+.releaseNotesView {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 48px);
+  min-height: 0;
+  padding: 18px;
+}
+
+.releaseNotesHeader {
+  padding-right: 40px;
+  flex-shrink: 0;
+}
+
+.releaseNotesBody {
+  overflow: auto;
+  min-height: 260px;
+  padding: 14px 2px 0;
+}
+
+.releaseNotesBody::-webkit-scrollbar {
+  width: 8px;
+}
+
+.releaseNotesBody::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.releaseNotesBody::-webkit-scrollbar-thumb {
+  background: var(--line);
+  border-radius: 999px;
+}
+
+.releaseNotesState {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  min-height: 260px;
+  text-align: center;
+}
+
+.releaseNotesError {
+  align-items: center;
+  flex-direction: column;
+}
+
+.releaseNotesPlain {
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown {
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.78;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown h1 {
+  font-size: 1.35em;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown h2 {
+  font-size: 1.22em;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown h3 {
+  font-size: 1.1em;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown ul,
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown ol {
+  margin: 0.5em 0 0.85em;
+  padding-left: 1.35rem;
+}
+
+.feedbackMdContent.inboxMarkdown.releaseNotesMarkdown li {
+  margin: 0.3em 0;
+}
+
 /* Dialog sections */
 .dialogSection {
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary
- Add a sidebar version click target that opens a release notes dialog styled like the inbox dialog.
- Load release notes from the matching OSS `/api/releases/vX.Y.Z.json` path, render notes as Markdown, and show publication time.
- Show a load failure state when the matching version JSON is unavailable.

## Tests
- npm run build
- git diff --check