### PR TITLE
fix org JSONL readers and runtime repair to recover from corrupted tail writes

### DIFF
--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -1620,6 +1620,10 @@ fn runtime_cache_dir() -> PathBuf {
     runtime_root_dir().join("cache")
 }
 
+fn runtime_uv_cache_dir() -> PathBuf {
+    runtime_cache_dir().join("uv")
+}
+
 fn runtime_venv_python_path(venv_dir: &Path) -> PathBuf {
     if cfg!(windows) {
         venv_dir.join("Scripts").join("python.exe")
@@ -1730,7 +1734,7 @@ fn ensure_runtime_layout() -> Result<(), String> {
         agent_venv_dir(),
         runtime_logs_dir(),
         runtime_cache_dir().join("wheels"),
-        runtime_cache_dir().join("uv"),
+        runtime_uv_cache_dir(),
         runtime_cache_dir().join("python"),
     ] {
         if let Err(e) = fs::create_dir_all(&dir) {
@@ -2071,7 +2075,7 @@ fn apply_runtime_bootstrap_env(cmd: &mut Command, pip_index: Option<&RuntimePipI
     cmd.env("UV_PYTHON_INSTALL_DIR", &py_install);
     cmd.env("UV_PYTHON_BIN_DIR", &py_install);
     // 给 uv 的下载缓存也定向到 runtime/cache/uv/，与现有 cache layout 一致。
-    cmd.env("UV_CACHE_DIR", runtime_cache_dir().join("uv"));
+    cmd.env("UV_CACHE_DIR", runtime_uv_cache_dir());
 }
 
 fn apply_runtime_core_env(cmd: &mut Command) {
@@ -2136,6 +2140,56 @@ fn health_check_python(py: &Path, code: &str, log_path: &Path) -> bool {
             false
         }
         Err(_) => false,
+    }
+}
+
+fn quarantine_runtime_uv_cache(report: &mut String) {
+    let cache_dir = runtime_uv_cache_dir();
+    if !cache_dir.exists() {
+        report.push_str(&format!("uv cache absent: {}\n", cache_dir.display()));
+        if let Err(e) = fs::create_dir_all(&cache_dir) {
+            report.push_str(&format!(
+                "warn: recreate uv cache dir {} failed: {}\n",
+                cache_dir.display(),
+                e
+            ));
+        }
+        return;
+    }
+
+    let quarantine = runtime_root_dir()
+        .join("reports")
+        .join(format!("uv-cache-quarantine-{}", now_epoch_secs()));
+    match fs::rename(&cache_dir, &quarantine) {
+        Ok(()) => {
+            report.push_str(&format!(
+                "quarantined uv cache {} -> {}\n",
+                cache_dir.display(),
+                quarantine.display()
+            ));
+        }
+        Err(rename_err) => {
+            report.push_str(&format!(
+                "warn: quarantine uv cache {} failed: {}; deleting cache\n",
+                cache_dir.display(),
+                rename_err
+            ));
+            match fs::remove_dir_all(&cache_dir) {
+                Ok(()) => report.push_str(&format!("removed uv cache {}\n", cache_dir.display())),
+                Err(remove_err) => report.push_str(&format!(
+                    "warn: remove uv cache {} failed: {}\n",
+                    cache_dir.display(),
+                    remove_err
+                )),
+            }
+        }
+    }
+    if let Err(e) = fs::create_dir_all(&cache_dir) {
+        report.push_str(&format!(
+            "warn: recreate uv cache dir {} failed: {}\n",
+            cache_dir.display(),
+            e
+        ));
     }
 }
 
@@ -2321,11 +2375,30 @@ report = {{
     "sys_path": sys.path,
     "site_packages": [],
     "packages": {{}},
+    "package_errors": {{}},
     "native_extensions": [],
+    "nul_byte_files": [],
     "managed_roots": managed_roots,
 }}
 
+def scan_nul_bytes(root, limit=20):
+    try:
+        base = pathlib.Path(root)
+        for py_file in base.rglob("*.py"):
+            try:
+                data = py_file.read_bytes()
+            except Exception:
+                continue
+            if b"\x00" in data:
+                report["nul_byte_files"].append(str(py_file.resolve()))
+                if len(report["nul_byte_files"]) >= limit:
+                    break
+    except Exception as exc:
+        report["nul_scan_error"] = repr(exc)
+
 def fail(reason):
+    scan_nul_bytes(venv / "Lib" / "site-packages")
+    scan_nul_bytes(venv / "lib")
     report["health_status"] = "failed"
     report["health_reason"] = reason
     print(json.dumps(report, ensure_ascii=False, indent=2))
@@ -2382,8 +2455,17 @@ for p in sys.path:
     if "site-packages" in low and any(marker in low for marker in bad_path_markers):
         fail("sys.path contains disallowed site-packages: " + str(p))
 
-for mod_name in ("openakita", "pydantic", "pydantic_core", "certifi"):
-    mod = importlib.import_module(mod_name)
+for mod_name in ("openakita", "yaml", "pydantic", "pydantic_core", "certifi"):
+    try:
+        mod = importlib.import_module(mod_name)
+    except Exception as exc:
+        report["package_errors"][mod_name] = {{
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "filename": getattr(exc, "filename", ""),
+            "lineno": getattr(exc, "lineno", None),
+        }}
+        fail(f"{{mod_name}} import failed: {{type(exc).__name__}}: {{exc}}")
     mod_file = pathlib.Path(getattr(mod, "__file__", "") or "").resolve()
     report["packages"][mod_name] = str(mod_file)
     if not mod_file or not is_under(mod_file, venv):
@@ -2598,7 +2680,11 @@ fn ensure_app_venv(
                 app_venv_dir().display()
             ));
         }
-        Err("app venv health check failed after OpenAkita install".into())
+        Err(format!(
+            "app venv health check failed after OpenAkita install: python={}, log={}",
+            app_py.display(),
+            log_path.display()
+        ))
     }
 }
 
