### PR TITLE
fix chat resume for long-running streams

### DIFF
--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -82,6 +82,22 @@ def _chat_endpoint_names() -> set[str]:
         return set()
 
 
+def _should_emit_resume_task_idle(
+    *,
+    busy: bool,
+    terminal_seen: bool,
+    seconds_since_event: float,
+) -> bool:
+    """Whether ``/api/chat/resume`` may close with synthetic task_idle.
+
+    Busy state alone is not a completion signal: the lifecycle lease can be
+    released by stale cleanup, explicit cancel, or background handoff.  Resume
+    only uses synthetic ``done`` after the SSE session itself has observed a
+    real terminal event for the current turn.
+    """
+    return (not busy) and terminal_seen and seconds_since_event > 1.0
+
+
 def _format_controlled_action_result(
     decision: ConfirmationDecision,
     result: dict,
@@ -1162,6 +1178,30 @@ async def _stream_chat(
     _save_done = False
     session = None
     conversation_id = chat_request.conversation_id or ""
+    _BUSY_REFRESH_INTERVAL = 60.0
+    _last_busy_refresh_ts = 0.0
+
+    async def _refresh_busy_lease(*, force: bool = False) -> None:
+        nonlocal _last_busy_refresh_ts
+        if not conversation_id or not busy_generation:
+            return
+        now = time.time()
+        if not force and now - _last_busy_refresh_ts < _BUSY_REFRESH_INTERVAL:
+            return
+        try:
+            refreshed = await get_lifecycle_manager().refresh(
+                conversation_id,
+                generation=busy_generation,
+            )
+            if refreshed:
+                _last_busy_refresh_ts = now
+        except Exception:
+            logger.debug(
+                "[Chat API] busy lease refresh failed (conv=%s, gen=%d)",
+                conversation_id,
+                busy_generation,
+                exc_info=True,
+            )
 
     try:
         # ── Turn-scoped replay floor (cross-turn replay guard) ──
@@ -1211,6 +1251,7 @@ async def _stream_chat(
         conversation_id = chat_request.conversation_id or f"api_{_uuid.uuid4().hex[:12]}"
         turn_id = f"{conversation_id}:{request_id or _uuid.uuid4().hex[:12]}"
         session_messages_history: list[dict] = []
+        await _refresh_busy_lease(force=True)
 
         if session_manager and conversation_id:
             try:
@@ -1419,6 +1460,7 @@ async def _stream_chat(
             return out
 
         while True:
+            await _refresh_busy_lease()
             try:
                 event = await asyncio.wait_for(_agent_queue.get(), timeout=COALESCER_TICK_INTERVAL)
             except TimeoutError:
@@ -1439,6 +1481,7 @@ async def _stream_chat(
             if event is None:
                 break
 
+            await _refresh_busy_lease()
             event_type = event.get("type", "")
 
             # Observe every raw event (before coalescing / disconnect gating) so
@@ -1987,8 +2030,33 @@ async def _stream_org_command_chat(
     target_node_id = chat_request.org_node_id or None
     queue = None
     command_id = ""
+    _BUSY_REFRESH_INTERVAL = 60.0
+    _last_busy_refresh_ts = 0.0
+
+    async def _refresh_busy_lease(*, force: bool = False) -> None:
+        nonlocal _last_busy_refresh_ts
+        if not conversation_id or not busy_generation:
+            return
+        now = time.time()
+        if not force and now - _last_busy_refresh_ts < _BUSY_REFRESH_INTERVAL:
+            return
+        try:
+            refreshed = await get_lifecycle_manager().refresh(
+                conversation_id,
+                generation=busy_generation,
+            )
+            if refreshed:
+                _last_busy_refresh_ts = now
+        except Exception:
+            logger.debug(
+                "[Chat API] org busy lease refresh failed (conv=%s, gen=%d)",
+                conversation_id,
+                busy_generation,
+                exc_info=True,
+            )
 
     try:
+        await _refresh_busy_lease(force=True)
         if session_manager:
             session = session_manager.get_session(
                 channel="desktop",
@@ -2070,12 +2138,14 @@ async def _stream_org_command_chat(
         # 事件实时构建独立的 timeline 卡片，不再需要把它塞进 text_replace 正文。
         progress_entries: list[dict] = []
         while True:
+            await _refresh_busy_lease()
             try:
                 item = await asyncio.wait_for(queue.get(), timeout=30)
             except TimeoutError:
                 yield _sse("heartbeat", {"org_id": org_id, "command_id": command_id})
                 continue
 
+            await _refresh_busy_lease()
             if item.get("type") == "org_progress":
                 summary = item.get("summary") or ""
                 if summary:
@@ -3104,10 +3174,11 @@ async def chat_resume(
     2. Tail-poll the ringbuffer every 100ms; whenever ``current_seq``
        advances, flush the newly-buffered events.
     3. Exit when ANY of:
-       - Client disconnects (``request.is_disconnected()``).
-       - Lifecycle reports the conversation idle (task ended).
-       - 15 minutes elapse with no new events (matches the SSE
-         disconnect grace period — beyond this we'd just be a leak).
+        - Client disconnects (``request.is_disconnected()``).
+        - The SSE session has seen this turn's terminal event and
+          lifecycle also reports the conversation idle.
+        - 15 minutes elapse with no new events (matches the SSE
+          disconnect grace period — beyond this we'd just be a leak).
 
     The same conversation can have multiple concurrent ``/resume``
     subscribers (e.g. user has the app open on two devices); each gets
@@ -3206,22 +3277,29 @@ async def chat_resume(
                     _last_event_time = _now
                     _last_ping_time = _now
                 else:
-                    # No new events.  Check if the lifecycle says the
-                    # conversation is no longer busy and we've quiesced
-                    # for a bit — then we can close cleanly.
+                    # No new events.  Busy state alone is not a terminal
+                    # signal: stale lease cleanup or background handoff can
+                    # make lifecycle look idle while the agent is still
+                    # between events.  Only close with synthetic done after
+                    # the ringbuffer has observed this turn's real done.
                     try:
                         status = await lifecycle.get_busy_status(conversation_id)
                         busy = bool(status.get("busy"))
                     except Exception:
                         busy = False
-                    if not busy and time.time() - _last_event_time > 1.0:
+                    if _should_emit_resume_task_idle(
+                        busy=busy,
+                        terminal_seen=sse_session.is_terminal,
+                        seconds_since_event=time.time() - _last_event_time,
+                    ):
                         # Emit a synthetic done so the client can clean up.
                         yield (
                             f"data: {json.dumps({'type': 'done', 'reason': 'task_idle', 'last_seq': _last_emitted_seq}, ensure_ascii=False)}\n\n"
                         )
                         break
-                    # Idle but still busy — periodic keepalive ping so
-                    # the connection survives long LLM thinking turns.
+                    # No terminal event yet — periodic keepalive ping so the
+                    # connection survives long LLM thinking turns even if the
+                    # lifecycle lease is momentarily absent.
                     if time.time() - _last_ping_time >= 15.0:
                         yield (
                             f": ping resume-tail elapsed={(time.time() - _tail_started_at):.0f}s\n\n"

--- a/src/openakita/api/routes/conversation_lifecycle.py
+++ b/src/openakita/api/routes/conversation_lifecycle.py
@@ -33,7 +33,7 @@ from .double_texting import DoubleTextingPolicy
 
 logger = logging.getLogger(__name__)
 
-BUSY_TIMEOUT_SECONDS = 600  # 10 min auto-release
+BUSY_TIMEOUT_SECONDS = 600  # 10 min idle lease auto-release
 
 
 @dataclass
@@ -44,6 +44,9 @@ class BusyInfo:
     # v1.27.14: optional per-turn idempotency key (S1.6).  None when the
     # caller did not supply one or for legacy endpoints.
     turn_id: str | None = None
+    # Last positive liveness signal from the owner.  ``start_time`` remains
+    # the user-visible "busy since" value; stale cleanup uses this lease clock.
+    last_heartbeat: float = field(default_factory=time.time)
 
 
 @dataclass
@@ -199,12 +202,15 @@ class ConversationLifecycleManager:
                     )
                 took_over = existing
 
+            now = time.time()
             self._generation_counter += 1
             gen = self._generation_counter
             self._busy[conversation_id] = BusyInfo(
                 client_id=client_id,
+                start_time=now,
                 generation=gen,
                 turn_id=turn_id,
+                last_heartbeat=now,
             )
             # FIX 3 (v1.27.14 b-cut): wake & drop the stale idle Event.
             #
@@ -288,6 +294,36 @@ class ConversationLifecycleManager:
         )
         return True
 
+    async def refresh(
+        self,
+        conversation_id: str,
+        *,
+        generation: int | None = None,
+    ) -> bool:
+        """Refresh the active busy lease for a still-running owner.
+
+        ``start_time`` is intentionally unchanged so clients keep seeing the
+        original "busy since" timestamp.  The optional generation guard mirrors
+        :meth:`finish` and prevents stale streams from extending a newer lock.
+        """
+        if not conversation_id:
+            return False
+        async with self._lock:
+            existing = self._busy.get(conversation_id)
+            if existing is None:
+                return False
+            if generation is not None and existing.generation != generation:
+                logger.debug(
+                    "[Lifecycle] refresh() skipped: generation mismatch "
+                    "conv=%s current=%d requested=%d",
+                    conversation_id,
+                    existing.generation,
+                    generation,
+                )
+                return False
+            existing.last_heartbeat = time.time()
+            return True
+
     async def wait_for_idle(
         self,
         conversation_id: str,
@@ -355,6 +391,7 @@ class ConversationLifecycleManager:
                         "conversation_id": conversation_id,
                         "client_id": info.client_id,
                         "since": info.start_time,
+                        "last_heartbeat": info.last_heartbeat,
                     }
                 return {"busy": False, "conversation_id": conversation_id}
             return {
@@ -363,6 +400,7 @@ class ConversationLifecycleManager:
                         "conversation_id": cid,
                         "client_id": info.client_id,
                         "since": info.start_time,
+                        "last_heartbeat": info.last_heartbeat,
                     }
                     for cid, info in self._busy.items()
                 ],
@@ -379,9 +417,9 @@ class ConversationLifecycleManager:
             pass
 
     def _expire_stale(self) -> None:
-        """Remove entries older than BUSY_TIMEOUT_SECONDS.  Caller holds ``self._lock``."""
+        """Remove entries whose owner has not refreshed its lease in time."""
         now = time.time()
-        stale = [k for k, v in self._busy.items() if now - v.start_time > BUSY_TIMEOUT_SECONDS]
+        stale = [k for k, v in self._busy.items() if now - v.last_heartbeat > BUSY_TIMEOUT_SECONDS]
         for k in stale:
             logger.info("[Lifecycle] Auto-releasing stale busy lock: conv=%s", k)
             del self._busy[k]

--- a/src/openakita/core/sse_replay.py
+++ b/src/openakita/core/sse_replay.py
@@ -112,6 +112,10 @@ class SSESession:
     # this floor to the current max seq at the start of each turn, making
     # cross-turn replay structurally impossible. See ``begin_turn``.
     _replay_floor: int = 0
+    # Terminal marker for the current turn.  ``done`` may be evicted from the
+    # ringbuffer, but resume still needs to know that this turn actually ended.
+    _terminal_seq: int = 0
+    _terminal_event_type: str = ""
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _last_activity: float = field(default_factory=time.time)
 
@@ -137,6 +141,9 @@ class SSESession:
             )
             self._events.append(evt)
             self._last_activity = evt.ts
+            if event_type == "done":
+                self._terminal_seq = evt.seq
+                self._terminal_event_type = event_type
             return evt
 
     # ------------------------------------------------------------------
@@ -162,6 +169,8 @@ class SSESession:
         with self._lock:
             if self._seq > self._replay_floor:
                 self._replay_floor = self._seq
+            self._terminal_seq = 0
+            self._terminal_event_type = ""
             return self._replay_floor
 
     # ------------------------------------------------------------------
@@ -213,6 +222,21 @@ class SSESession:
     def last_activity(self) -> float:
         with self._lock:
             return self._last_activity
+
+    @property
+    def is_terminal(self) -> bool:
+        with self._lock:
+            return self._terminal_seq > 0
+
+    @property
+    def terminal_seq(self) -> int:
+        with self._lock:
+            return self._terminal_seq
+
+    @property
+    def terminal_event_type(self) -> str:
+        with self._lock:
+            return self._terminal_event_type
 
     def __len__(self) -> int:  # noqa: D401 - len of buffered events
         with self._lock:

--- a/tests/integration/test_conversation_concurrency.py
+++ b/tests/integration/test_conversation_concurrency.py
@@ -201,6 +201,54 @@ class TestConversationLifecycleStart:
         assert ok is False
 
 
+class TestConversationLifecycleRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_extends_busy_lease_without_changing_since(self, monkeypatch) -> None:
+        from openakita.api.routes import conversation_lifecycle as lifecycle_mod
+
+        now = 1000.0
+        monkeypatch.setattr(lifecycle_mod.time, "time", lambda: now)
+
+        mgr = ConversationLifecycleManager()
+        r = await mgr.start("conv-lease", "client-A", policy=DoubleTextingPolicy.QUEUE)
+        assert r.generation == 1
+        assert mgr._busy["conv-lease"].start_time == 1000.0
+        assert mgr._busy["conv-lease"].last_heartbeat == 1000.0
+
+        now = 1500.0
+        assert await mgr.refresh("conv-lease", generation=r.generation) is True
+        assert mgr._busy["conv-lease"].start_time == 1000.0
+        assert mgr._busy["conv-lease"].last_heartbeat == 1500.0
+
+        now = 2099.0
+        status = await mgr.get_busy_status("conv-lease")
+        assert status["busy"] is True
+        assert status["since"] == 1000.0
+        assert status["last_heartbeat"] == 1500.0
+
+        now = 2101.0
+        status = await mgr.get_busy_status("conv-lease")
+        assert status["busy"] is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_generation_mismatch_does_not_extend_lease(self, monkeypatch) -> None:
+        from openakita.api.routes import conversation_lifecycle as lifecycle_mod
+
+        now = 1000.0
+        monkeypatch.setattr(lifecycle_mod.time, "time", lambda: now)
+
+        mgr = ConversationLifecycleManager()
+        r = await mgr.start("conv-lease", "client-A", policy=DoubleTextingPolicy.QUEUE)
+
+        now = 1500.0
+        assert await mgr.refresh("conv-lease", generation=r.generation + 1) is False
+        assert mgr._busy["conv-lease"].last_heartbeat == 1000.0
+
+        now = 1601.0
+        status = await mgr.get_busy_status("conv-lease")
+        assert status["busy"] is False
+
+
 # ── S1.5: TaskState settled_event / abandoned ─────────────────────────
 
 

--- a/tests/unit/test_c17_sse_replay.py
+++ b/tests/unit/test_c17_sse_replay.py
@@ -97,6 +97,23 @@ class TestSSESession:
         time.sleep(0.03)
         assert s.is_idle() is True
 
+    def test_done_marks_session_terminal(self) -> None:
+        s = SSESession(session_id="conv_terminal")
+        assert s.is_terminal is False
+        evt = s.add_event("done", {})
+        assert s.is_terminal is True
+        assert s.terminal_seq == evt.seq
+        assert s.terminal_event_type == "done"
+
+    def test_begin_turn_clears_terminal_marker(self) -> None:
+        s = SSESession(session_id="conv_terminal_clear")
+        s.add_event("done", {})
+        assert s.is_terminal is True
+        s.begin_turn()
+        assert s.is_terminal is False
+        assert s.terminal_seq == 0
+        assert s.terminal_event_type == ""
+
 
 # ---------------------------------------------------------------------------
 # Turn-boundary replay floor — the cross-turn replay guard.

--- a/tests/unit/test_chat_resume_idle.py
+++ b/tests/unit/test_chat_resume_idle.py
@@ -1,0 +1,34 @@
+from openakita.api.routes.chat import _should_emit_resume_task_idle
+
+
+def test_resume_task_idle_requires_terminal_event() -> None:
+    assert (
+        _should_emit_resume_task_idle(
+            busy=False,
+            terminal_seen=False,
+            seconds_since_event=30.0,
+        )
+        is False
+    )
+
+
+def test_resume_task_idle_emits_after_terminal_and_idle() -> None:
+    assert (
+        _should_emit_resume_task_idle(
+            busy=False,
+            terminal_seen=True,
+            seconds_since_event=1.1,
+        )
+        is True
+    )
+
+
+def test_resume_task_idle_does_not_emit_while_busy() -> None:
+    assert (
+        _should_emit_resume_task_idle(
+            busy=True,
+            terminal_seen=True,
+            seconds_since_event=30.0,
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- Refresh conversation busy leases during long-running streaming turns so active tasks are not auto-released by the stale-lock timeout.
- Track terminal SSE state and require resume tails to see a real terminal event before emitting synthetic task_idle.

## Tests
- uv run pytest tests\integration\test_conversation_concurrency.py -k "ConversationLifecycleRefresh or ConversationLifecycleStart or WaitForIdle"
- uv run pytest tests\unit\test_c17_sse_replay.py -k "SSESession or TurnBoundaryReplayFloor"
- uv run pytest tests\unit\test_chat_resume_idle.py
- uv run ruff check src\openakita\api\routes\chat.py src\openakita\api\routes\conversation_lifecycle.py src\openakita\core\sse_replay.py tests\integration\test_conversation_concurrency.py tests\unit\test_c17_sse_replay.py tests\unit\test_chat_resume_idle.py

Fixes #683