### PR TITLE
Fix local context window normalization

### DIFF
--- a/src/openakita/llm/types.py
+++ b/src/openakita/llm/types.py
@@ -523,8 +523,10 @@ def normalize_context_window(
     """Normalize endpoint context windows.
 
     Hosted providers keep the broad historical default. Local runtimes often
-    expose 4K/8K GGUF models; treating a missing value as 200K causes the
-    prompt/tool budgeter to overload them before it can recover.
+    expose 4K/8K GGUF models; treating a missing or invalid value as 200K
+    causes the prompt/tool budgeter to overload them before it can recover.
+    Preserve explicit local values, including the historical 200K default,
+    because they may come from user config or model capability probing.
     """
     is_local = is_local_endpoint_config(provider, base_url)
     try:
@@ -532,7 +534,7 @@ def normalize_context_window(
     except (TypeError, ValueError):
         ctx = 0
 
-    if is_local and (ctx <= 0 or ctx == DEFAULT_CONTEXT_WINDOW):
+    if is_local and ctx <= 0:
         return LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW
     if ctx <= 0:
         return DEFAULT_CONTEXT_WINDOW
@@ -552,7 +554,7 @@ class EndpointConfig:
     model: str = ""  # 模型名称
     priority: int = 1  # 优先级 (越小越优先)
     max_tokens: int = 0  # 最大输出 tokens (0=不限制，使用模型默认上限)
-    context_window: int = DEFAULT_CONTEXT_WINDOW  # 上下文窗口大小 (输入+输出总 token 上限)
+    context_window: int = 0  # 上下文窗口大小 (输入+输出总 token 上限，0=未知/使用默认)
     timeout: int = 180  # 超时时间 (秒)
     capabilities: list[str] | None = None  # 能力列表
     extra_params: dict | None = None  # 额外参数

--- a/tests/unit/test_intent_prompt_contract.py
+++ b/tests/unit/test_intent_prompt_contract.py
@@ -17,7 +17,6 @@ from openakita.core.intent_analyzer import (
     _try_fast_query_shortcut,
 )
 from openakita.llm.types import (
-    DEFAULT_CONTEXT_WINDOW,
     LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
     EndpointConfig,
 )
@@ -246,13 +245,14 @@ def test_previous_answer_replay_hint_preserves_original_user_request():
 
 
 def test_local_endpoint_missing_context_window_uses_small_model_budget():
-    endpoint = EndpointConfig(
-        name="ollama-qwen3-4b",
-        provider="ollama",
-        api_type="openai",
-        base_url="http://localhost:11434/v1",
-        model="qwen3:4b",
-        context_window=DEFAULT_CONTEXT_WINDOW,
+    endpoint = EndpointConfig.from_dict(
+        {
+            "name": "ollama-qwen3-4b",
+            "provider": "ollama",
+            "api_type": "openai",
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3:4b",
+        }
     )
 
     assert endpoint.context_window == LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW

--- a/tests/unit/test_local_endpoint_context_window.py
+++ b/tests/unit/test_local_endpoint_context_window.py
@@ -3,7 +3,12 @@ from types import SimpleNamespace
 from openakita.core.brain import Brain
 from openakita.llm.client import _friendly_error_hint
 from openakita.llm.error_types import FailoverReason
-from openakita.llm.types import LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW, EndpointConfig
+from openakita.llm.types import (
+    DEFAULT_CONTEXT_WINDOW,
+    LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
+    EndpointConfig,
+    normalize_context_window,
+)
 from openakita.tools.handlers.config import ConfigHandler
 
 
@@ -21,7 +26,7 @@ def test_local_endpoint_missing_context_window_uses_small_safe_default():
     assert endpoint.context_window == LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW
 
 
-def test_local_endpoint_legacy_large_default_is_normalized():
+def test_local_endpoint_explicit_default_sized_context_window_is_preserved():
     endpoint = EndpointConfig.from_dict(
         {
             "name": "localai-gemma",
@@ -33,7 +38,22 @@ def test_local_endpoint_legacy_large_default_is_normalized():
         }
     )
 
-    assert endpoint.context_window == LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW
+    assert endpoint.context_window == DEFAULT_CONTEXT_WINDOW
+
+
+def test_local_endpoint_context_normalization_distinguishes_missing_from_explicit_default():
+    assert (
+        normalize_context_window(None, provider="lmstudio", base_url="http://127.0.0.1:1234/v1")
+        == LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW
+    )
+    assert (
+        normalize_context_window(
+            DEFAULT_CONTEXT_WINDOW,
+            provider="lmstudio",
+            base_url="http://127.0.0.1:1234/v1",
+        )
+        == DEFAULT_CONTEXT_WINDOW
+    )
 
 
 def test_local_endpoint_explicit_large_context_window_is_preserved():


### PR DESCRIPTION
## Summary
- Preserve explicitly configured local endpoint context_window values, including 200000.
- Keep missing or invalid local endpoint context_window values on the small safe default.

## Tests
- uv run pytest tests\unit\test_local_endpoint_context_window.py tests\unit\test_intent_prompt_contract.py tests\component\test_llm_client.py
- uv run pytest tests\unit\test_config.py tests\unit\test_config_endpoint_save_api.py tests\integration\test_context_length_api.py tests\unit\test_context_budget_adaptive.py

Fixes #690