### PR TITLE
route web search providers through shared proxy configuration and log provider test diagnostics

### DIFF
--- a/src/openakita/api/routes/web_search.py
+++ b/src/openakita/api/routes/web_search.py
@@ -40,6 +40,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/web-search", tags=["搜索源"])
 
 
+def _proxy_diagnostic() -> str:
+    """Return a scrubbed proxy hint for diagnostics without exposing credentials."""
+    try:
+        from ...llm.providers.proxy_utils import format_proxy_hint
+
+        return format_proxy_hint().strip()
+    except Exception as exc:  # pragma: no cover - diagnostics must not break tests
+        return f"proxy diagnostic unavailable: {type(exc).__name__}: {exc}"
+
+
 class TestSearchRequest(BaseModel):
     """Body for ``POST /test``."""
 
@@ -127,10 +137,25 @@ async def test_search(req: TestSearchRequest) -> TestSearchResponse:
     Always 200 (no HTTPException), with structured ``ok`` + ``error_code`` so
     the frontend can render an inline result instead of a generic error toast.
     """
+    logger.info(
+        "[web_search.test] start provider=%s query_len=%d max_results=%d timeout=%.1fs proxy=%s",
+        req.provider_id,
+        len(req.query or ""),
+        req.max_results,
+        req.timeout_seconds,
+        _proxy_diagnostic() or "none",
+    )
     # Validate provider_id up front to give a clear UI message.
     try:
         get_provider(req.provider_id)
     except KeyError:
+        logger.warning(
+            "[web_search.test] failed provider=%s error_type=%s error_code=%s proxy=%s",
+            req.provider_id,
+            "KeyError",
+            "missing_credential",
+            _proxy_diagnostic() or "none",
+        )
         return TestSearchResponse(
             ok=False,
             provider_id=req.provider_id,
@@ -148,6 +173,14 @@ async def test_search(req: TestSearchRequest) -> TestSearchResponse:
             timeout_seconds=req.timeout_seconds,
         )
     except NoProviderAvailable as exc:
+        logger.warning(
+            "[web_search.test] failed provider=%s error_type=%s error_code=%s proxy=%s message=%s",
+            req.provider_id,
+            type(exc).__name__,
+            exc.error_code,
+            _proxy_diagnostic() or "none",
+            str(exc),
+        )
         return TestSearchResponse(
             ok=False,
             provider_id=req.provider_id,
@@ -155,14 +188,28 @@ async def test_search(req: TestSearchRequest) -> TestSearchResponse:
             message=str(exc) or "搜索源不可用",
         )
     except ProviderError as exc:
+        error_code = getattr(exc, "error_code", "unknown")
+        logger.warning(
+            "[web_search.test] failed provider=%s error_type=%s error_code=%s proxy=%s message=%s",
+            req.provider_id,
+            type(exc).__name__,
+            error_code,
+            _proxy_diagnostic() or "none",
+            str(exc),
+        )
         return TestSearchResponse(
             ok=False,
             provider_id=req.provider_id,
-            error_code=getattr(exc, "error_code", "unknown"),
+            error_code=error_code,
             message=str(exc) or "测试失败",
         )
     except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("[web_search.test] unexpected error testing %s", req.provider_id)
+        logger.exception(
+            "[web_search.test] unexpected provider=%s error_type=%s proxy=%s",
+            req.provider_id,
+            type(exc).__name__,
+            _proxy_diagnostic() or "none",
+        )
         return TestSearchResponse(
             ok=False,
             provider_id=req.provider_id,
@@ -170,6 +217,13 @@ async def test_search(req: TestSearchRequest) -> TestSearchResponse:
             message=f"{type(exc).__name__}: {exc}",
         )
 
+    logger.info(
+        "[web_search.test] success provider=%s result_provider=%s results=%d proxy=%s",
+        req.provider_id,
+        bundle.provider_id,
+        len(bundle.results),
+        _proxy_diagnostic() or "none",
+    )
     return TestSearchResponse(
         ok=True,
         provider_id=bundle.provider_id,

--- a/src/openakita/tools/web_search/providers/_http.py
+++ b/src/openakita/tools/web_search/providers/_http.py
@@ -1,0 +1,17 @@
+"""Shared HTTP helpers for web search providers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ....llm.providers.proxy_utils import extract_connection_error, get_httpx_client_kwargs
+
+
+def search_httpx_client_kwargs(*, timeout: float, target_url: str) -> dict[str, Any]:
+    """Build an httpx client config using OpenAkita's proxy/NO_PROXY rules."""
+    return get_httpx_client_kwargs(timeout=timeout, target_url=target_url)
+
+
+def describe_httpx_failure(exc: BaseException) -> str:
+    """Return the useful root-cause detail hidden inside httpx wrapper errors."""
+    return extract_connection_error(exc)