@@ -7390,6 +7476,7 @@ fn repair_runtime_env() -> Result<String, String> {
     if agent_venv_log.exists() {
         let _ = fs::remove_file(&agent_venv_log);
     }
+    quarantine_runtime_uv_cache(&mut report);
     match ensure_dual_runtime_env() {
         Ok(info) => {
             report.push_str(&format!(

--- a/src/openakita/api/routes/bug_report.py
+++ b/src/openakita/api/routes/bug_report.py
@@ -1082,7 +1082,7 @@ async def _build_bug_zip(
                 zf,
                 data_dir / "orgs",
                 "orgs",
-                patterns=("*.jsonl", "*.md"),
+                patterns=("*.jsonl", "*.json", "*.md"),
                 max_total_bytes=2 * 1024 * 1024,
             )
             _add_dir_recent(

--- a/src/openakita/orgs/blackboard.py
+++ b/src/openakita/orgs/blackboard.py
@@ -12,6 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from .jsonl_utils import read_jsonl_objects
 from .models import MemoryScope, MemoryType, OrgMemoryEntry
 
 logger = logging.getLogger(__name__)
@@ -248,20 +249,15 @@ class OrgBlackboard:
         for fpath in self._all_memory_files():
             if not fpath.is_file():
                 continue
-            lines = fpath.read_text(encoding="utf-8").strip().split("\n")
             new_lines = []
             found = False
-            for line in lines:
-                if not line.strip():
+            for data in read_jsonl_objects(fpath, log=logger):
+                if not isinstance(data, dict):
                     continue
-                try:
-                    data = json.loads(line)
-                    if data.get("id") == memory_id:
-                        found = True
-                        continue
-                except Exception:
-                    pass
-                new_lines.append(line)
+                if data.get("id") == memory_id:
+                    found = True
+                    continue
+                new_lines.append(json.dumps(data, ensure_ascii=False))
             if found:
                 fpath.write_text("\n".join(new_lines) + "\n" if new_lines else "", encoding="utf-8")
                 return True
@@ -300,18 +296,19 @@ class OrgBlackboard:
         if not path.is_file():
             return []
         entries: list[OrgMemoryEntry] = []
-        try:
-            for line in path.read_text(encoding="utf-8").strip().split("\n"):
-                if not line.strip():
-                    continue
-                e = OrgMemoryEntry.from_dict(json.loads(line))
+        for e in read_jsonl_objects(
+            path,
+            log=logger,
+            decoder=OrgMemoryEntry.from_dict,
+        ):
+            try:
                 if tag and tag not in e.tags:
                     continue
                 if self._is_expired(e):
                     continue
                 entries.append(e)
-        except Exception as exc:
-            logger.warning(f"Failed to read memory {path}: {exc}")
+            except Exception as exc:
+                logger.warning(f"Failed to read memory entry from {path}: {exc}")
         entries.sort(key=lambda e: _safe_float(e.importance), reverse=True)
         return entries[:limit]
 
@@ -323,18 +320,12 @@ class OrgBlackboard:
         prefix = content[:prefix_len].strip()
         if not prefix:
             return False
-        try:
-            for line in path.read_text(encoding="utf-8").strip().split("\n"):
-                if not line.strip():
-                    continue
-                try:
-                    existing = json.loads(line).get("content", "")
-                    if existing[:prefix_len].strip() == prefix:
-                        return True
-                except (json.JSONDecodeError, KeyError):
-                    continue
-        except Exception:
-            pass
+        for record in read_jsonl_objects(path, log=logger):
+            if not isinstance(record, dict):
+                continue
+            existing = record.get("content", "")
+            if isinstance(existing, str) and existing[:prefix_len].strip() == prefix:
+                return True
         return False
 
     def _append(self, path: Path, entry: OrgMemoryEntry, max_entries: int) -> None:
@@ -348,18 +339,22 @@ class OrgBlackboard:
         """Remove expired and least important entries if over capacity."""
         if not path.is_file():
             return
-        lines = [ln for ln in path.read_text(encoding="utf-8").strip().split("\n") if ln.strip()]
+        records = [record for record in read_jsonl_objects(path, log=logger) if isinstance(record, dict)]
 
         live_entries: list[tuple[float, str]] = []
         expired_count = 0
-        for line in lines:
+        for record in records:
             try:
-                d = json.loads(line)
-                entry = OrgMemoryEntry.from_dict(d)
+                entry = OrgMemoryEntry.from_dict(record)
                 if self._is_expired(entry):
                     expired_count += 1
                     continue
-                live_entries.append((_safe_float(entry.importance), line))
+                live_entries.append(
+                    (
+                        _safe_float(entry.importance),
+                        json.dumps(record, ensure_ascii=False),
+                    )
+                )
             except Exception:
                 continue
 

--- a/src/openakita/orgs/event_store.py
+++ b/src/openakita/orgs/event_store.py
@@ -31,6 +31,7 @@ from collections import Counter
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from .jsonl_utils import iter_jsonl_objects_reverse, read_jsonl_objects
 from .models import _new_id
 
 logger = logging.getLogger(__name__)
@@ -174,7 +175,7 @@ class OrgEventStore:
 
         return event
 
-    def _read_jsonl_safely(self, path: Path) -> list[str]:
+    def _read_jsonl_safely(self, path: Path) -> list[dict]:
         """Read a JSONL day file under ``self._lock`` so we don't see a
         torn line if another thread is mid-``emit``.
 
@@ -185,10 +186,7 @@ class OrgEventStore:
         vanishingly rare for our event sizes (a few hundred bytes).
         """
         with self._lock:
-            try:
-                return path.read_text(encoding="utf-8").strip().split("\n")
-            except OSError:
-                return []
+            return [record for record in read_jsonl_objects(path, log=logger) if isinstance(record, dict)]
 
     def query(
         self,
@@ -217,32 +215,25 @@ class OrgEventStore:
                 if day > until.replace("-", "")[:8]:
                     continue
 
-            lines = self._read_jsonl_safely(f)
-            try:
-                for line in reversed(lines):
-                    if not line.strip():
-                        continue
-                    evt = json.loads(line)
-                    ts = evt.get("timestamp", "")
-                    if since and ts < since:
-                        enough = True
-                        break
-                    if until and ts > until:
-                        continue
-                    if event_type and evt.get("event_type") != event_type:
-                        continue
-                    if actor and evt.get("actor") != actor:
-                        continue
-                    data = evt.get("data") or {}
-                    if chain_id is not None and data.get("chain_id") != chain_id:
-                        continue
-                    if task_id is not None and data.get("task_id") != task_id:
-                        continue
-                    results.append(evt)
-                    if len(results) >= limit:
-                        return results
-            except Exception as e:
-                logger.warning(f"[EventStore] Failed to parse {f}: {e}")
+            for evt in reversed(self._read_jsonl_safely(f)):
+                ts = evt.get("timestamp", "")
+                if since and ts < since:
+                    enough = True
+                    break
+                if until and ts > until:
+                    continue
+                if event_type and evt.get("event_type") != event_type:
+                    continue
+                if actor and evt.get("actor") != actor:
+                    continue
+                data = evt.get("data") or {}
+                if chain_id is not None and data.get("chain_id") != chain_id:
+                    continue
+                if task_id is not None and data.get("task_id") != task_id:
+                    continue
+                results.append(evt)
+                if len(results) >= limit:
+                    return results
 
         return results
 
@@ -250,19 +241,12 @@ class OrgEventStore:
         """Find the last pending/in-progress event for a node (for restart recovery)."""
         files = sorted(self._events_dir.glob("*.jsonl"), reverse=True)
         for f in files[:3]:
-            lines = self._read_jsonl_safely(f)
-            try:
-                for line in reversed(lines):
-                    if not line.strip():
-                        continue
-                    evt = json.loads(line)
-                    if evt.get("actor") == node_id and evt.get("event_type") in (
-                        "task_started",
-                        "node_activated",
-                    ):
-                        return evt
-            except Exception:
-                continue
+            for evt in iter_jsonl_objects_reverse(f, log=logger):
+                if evt.get("actor") == node_id and evt.get("event_type") in (
+                    "task_started",
+                    "node_activated",
+                ):
+                    return evt
         return None
 
     # ------------------------------------------------------------------

--- a/src/openakita/orgs/jsonl_utils.py
+++ b/src/openakita/orgs/jsonl_utils.py
@@ -1,0 +1,92 @@
+"""Shared tolerant JSONL readers for org append-only stores."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _is_nul_only_line(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped) and set(stripped) == {"\x00"}
+
+
+def _strip_trailing_nul_bytes(line: str) -> str:
+    if "\x00" not in line:
+        return line
+    return line.rstrip("\x00").rstrip()
+
+
+def read_jsonl_objects(
+    path: Path,
+    *,
+    log: logging.Logger | None = None,
+    decoder: Callable[[dict[str, Any]], Any] | None = None,
+) -> list[Any]:
+    """Read JSONL records while tolerating corrupt trailing lines.
+
+    Organization stores are append-only files. A crash or interrupted write can
+    leave the last line partially written or NUL-filled; callers should still
+    see earlier valid records instead of treating the whole file as empty.
+    Non-tail corrupt lines are skipped too, but logged more prominently because
+    they indicate older damage rather than a normal torn append.
+    """
+
+    active_log = log or logger
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    raw_lines = text.splitlines()
+    total_lines = len(raw_lines)
+    objects: list[Any] = []
+    skipped = 0
+    for index, line in enumerate(raw_lines, start=1):
+        if not line.strip():
+            continue
+        candidate = _strip_trailing_nul_bytes(line)
+        if not candidate:
+            candidate = line
+        try:
+            payload = json.loads(candidate)
+            objects.append(decoder(payload) if decoder else payload)
+        except Exception as exc:  # noqa: BLE001 - tolerate corrupt rows by design.
+            skipped += 1
+            is_tail = index == total_lines
+            reason = "NUL-only" if _is_nul_only_line(line) else type(exc).__name__
+            position = "tail" if is_tail else "non-tail"
+            message = f"Skipped corrupt {position} JSONL line {index} in {path} ({reason}: {exc})"
+            if is_tail:
+                active_log.warning(message)
+            else:
+                active_log.error(message)
+            continue
+
+    if skipped:
+        active_log.warning(
+            "Recovered %s valid JSONL records from %s after skipping %s corrupt line(s)",
+            len(objects),
+            path,
+            skipped,
+        )
+    return objects
+
+
+def iter_jsonl_objects_reverse(
+    path: Path,
+    *,
+    log: logging.Logger | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield JSON objects newest-first from a tolerant JSONL read."""
+
+    records = read_jsonl_objects(path, log=log)
+    for record in reversed(records):
+        if isinstance(record, dict):
+            yield record
+

--- a/tests/orgs/test_blackboard.py
+++ b/tests/orgs/test_blackboard.py
@@ -97,6 +97,28 @@ class TestWriteRead:
 
         assert len(entries) == 20
 
+    def test_read_org_ignores_corrupt_nul_tail_line(self, blackboard: OrgBlackboard):
+        blackboard.write_org("保留的组织记忆", "node_ceo", importance=0.7)
+        bb_path = blackboard._memory_dir / "blackboard.jsonl"
+        with bb_path.open("ab") as f:
+            f.write(b"\x00" * 128)
+
+        entries = blackboard.read_org()
+
+        assert [entry.content for entry in entries] == ["保留的组织记忆"]
+
+    def test_read_org_recovers_json_line_with_appended_nul_tail(
+        self, blackboard: OrgBlackboard
+    ):
+        blackboard.write_org("尾部 NUL 不应隐藏这一条", "node_ceo", importance=0.7)
+        bb_path = blackboard._memory_dir / "blackboard.jsonl"
+        content = bb_path.read_bytes().rstrip(b"\r\n") + (b"\x00" * 128)
+        bb_path.write_bytes(content)
+
+        entries = blackboard.read_org()
+
+        assert [entry.content for entry in entries] == ["尾部 NUL 不应隐藏这一条"]
+
 
 class TestTagFilter:
     def test_read_with_tag(self, blackboard: OrgBlackboard):

--- a/tests/orgs/test_event_store.py
+++ b/tests/orgs/test_event_store.py
@@ -49,6 +49,27 @@ class TestEmitAndQuery:
     def test_query_empty(self, event_store: OrgEventStore):
         assert event_store.query() == []
 
+    def test_query_ignores_corrupt_nul_tail_line(self, event_store: OrgEventStore):
+        event_store.emit("task_completed", "n1", {"x": 1})
+        event_store.emit("task_failed", "n2", {"err": "timeout"})
+        day_file = next(event_store._events_dir.glob("*.jsonl"))
+        with day_file.open("ab") as f:
+            f.write(b"\x00" * 128)
+
+        events = event_store.query()
+
+        assert [event["event_type"] for event in events] == ["task_failed", "task_completed"]
+
+    def test_query_recovers_json_line_with_appended_nul_tail(self, event_store: OrgEventStore):
+        event_store.emit("task_completed", "n1", {"x": 1})
+        day_file = next(event_store._events_dir.glob("*.jsonl"))
+        content = day_file.read_bytes().rstrip(b"\r\n") + (b"\x00" * 128)
+        day_file.write_bytes(content)
+
+        events = event_store.query()
+
+        assert [event["event_type"] for event in events] == ["task_completed"]
+
 
 class TestGetLastPending:
     def test_finds_last_activated(self, event_store: OrgEventStore):
@@ -60,6 +81,17 @@ class TestGetLastPending:
 
     def test_returns_none_when_empty(self, event_store: OrgEventStore):
         assert event_store.get_last_pending("nonexistent") is None
+
+    def test_ignores_corrupt_nul_tail_line(self, event_store: OrgEventStore):
+        event_store.emit("node_activated", "node_ceo", {"prompt": "test"})
+        day_file = next(event_store._events_dir.glob("*.jsonl"))
+        with day_file.open("ab") as f:
+            f.write(b"\x00" * 128)
+
+        pending = event_store.get_last_pending("node_ceo")
+
+        assert pending is not None
+        assert pending["event_type"] == "node_activated"
 
 
 class TestAuditLog:

--- a/tests/unit/test_feedback_sanitized_config.py
+++ b/tests/unit/test_feedback_sanitized_config.py
@@ -1,4 +1,8 @@
 import json
+import zipfile
+from io import BytesIO
+
+import pytest
 
 from openakita.api.routes import bug_report
 from openakita.utils.redaction import REDACTION
@@ -34,3 +38,39 @@ def test_sanitized_config_redacts_runtime_state_bot_credentials(monkeypatch, tmp
     assert credentials["app_id"] == "cli_public"
     assert credentials["app_secret"] == REDACTION
     assert credentials["streaming_enabled"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_bug_report_zip_includes_org_json_state(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    org_dir = data_dir / "orgs" / "org_123"
+    org_dir.mkdir(parents=True)
+    (org_dir / "org.json").write_text(json.dumps({"id": "org_123"}), encoding="utf-8")
+    (org_dir / "state.json").write_text(json.dumps({"status": "active"}), encoding="utf-8")
+    (org_dir / "events").mkdir()
+    (org_dir / "events" / "20260627.jsonl").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(bug_report, "_resolve_data_dir", lambda: data_dir)
+    monkeypatch.setattr(bug_report, "_get_recent_llm_debug_files", lambda limit=50: [])
+    monkeypatch.setattr(bug_report, "_collect_sanitized_config", lambda: {})
+    monkeypatch.setattr(bug_report, "_add_windows_crash_artifacts", lambda zf: None)
+
+    zip_bytes = await bug_report._build_bug_zip(
+        report_id="r1",
+        title="bug",
+        description="desc",
+        steps="",
+        sys_info={},
+        contact_email="",
+        contact_wechat="",
+        images=None,
+        upload_logs=False,
+        upload_debug=True,
+    )
+
+    with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+        names = set(zf.namelist())
+
+    assert "orgs/org_123/org.json" in names
+    assert "orgs/org_123/state.json" in names
+    assert "orgs/org_123/events/20260627.jsonl" in names


### PR DESCRIPTION
## Summary
- Make org JSONL readers tolerate corrupted or NUL-filled tail records so valid event and blackboard data still loads.
- Quarantine the managed uv cache during runtime repair and add app venv health diagnostics for import failures and NUL-byte corruption.
- Include org JSON state files in bug report bundles.

## Tests
- `uv run --no-project python -m pytest tests/orgs/test_event_store.py tests/orgs/test_blackboard.py tests/unit/test_feedback_sanitized_config.py`
- `uv run --no-project ruff check src/openakita/orgs/jsonl_utils.py src/openakita/orgs/event_store.py src/openakita/orgs/blackboard.py src/openakita/api/routes/bug_report.py tests/orgs/test_event_store.py tests/orgs/test_blackboard.py tests/unit/test_feedback_sanitized_config.py`
- `cargo check --manifest-path apps/setup-center/src-tauri/Cargo.toml`

Fixes #684