--- a/src/openakita/tools/web_search/providers/bocha.py
+++ b/src/openakita/tools/web_search/providers/bocha.py
@@ -20,6 +20,7 @@ from ..base import (
     SearchResult,
 )
 from ..registry import register
+from ._http import describe_httpx_failure, search_httpx_client_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -89,16 +90,18 @@ async def _post_and_parse(
     import httpx
 
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(
+            **search_httpx_client_kwargs(timeout=timeout, target_url=url)
+        ) as client:
             resp = await client.post(url, headers=headers, json=json_body)
     except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
         raise NetworkUnreachableError(
-            f"{provider_id} transport failure: {type(exc).__name__}: {exc}",
+            f"{provider_id} transport failure: {describe_httpx_failure(exc)}",
             provider_id=provider_id,
         ) from exc
     except httpx.HTTPError as exc:
         raise NetworkUnreachableError(
-            f"{provider_id} HTTP error: {type(exc).__name__}: {exc}",
+            f"{provider_id} HTTP error: {describe_httpx_failure(exc)}",
             provider_id=provider_id,
         ) from exc
 

--- a/src/openakita/tools/web_search/providers/jina.py
+++ b/src/openakita/tools/web_search/providers/jina.py
@@ -21,6 +21,7 @@ from ..base import (
     SearchResult,
 )
 from ..registry import register
+from ._http import describe_httpx_failure, search_httpx_client_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -58,16 +59,18 @@ class JinaProvider:
         import httpx
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                **search_httpx_client_kwargs(timeout=timeout, target_url=url)
+            ) as client:
                 resp = await client.get(url, headers=headers)
         except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
             raise NetworkUnreachableError(
-                f"jina transport failure: {type(exc).__name__}: {exc}",
+                f"jina transport failure: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
         except httpx.HTTPError as exc:
             raise NetworkUnreachableError(
-                f"jina HTTP error: {type(exc).__name__}: {exc}",
+                f"jina HTTP error: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
 

--- a/src/openakita/tools/web_search/providers/searxng.py
+++ b/src/openakita/tools/web_search/providers/searxng.py
@@ -20,6 +20,7 @@ from ..base import (
     SearchResult,
 )
 from ..registry import register
+from ._http import describe_httpx_failure, search_httpx_client_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -58,20 +59,23 @@ class SearXNGProvider:
             "language": _region_to_lang(region),
         }
         timeout = timeout_seconds if timeout_seconds and timeout_seconds > 0 else 30.0
+        endpoint = self._endpoint()
 
         import httpx
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.get(self._endpoint(), params=params)
+            async with httpx.AsyncClient(
+                **search_httpx_client_kwargs(timeout=timeout, target_url=endpoint)
+            ) as client:
+                resp = await client.get(endpoint, params=params)
         except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
             raise NetworkUnreachableError(
-                f"searxng transport failure: {type(exc).__name__}: {exc}",
+                f"searxng transport failure: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
         except httpx.HTTPError as exc:
             raise NetworkUnreachableError(
-                f"searxng HTTP error: {type(exc).__name__}: {exc}",
+                f"searxng HTTP error: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
 

--- a/src/openakita/tools/web_search/providers/tavily.py
+++ b/src/openakita/tools/web_search/providers/tavily.py
@@ -20,6 +20,7 @@ from ..base import (
     SearchResult,
 )
 from ..registry import register
+from ._http import describe_httpx_failure, search_httpx_client_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -62,16 +63,18 @@ class TavilyProvider:
         import httpx
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                **search_httpx_client_kwargs(timeout=timeout, target_url=self._ENDPOINT)
+            ) as client:
                 resp = await client.post(self._ENDPOINT, json=payload)
         except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
             raise NetworkUnreachableError(
-                f"tavily transport failure: {type(exc).__name__}: {exc}",
+                f"tavily transport failure: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
         except httpx.HTTPError as exc:
             raise NetworkUnreachableError(
-                f"tavily HTTP error: {type(exc).__name__}: {exc}",
+                f"tavily HTTP error: {describe_httpx_failure(exc)}",
                 provider_id=self.id,
             ) from exc
 


### PR DESCRIPTION
Summary
- Route web search HTTP providers through the shared proxy configuration helper.
- Log provider test diagnostics with provider, error type, error code, and scrubbed proxy details.

Tests
- uv run ruff check src\openakita\tools\web_search\providers\_http.py src\openakita\tools\web_search\providers\jina.py src\openakita\tools\web_search\providers\tavily.py src\openakita\tools\web_search\providers\bocha.py src\openakita\tools\web_search\providers\searxng.py src\openakita\api\routes\web_search.py
- uv run pytest tests\unit\test_web_search_provider_panel.py

Fixes #662