### PR TITLE
fix chat session history to persist attachments as structured message data

### DIFF
--- a/apps/setup-center/src/components/OrgChatPanel.tsx
+++ b/apps/setup-center/src/components/OrgChatPanel.tsx
@@ -33,13 +33,10 @@ interface ChatMsg {
   timestamp: number;
   streaming?: boolean;
   attachments?: FileAttachment[];
-  inputAttachments?: ChatAttachment[];
+  userAttachments?: ChatAttachment[];
   /**
-   * P11: 内容种类的细粒度标记，用于让样式（bubble 颜色 / class 名）跟"语义"
-   * 解耦。例如 role="system" 同时被用于真正的错误通知（红色合理）和
-   * IM/桌面/指挥台事件流（应当中性、不要红）。kind="activity" 即一组组织
-   * 事件聚合后渲染出的活动时间线 bubble，CSS 用 `.ocp-msg-activity` 给中性
-   * 颜色覆盖。
+   * Separates message styling from role. Activity entries reuse role="system"
+   * for ordering but render with neutral event styling instead of error styling.
    */
   kind?: "activity";
 }
@@ -84,9 +81,7 @@ interface TimelineSegment {
   /** 后端 failure_diagnoser 生成的结构化诊断 */
   diagnosis?: FailureDiagnosis;
   /**
-   * P10: 节点退出后处于"需要用户/上级补充输入"的挂起态。
-   * - "waiting_user": 节点 escalate 给用户、等待回复。UI 必须显眼提示用户回复，
-   *   否则用户会误以为系统卡死、自己点取消导致 producer 链路被 soft_stop。
+   * The node is paused because it needs a user reply before work can continue.
    */
   paused?: "waiting_user";
 }
@@ -147,19 +142,10 @@ function isSoftOrgExitReason(reason?: string): boolean {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// P11: 组织活动时间线（/api/orgs/{org}/activity）的中性渲染器。
-//
-// 之前的行为是把每个 activity item（user_command / task_assigned /
-// workbench_started / workbench_succeeded / task_completed …）映射成一条
-// 独立的 role="system" 消息——而 `.ocp-msg-system` 用了红色样式（语义上
-// 是错误通知），导致整个 IM 转发流量看起来全是"红色错误条"，并且 raw
-// event_type 直接打到标题上（[workbench_started] / [task_completed]），
-// 视觉非常吵闹、信息密度极低。
-//
-// 这里把同一条 user_command（command_id 相同）下产生的所有事件聚合到一条
-// "活动 bubble" 里，bubble 内部按时间顺序逐行渲染图标 + 行为简述，整体
-// 仍是 markdown 内容（保留 details/collapsed 等能力），而 bubble 本身用
-// kind="activity" 标记，CSS 走中性色而不是红色。
+// Neutral renderer for organization activity events from /api/orgs/{org}/activity.
+// Activity entries are grouped by command and rendered chronologically inside a
+// neutral bubble. The message still carries role="system" for ordering, while
+// kind="activity" selects the neutral visual treatment.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface ActivityItem {
@@ -342,11 +328,11 @@ function saveToLocalStorage(cid: string, msgs: ChatMsg[]): void {
       : msgs;
     const slim = windowed
       .filter(m => !m.streaming)
-      .map(({ id, role, content, timestamp, attachments, inputAttachments, kind }) => {
+      .map(({ id, role, content, timestamp, attachments, userAttachments, kind }) => {
         const o: Record<string, unknown> = { id, role, content, timestamp };
         if (attachments && attachments.length > 0) o.attachments = attachments;
-        if (inputAttachments && inputAttachments.length > 0) {
-          o.inputAttachments = cleanInputAttachments(inputAttachments);
+        if (userAttachments && userAttachments.length > 0) {
+          o.userAttachments = cleanUserAttachments(userAttachments);
         }
         if (kind) o.kind = kind;
         return o;
@@ -363,7 +349,7 @@ function loadFromLocalStorage(cid: string): ChatMsg[] {
   } catch { return []; }
 }
 
-function normalizeInputAttachments(raw: unknown): ChatAttachment[] | undefined {
+function normalizeUserAttachments(raw: unknown): ChatAttachment[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const out: ChatAttachment[] = [];
   for (const item of raw) {
@@ -382,11 +368,11 @@ function normalizeInputAttachments(raw: unknown): ChatAttachment[] | undefined {
       type,
       name,
       url,
-      localPath: typeof obj.localPath === "string" ? obj.localPath : typeof obj.local_path === "string" ? obj.local_path : undefined,
-      uploadId: typeof obj.uploadId === "string" ? obj.uploadId : typeof obj.upload_id === "string" ? obj.upload_id : undefined,
+      localPath: typeof obj.localPath === "string" ? obj.localPath : undefined,
+      uploadId: typeof obj.uploadId === "string" ? obj.uploadId : undefined,
       previewUrl: type === "image" ? (previewUrl && !previewUrl.startsWith("blob:") ? previewUrl : url) : undefined,
       size: typeof obj.size === "number" ? obj.size : undefined,
-      mimeType: typeof obj.mimeType === "string" ? obj.mimeType : typeof obj.mime_type === "string" ? obj.mime_type : undefined,
+      mimeType: typeof obj.mimeType === "string" ? obj.mimeType : undefined,
       uploadStatus: obj.uploadStatus === "failed" ? "failed" : obj.uploadStatus === "uploading" ? "uploading" : "uploaded",
       uploadError: typeof obj.uploadError === "string" ? obj.uploadError : undefined,
     });
@@ -394,7 +380,7 @@ function normalizeInputAttachments(raw: unknown): ChatAttachment[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
-function cleanInputAttachments(atts: ChatAttachment[]): ChatAttachment[] {
+function cleanUserAttachments(atts: ChatAttachment[]): ChatAttachment[] {
   return atts.map((att) => ({
     type: att.type,
     name: att.name,
@@ -412,7 +398,7 @@ function cleanInputAttachments(atts: ChatAttachment[]): ChatAttachment[] {
 }
 
 function toOrgCommandAttachments(atts: ChatAttachment[]): Record<string, unknown>[] {
-  return cleanInputAttachments(atts).map((att) => ({
+  return cleanUserAttachments(atts).map((att) => ({
     type: att.type,
     name: att.name,
     url: att.url,
@@ -425,8 +411,8 @@ function toOrgCommandAttachments(atts: ChatAttachment[]): Record<string, unknown
 
 function toPersistedMessage(m: ChatMsg): Record<string, unknown> {
   const out: Record<string, unknown> = { role: m.role, content: m.content };
-  if (m.inputAttachments && m.inputAttachments.length > 0) {
-    out.input_attachments = cleanInputAttachments(m.inputAttachments);
+  if (m.userAttachments && m.userAttachments.length > 0) {
+    out.attachments = cleanUserAttachments(m.userAttachments);
   }
   return out;
 }
@@ -444,7 +430,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
   const md = useMdModules();
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [input, setInput] = useState("");
-  const [inputAttachments, setInputAttachments] = useState<ChatAttachment[]>([]);
+  const [composerAttachments, setComposerAttachments] = useState<ChatAttachment[]>([]);
   const [sending, setSending] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [canContinuePrevious, setCanContinuePrevious] = useState(false);
@@ -547,15 +533,15 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         const data = await res.json();
         if (cancelled) return;
         const histMsgs: ChatMsg[] = (data.messages || []).map((m: any) => {
-          const inputAtts = normalizeInputAttachments(
-            m.input_attachments || m.inputAttachments || (m.role === "user" ? m.attachments : undefined),
+          const userAttachments = normalizeUserAttachments(
+            m.role === "user" ? m.attachments : undefined,
           );
           return {
             id: m.id || genId(),
             role: m.role || "assistant",
             content: m.content || "",
             timestamp: m.timestamp || Date.now(),
-            inputAttachments: inputAtts,
+            userAttachments,
           };
         });
         const merged = [...activityMsgs, ...histMsgs].sort(
@@ -630,15 +616,15 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         const [histData, actData] = await Promise.all([histPromise, activityPromise]);
         if (!mountedRef.current) return;
         const histMsgs: ChatMsg[] = (histData.messages || []).map((m: any) => {
-          const inputAtts = normalizeInputAttachments(
-            m.input_attachments || m.inputAttachments || (m.role === "user" ? m.attachments : undefined),
+          const userAttachments = normalizeUserAttachments(
+            m.role === "user" ? m.attachments : undefined,
           );
           return {
             id: m.id || genId(),
             role: m.role || "assistant",
             content: m.content || "",
             timestamp: m.timestamp || Date.now(),
-            inputAttachments: inputAtts,
+            userAttachments,
           };
         });
         const nameFmt2 = (id: string) => nodeNamesRef.current?.[id] || id;
@@ -812,7 +798,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
 
   const handleClear = useCallback(async () => {
     setMessages([]);
-    setInputAttachments([]);
+    setComposerAttachments([]);
     _pendingCmds.delete(convId);
     setPendingCmdId(null);
     setCanContinuePrevious(false);
@@ -891,11 +877,11 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         uploadStatus: "uploading",
         _uploadId: uploadId,
       };
-      setInputAttachments(prev => [...prev, att]);
+      setComposerAttachments(prev => [...prev, att]);
       uploadFile(file, file.name)
         .then((uploaded) => {
           const url = `${apiBaseUrl}${uploaded.url}`;
-          setInputAttachments(prev => prev.map(a => a._uploadId === uploadId
+          setComposerAttachments(prev => prev.map(a => a._uploadId === uploadId
             ? {
               ...a,
               url,
@@ -911,7 +897,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         })
         .catch((err) => {
           toast.error(`文件上传失败: ${file.name}`);
-          setInputAttachments(prev => prev.map(a => a._uploadId === uploadId
+          setComposerAttachments(prev => prev.map(a => a._uploadId === uploadId
             ? { ...a, uploadStatus: "failed", uploadError: String(err) }
             : a));
         });
@@ -921,7 +907,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
 
   const handleSend = useCallback(async (opts?: { continuePrevious?: boolean; text?: string }) => {
     const text = (opts?.text ?? input).trim();
-    const attachmentsToSend = opts?.continuePrevious ? [] : inputAttachments;
+    const attachmentsToSend = opts?.continuePrevious ? [] : composerAttachments;
     if ((!text && attachmentsToSend.length === 0) || sending) return;
     const pendingUploads = attachmentsToSend.filter(a => a.uploadStatus === "uploading" || (!a.url && !a.localPath));
     if (pendingUploads.length > 0) {
@@ -934,12 +920,12 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
     }
 
     const commandText = text || t("org.chat.attachmentsOnlyCommand", "请处理这些附件。");
-    const displayAttachments = cleanInputAttachments(attachmentsToSend);
+    const displayAttachments = cleanUserAttachments(attachmentsToSend);
     const userMsg: ChatMsg = {
       id: genId(),
       role: "user",
       content: text,
-      inputAttachments: displayAttachments.length > 0 ? displayAttachments : undefined,
+      userAttachments: displayAttachments.length > 0 ? displayAttachments : undefined,
       timestamp: Date.now(),
     };
     const placeholderId = genId();
@@ -948,7 +934,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
     };
     setMessages(prev => [...prev, userMsg, placeholder]);
     setInput("");
-    setInputAttachments([]);
+    setComposerAttachments([]);
     setCanContinuePrevious(false);
     setSending(true);
 
@@ -1038,9 +1024,8 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
       return segments.map(seg => {
         const body = seg.lines.join("\n\n");
         if (seg.done) {
-          // P10: waiting_user 节点单独走"挂起需回复"模板。默认展开 + 标题用
-          // ⏸ 取代 ✓，body 顶部加 blockquote 引导用户在下方输入框回应，
-          // 避免被当成普通"完成"折叠而忽略。
+          // Waiting-user nodes need an open prompt instead of a collapsed
+          // completed-task summary.
           if (seg.paused === "waiting_user") {
             const hint = t("org.chat.waitingUserNotice", {
               name: seg.nodeName,
@@ -1082,10 +1067,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         pending.allFiles = flat;
       }
       if (!mountedRef.current) return;
-      // P10: 进度流式更新时也把 attachments 推上去，让用户在过程阶段就能
-      // 看到图片/视频预览（FileAttachmentCard 已支持 img/video 内嵌）。
-      // 之前只在 finalize 时才注入 attachments，进度期间黑板登记的媒体
-      // 一直被隐藏直到任务完成。
+      // Keep generated files visible while the command is still running.
       const streamingAtts = pending?.allFiles && pending.allFiles.length > 0
         ? pending.allFiles
         : undefined;
@@ -1158,10 +1140,8 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
             segments[idx].failed = false;
             segments[idx].diagnosis = undefined;
           }
-          // P10: waiting_user 单独标记 paused 状态，让 renderTimeline 显眼
-          // 提示用户"需要你回复"。如果不标，用户会以为节点正常完成、
-          // 没有任何挂起，于是看到 producer/art-director 静默几分钟后自己
-          // 点取消（产生"任务莫名其妙被取消"的错觉）。
+          // Mark waiting-user termination separately so renderTimeline can show
+          // the reply prompt instead of a normal completion state.
           if (reason === "waiting_user") {
             segments[idx].paused = "waiting_user";
           } else {
@@ -1438,7 +1418,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         }
       }
     }
-  }, [input, inputAttachments, sending, orgId, nodeId, apiBaseUrl, convId, persistToBackend, forwardTargets, t]);
+  }, [input, composerAttachments, sending, orgId, nodeId, apiBaseUrl, convId, persistToBackend, forwardTargets, t]);
 
   const handleContinuePrevious = useCallback(() => {
     handleSend({
@@ -1538,7 +1518,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
           >
             <div className={`ocp-msg-bubble ${m.role !== "user" ? "chatMdContent" : ""}`}>
               {m.role === "user" ? (
-                m.content || (m.inputAttachments && m.inputAttachments.length > 0 ? t("org.chat.attachmentsOnlyCommand", "请处理这些附件。") : "")
+                m.content || (m.userAttachments && m.userAttachments.length > 0 ? t("org.chat.attachmentsOnlyCommand", "请处理这些附件。") : "")
               ) : md ? (
                 <md.ReactMarkdown remarkPlugins={md.remarkPlugins} rehypePlugins={md.rehypePlugins}>
                   {m.content}
@@ -1546,19 +1526,15 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
               ) : (
                 m.content
               )}
-              {m.inputAttachments && m.inputAttachments.length > 0 && (
+              {m.userAttachments && m.userAttachments.length > 0 && (
                 <div className="ocp-input-attachments ocp-msg-input-attachments">
-                  {m.inputAttachments.map((att, i) => (
-                    <AttachmentPreview key={`${att.name}-${i}`} att={att} />
+                  {m.userAttachments.map((att, i) => (
+                    <AttachmentPreview key={`${att.name}-${i}`} att={att} apiBaseUrl={apiBaseUrl} />
                   ))}
                 </div>
               )}
               {m.streaming && <span className="ocp-typing">●</span>}
               {m.attachments && m.attachments.length > 0 && (
-                /* P10: 不再用 !m.streaming 阻塞 attachments 渲染——进度阶段
-                   收到的图片/视频可以即时显示给用户，避免任务完成前用户
-                   一直看不到媒体。FileAttachmentCard 已根据扩展名渲染
-                   img / video 内嵌预览。 */
                 <div style={{ borderTop: "1px solid rgba(100,116,139,0.2)", marginTop: 10, paddingTop: 8, display: "flex", flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
                   {m.attachments.map((f, i) => (
                     <FileAttachmentCard key={f.file_path || i} file={f} apiBaseUrl={apiBaseUrl} inline />
@@ -1637,14 +1613,15 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         </div>
       )}
 
-      {inputAttachments.length > 0 && (
+      {composerAttachments.length > 0 && (
         <div className="ocp-input-attachments ocp-composer-attachments">
-          {inputAttachments.map((att, i) => (
+          {composerAttachments.map((att, i) => (
             <AttachmentPreview
               key={att._uploadId || `${att.name}-${i}`}
               att={att}
+              apiBaseUrl={apiBaseUrl}
               onRemove={() => {
-                setInputAttachments(prev => prev.filter((_, ix) => ix !== i));
+                setComposerAttachments(prev => prev.filter((_, ix) => ix !== i));
               }}
             />
           ))}
@@ -1695,7 +1672,7 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
         <button
           data-slot="ocp"
           onClick={() => handleSend()}
-          disabled={sending || (!input.trim() && inputAttachments.length === 0)}
+          disabled={sending || (!input.trim() && composerAttachments.length === 0)}
           className={`ocp-send ${sending ? "ocp-send-busy" : ""}`}
         >
           {sending ? (
@@ -1848,10 +1825,7 @@ const CHAT_CSS = `
   color: #fca5a5;
   border-bottom-left-radius: 4px;
 }
-/* P11: activity bubble（组织事件聚合）走中性色而非红色——红色只留给真正
-   的错误/警告通知。class 同时叠加到 role="system" 上，所以放在 system 之
-   后才能覆盖；视觉上与 assistant 接近，但用 surface 标签和"活动事件"小
-   chip 在 bubble 头部点明这是事件流。 */
+/* Activity bubbles are timeline entries, not error notices. */
 .ocp-msg-activity .ocp-msg-bubble {
   background: var(--bg-subtle, rgba(30,41,59,0.55));
   border: 1px solid var(--line, rgba(100,116,139,0.25));

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -1213,6 +1213,7 @@ export function ChatView({
       (msg.progressEvents?.length ? 10 + msg.progressEvents.length : 0) +
       (msg.thinkingChain?.length ? 50 + msg.thinkingChain.length : 0) +
       (msg.artifacts?.length ? 20 + msg.artifacts.length : 0) +
+      (msg.attachments?.length ? 20 + msg.attachments.length : 0) +
       (msg.askUser ? 10 : 0) +
       (msg.streaming ? 5 : 0) +
       Math.min(msg.content.length, 2000) / 2000,
@@ -6059,6 +6060,7 @@ export function ChatView({
               <AttachmentPreview
                 key={`${att.name}-${att.type}-${idx}`}
                 att={att}
+                apiBaseUrl={apiBaseUrl}
                 onRemove={() => setPendingAttachments((prev) => prev.filter((_, i) => i !== idx))}
               />
             ))}

--- a/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
+++ b/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
@@ -1,13 +1,35 @@
 import type { ChatAttachment } from "../utils/chatTypes";
+import { appendAuthToken } from "../utils/chatHelpers";
 import {
   IconX, IconMic, IconPlay, IconImage, IconPaperclip,
 } from "../../../icons";
 
-export function AttachmentPreview({ att, onRemove }: { att: ChatAttachment; onRemove?: () => void }) {
-  if (att.type === "image" && att.previewUrl) {
+function resolvePreviewUrl(att: ChatAttachment, apiBaseUrl?: string): string {
+  const raw = att.previewUrl || att.url || "";
+  if (raw.startsWith("data:") || raw.startsWith("blob:")) return raw;
+  if (raw.startsWith("http")) return appendAuthToken(raw);
+  if (raw.startsWith("/")) return appendAuthToken(`${apiBaseUrl || ""}${raw}`);
+  if (raw) return raw;
+  if (att.localPath) {
+    return appendAuthToken(`${apiBaseUrl || ""}/api/files?path=${encodeURIComponent(att.localPath)}`);
+  }
+  return "";
+}
+
+export function AttachmentPreview({
+  att,
+  onRemove,
+  apiBaseUrl,
+}: {
+  att: ChatAttachment;
+  onRemove?: () => void;
+  apiBaseUrl?: string;
+}) {
+  const previewUrl = att.type === "image" ? resolvePreviewUrl(att, apiBaseUrl) : "";
+  if (att.type === "image" && previewUrl) {
     return (
       <div style={{ position: "relative", display: "inline-block" }}>
-        <img src={att.previewUrl} alt={att.name} style={{ width: 80, height: 80, objectFit: "cover", display: "block", borderRadius: 10, border: "1px solid var(--line)" }} />
+        <img src={previewUrl} alt={att.name} style={{ width: 80, height: 80, objectFit: "cover", display: "block", borderRadius: 10, border: "1px solid var(--line)" }} />
         {onRemove && (
           <button
             onClick={onRemove}

--- a/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
+++ b/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
@@ -93,7 +93,7 @@ export const FlatMessageItem = memo(function FlatMessageItem({
           {msg.attachments && msg.attachments.length > 0 && (
             <div style={{ marginBottom: 6 }}>
               {msg.attachments.map((att, i) => (
-                <AttachmentPreview key={i} att={att} />
+                <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} />
               ))}
             </div>
           )}

--- a/apps/setup-center/src/views/chat/components/MessageBubble.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageBubble.tsx
@@ -105,7 +105,7 @@ export const MessageBubble = memo(function MessageBubble({
         {msg.attachments && msg.attachments.length > 0 && (
           <div style={{ marginBottom: 8 }}>
             {msg.attachments.map((att: ChatAttachment, i: number) => (
-              <AttachmentPreview key={i} att={att} />
+              <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} />
             ))}
           </div>
         )}

--- a/apps/setup-center/src/views/chat/utils/chatHelpers.ts
+++ b/apps/setup-center/src/views/chat/utils/chatHelpers.ts
@@ -9,6 +9,7 @@ import type {
   ChatSource,
   ChatMcpCall,
   ChatTodo,
+  ChatAttachment,
   MessagePart,
   ChainGroup,
   ChainEntry,
@@ -254,9 +255,23 @@ function latestMessageTimestamp(msgs: ChatMessage[]): number {
   return msgs.reduce((max, msg) => Math.max(max, Number.isFinite(msg.timestamp) ? msg.timestamp : 0), 0);
 }
 
+function attachmentSignature(attachments: ChatAttachment[] | null | undefined): string {
+  if (!attachments?.length) return "";
+  return attachments.map((att) => [
+    att.type,
+    att.name,
+    att.url,
+    att.localPath,
+    att.uploadId,
+    att.previewUrl,
+    att.size,
+    att.mimeType,
+  ].map((value) => String(value ?? "")).join("\u001f")).join("\u001e");
+}
+
 function messageSignature(msg: ChatMessage | undefined): string {
   if (!msg) return "";
-  return `${msg.role}\n${msg.timestamp}\n${msg.content}`;
+  return `${msg.role}\n${msg.timestamp}\n${msg.content}\n${attachmentSignature(msg.attachments)}`;
 }
 
 function firstUserContent(msgs: ChatMessage[]): string {
@@ -268,7 +283,12 @@ function removeAdjacentDuplicateUserMessages(msgs: ChatMessage[]): ChatMessage[]
   const deduped: ChatMessage[] = [];
   for (const msg of msgs) {
     const prev = deduped[deduped.length - 1];
-    if (msg.role === "user" && prev?.role === "user" && prev.content === msg.content) {
+    if (
+      msg.role === "user" &&
+      prev?.role === "user" &&
+      prev.content === msg.content &&
+      attachmentSignature(prev.attachments) === attachmentSignature(msg.attachments)
+    ) {
       changed = true;
       continue;
     }
@@ -277,42 +297,73 @@ function removeAdjacentDuplicateUserMessages(msgs: ChatMessage[]): ChatMessage[]
   return changed ? deduped : msgs;
 }
 
+function messageMatchKey(msg: Pick<ChatMessage, "role" | "content">): string {
+  return `${msg.role}\n${msg.content}`;
+}
+
+function backendMessageMatchKey(msg: Pick<BackendHistoryMessage, "role" | "content">): string {
+  return `${msg.role}\n${msg.content}`;
+}
+
+function mergeMissingAttachments(primary: ChatMessage[], secondary: ChatMessage[]): ChatMessage[] {
+  const withAttachments = new Map<string, ChatMessage[]>();
+  for (const msg of secondary) {
+    if (!msg.attachments?.length) continue;
+    const key = messageMatchKey(msg);
+    const queue = withAttachments.get(key);
+    if (queue) queue.push(msg);
+    else withAttachments.set(key, [msg]);
+  }
+
+  let changed = false;
+  const merged = primary.map((msg) => {
+    if (msg.attachments?.length) return msg;
+    const queue = withAttachments.get(messageMatchKey(msg));
+    const source = queue?.shift();
+    if (!source?.attachments?.length) return msg;
+    changed = true;
+    return { ...msg, attachments: source.attachments };
+  });
+  return changed ? merged : primary;
+}
+
 /**
  * Choose which message history should hydrate the UI.
  *
- * Backend history is the source of truth after SSE disconnect recovery because
- * the backend may save the completed answer after the local stream was aborted.
- * Merge backend assistant content into local first, so a newer local streaming
- * placeholder cannot hide a complete answer already persisted by the backend.
+ * Backend history is the source of truth after SSE disconnect recovery. Local
+ * messages can still contain structured fields that the backend has not seen
+ * yet during an in-flight turn, so hydration merges missing attachments before
+ * choosing the history to render.
  */
 export function chooseHydratedMessages(localMsgs: ChatMessage[], backendMsgs: ChatMessage[]): ChatMessage[] {
   const cleanBackend = removeAdjacentDuplicateUserMessages(backendMsgs);
-  if (cleanBackend.length === 0) return removeAdjacentDuplicateUserMessages(localMsgs);
-  if (localMsgs.length === 0) return cleanBackend;
+  const cleanLocal = removeAdjacentDuplicateUserMessages(localMsgs);
+  const backendWithLocalAttachments = mergeMissingAttachments(cleanBackend, cleanLocal);
+  if (backendWithLocalAttachments.length === 0) return cleanLocal;
+  if (cleanLocal.length === 0) return cleanBackend;
 
-  const localFirstUser = firstUserContent(localMsgs);
-  const backendFirstUser = firstUserContent(cleanBackend);
+  const localFirstUser = firstUserContent(cleanLocal);
+  const backendFirstUser = firstUserContent(backendWithLocalAttachments);
   if (localFirstUser && backendFirstUser && localFirstUser !== backendFirstUser) {
-    return cleanBackend;
+    return backendWithLocalAttachments;
   }
 
-  const cleanLocal = removeAdjacentDuplicateUserMessages(localMsgs);
   const patchedLocal = removeAdjacentDuplicateUserMessages(
-    patchMessagesWithBackend(cleanLocal, cleanBackend),
+    mergeMissingAttachments(patchMessagesWithBackend(cleanLocal, backendWithLocalAttachments), backendWithLocalAttachments),
   );
 
-  if (cleanBackend.length > cleanLocal.length) return cleanBackend;
+  if (backendWithLocalAttachments.length > cleanLocal.length) return backendWithLocalAttachments;
   if (cleanLocal.length > cleanBackend.length) return patchedLocal;
   if (patchedLocal !== cleanLocal) return patchedLocal;
 
   const localLatest = latestMessageTimestamp(cleanLocal);
-  const backendLatest = latestMessageTimestamp(cleanBackend);
-  if (backendLatest > localLatest) return cleanBackend;
+  const backendLatest = latestMessageTimestamp(backendWithLocalAttachments);
+  if (backendLatest > localLatest) return backendWithLocalAttachments;
   if (localLatest > backendLatest) return cleanLocal;
 
   const localLast = messageSignature(cleanLocal[cleanLocal.length - 1]);
-  const backendLast = messageSignature(cleanBackend[cleanBackend.length - 1]);
-  return backendLast && backendLast !== localLast ? cleanBackend : cleanLocal;
+  const backendLast = messageSignature(backendWithLocalAttachments[backendWithLocalAttachments.length - 1]);
+  return backendLast && backendLast !== localLast ? backendWithLocalAttachments : cleanLocal;
 }
 
 // ── 思维链 ──
@@ -583,6 +634,7 @@ type BackendHistoryMessage = {
   chain_summary?: ChainSummaryItem[];
   chain_timeline?: ChainTimelineGroup[];
   artifacts?: ChatArtifact[] | null;
+  attachments?: ChatAttachment[] | null;
   sources?: ChatSource[] | null;
   mcp_calls?: ChatMcpCall[] | null;
   usage?: ChatMessage["usage"];
@@ -660,9 +712,35 @@ export function patchMessagesWithBackendDetailed(
     return undefined;
   };
 
+  const backendAttachmentsByMessage = new Map<string, BackendHistoryMessage[]>();
+  for (const msg of backendMsgs) {
+    if (!msg.attachments?.length) continue;
+    const key = backendMessageMatchKey(msg);
+    const queue = backendAttachmentsByMessage.get(key);
+    if (queue) queue.push(msg);
+    else backendAttachmentsByMessage.set(key, [msg]);
+  }
+
+  const claimBackendAttachmentsForLocalMessage = (
+    m: ChatMessage,
+  ): BackendHistoryMessage | undefined => {
+    const queue = backendAttachmentsByMessage.get(messageMatchKey(m));
+    return queue?.shift();
+  };
+
   let changed = false;
   const patched = localMsgs.map((m, index) => {
-    if (m.role !== "assistant") return m;
+    if (m.role !== "assistant") {
+      if (!m.attachments?.length) {
+        const backend = claimBackendAttachmentsForLocalMessage(m);
+        if (backend?.attachments?.length) {
+          changed = true;
+          stats.patched += 1;
+          return { ...m, attachments: backend.attachments };
+        }
+      }
+      return m;
+    }
     const backend = claimBackendForLocalMessage(m, index);
     if (!backend) return m;
 
@@ -703,6 +781,15 @@ export function patchMessagesWithBackendDetailed(
 
     if (!m.artifacts?.length && backend.artifacts?.length) {
       patches.artifacts = backend.artifacts;
+    }
+
+    if (!m.attachments?.length) {
+      const attachmentBackend = backend.attachments?.length
+        ? backend
+        : claimBackendAttachmentsForLocalMessage(m);
+      if (attachmentBackend?.attachments?.length) {
+        patches.attachments = attachmentBackend.attachments;
+      }
     }
 
     if (!m.sources?.length && backend.sources?.length) {

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -22,12 +22,18 @@ from openakita.core.ask_user_context import AskUserReplyContext
 from openakita.core.context_stats import get_context_snapshot, merge_context_snapshot_into_usage
 from openakita.core.engine_bridge import engine_stream, is_dual_loop, to_engine
 
-from ..schemas import ChatControlRequest, ChatRequest
+from ..schemas import AttachmentInfo, ChatAttachmentRecord, ChatControlRequest, ChatRequest
 from .conversation_lifecycle import get_lifecycle_manager
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _history_attachments_from_request(
+    attachments: list[AttachmentInfo] | None,
+) -> list[dict[str, Any]]:
+    return [att.to_chat_attachment_dict() for att in attachments or []]
 
 
 def _session_for_desktop(
@@ -1080,8 +1086,10 @@ async def _stream_chat(
                         },
                     )
 
-                    if chat_request.message:
-                        session.add_message("user", chat_request.message)
+                    user_attachments = _history_attachments_from_request(chat_request.attachments)
+                    if chat_request.message or user_attachments:
+                        meta = {"attachments": user_attachments} if user_attachments else {}
+                        session.add_message("user", chat_request.message or "", **meta)
                         if ask_user_reply_context is not None:
                             _backfill_ask_user_answer(session, ask_user_reply_context.answer)
                     session_messages_history = (
@@ -1724,13 +1732,15 @@ def _org_file_attachments_to_chat_attachments(attachments: list[dict]) -> list[d
         suffix = Path(name).suffix.lower()
         att_type = "document" if suffix in {".doc", ".docx", ".pdf", ".md", ".txt"} else "file"
         converted.append(
-            {
-                "type": att_type,
-                "name": name,
-                "localPath": file_path,
-                "size": att.get("file_size") or att.get("size"),
-                "uploadStatus": "uploaded",
-            }
+            ChatAttachmentRecord.model_validate(
+                {
+                    "type": att_type,
+                    "name": name,
+                    "localPath": file_path,
+                    "size": att.get("file_size") or att.get("size"),
+                    "uploadStatus": "uploaded",
+                }
+            ).to_history_dict()
         )
     return converted
 
@@ -1859,8 +1869,10 @@ async def _stream_org_command_chat(
                         "orgNodeId": target_node_id or "",
                     },
                 )
-                if chat_request.message:
-                    session.add_message("user", chat_request.message)
+                user_attachments = _history_attachments_from_request(chat_request.attachments)
+                if chat_request.message or user_attachments:
+                    meta = {"attachments": user_attachments} if user_attachments else {}
+                    session.add_message("user", chat_request.message or "", **meta)
                 session_manager.mark_dirty()
 
         if svc is None:
@@ -1897,6 +1909,7 @@ async def _stream_org_command_chat(
                     ),
                     origin_surface=OrgCommandSurface.DESKTOP_CHAT,
                     output_scope=default_scope_for_surface(OrgCommandSurface.DESKTOP_CHAT),
+                    attachments=_history_attachments_from_request(chat_request.attachments),
                 )
             )
         except OrgCommandError as exc:
@@ -2774,7 +2787,9 @@ async def chat_sync(request: Request, body: ChatRequest):
                 )
                 if session is not None:
                     apply_classification_to_session(session, classify_entry("api-sync"))
-                    session.add_message("user", body.message or "")
+                    user_attachments = _history_attachments_from_request(body.attachments)
+                    meta = {"attachments": user_attachments} if user_attachments else {}
+                    session.add_message("user", body.message or "", **meta)
                     if ask_reply_context is not None:
                         _backfill_ask_user_answer(session, ask_reply_context.answer)
                     session_messages_history = session.context.get_messages()

--- a/src/openakita/api/routes/orgs.py
+++ b/src/openakita/api/routes/orgs.py
@@ -107,7 +107,7 @@ def _get_command_service(request: Request):
 
 
 def _coerce_attachment_info(raw: Any) -> Any | None:
-    """Normalize setup-center attachment JSON to the ChatRequest attachment shape."""
+    """Validate setup-center attachment JSON for org command processing."""
     if not isinstance(raw, dict):
         return None
     name = str(raw.get("name") or raw.get("filename") or "").strip()
@@ -120,10 +120,10 @@ def _coerce_attachment_info(raw: Any) -> Any | None:
             type=str(raw.get("type") or "file"),
             name=name,
             url=raw.get("url"),
-            local_path=raw.get("local_path") or raw.get("localPath"),
-            upload_id=raw.get("upload_id") or raw.get("uploadId"),
+            local_path=raw.get("local_path"),
+            upload_id=raw.get("upload_id"),
             size=raw.get("size"),
-            mime_type=raw.get("mime_type") or raw.get("mimeType"),
+            mime_type=raw.get("mime_type"),
         )
     except Exception:
         logger.debug("[OrgAPI] failed to normalize attachment: %r", raw, exc_info=True)
@@ -757,19 +757,7 @@ async def send_command(request: Request, org_id: str):
                 replace_existing=bool(body.get("replace_existing")),
                 continue_previous=bool(body.get("continue_previous")),
                 forward_to=forward_targets,
-                input_attachments=[
-                    {
-                        "type": getattr(att, "type", "file"),
-                        "name": getattr(att, "name", ""),
-                        "url": getattr(att, "url", None),
-                        "local_path": getattr(att, "local_path", None),
-                        "upload_id": getattr(att, "upload_id", None),
-                        "size": getattr(att, "size", None),
-                        "mime_type": getattr(att, "mime_type", None),
-                        "uploadStatus": "uploaded",
-                    }
-                    for att in attachments
-                ],
+                attachments=[att.to_chat_attachment_dict() for att in attachments],
             )
         )
     except OrgCommandConflict as exc:

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -14,6 +14,8 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from openakita.api.schemas import ChatAttachmentRecord
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -308,9 +310,6 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     attachments = msg.get("attachments")
     if attachments:
         entry["attachments"] = attachments
-    input_attachments = msg.get("input_attachments")
-    if input_attachments:
-        entry["input_attachments"] = input_attachments
     org_timeline = msg.get("org_timeline")
     if org_timeline:
         entry["org_timeline"] = org_timeline
@@ -640,10 +639,7 @@ def _cancel_tasks_for_session(request: Request, conversation_id: str, session_id
 class AppendMessageRequest(BaseModel):
     role: str = Field(..., description="user | assistant | system")
     content: str = Field(..., description="Message content")
-    input_attachments: list[dict] | None = Field(
-        None,
-        description="User-uploaded attachments shown in embedded chat UIs",
-    )
+    attachments: list[ChatAttachmentRecord] | None = Field(None, description="Message attachments")
 
 
 class AppendBatchRequest(BaseModel):
@@ -686,8 +682,8 @@ async def append_session_messages(
 
     for msg in body.messages:
         meta: dict = {}
-        if msg.input_attachments:
-            meta["input_attachments"] = msg.input_attachments
+        if msg.attachments:
+            meta["attachments"] = [att.to_history_dict() for att in msg.attachments]
         session.add_message(msg.role, msg.content, **meta)
 
     session_manager.mark_dirty()

--- a/src/openakita/api/schemas.py
+++ b/src/openakita/api/schemas.py
@@ -30,6 +30,83 @@ class AskUserReplyRequest(BaseModel):
     )
 
 
+class ChatAttachmentRecord(BaseModel):
+    """Attachment shape persisted in session history and rendered by ChatView."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["image", "file", "voice", "video", "document"] = Field(
+        ..., description="Attachment kind rendered by the chat UI."
+    )
+    name: str = Field(..., description="Display filename")
+    url: str | None = Field(None, description="Renderable or downloadable URL")
+    local_path: str | None = Field(
+        None,
+        alias="localPath",
+        description="Server-side local path for uploaded files",
+    )
+    upload_id: str | None = Field(
+        None,
+        alias="uploadId",
+        description="Upload identifier returned by /api/upload",
+    )
+    preview_url: str | None = Field(
+        None,
+        alias="previewUrl",
+        description="Image preview URL",
+    )
+    size: int | None = Field(None, description="Attachment size in bytes")
+    mime_type: str | None = Field(None, alias="mimeType", description="MIME type")
+    upload_status: Literal["uploading", "uploaded", "failed"] | None = Field(
+        None,
+        alias="uploadStatus",
+        description="Upload state shown by the chat UI",
+    )
+    upload_error: str | None = Field(
+        None,
+        alias="uploadError",
+        description="Upload error shown by the chat UI",
+    )
+
+    def to_history_dict(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, exclude_none=True)
+
+
+class AttachmentInfo(BaseModel):
+    """Attachment metadata accepted by chat request endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["image", "file", "voice", "video", "document"] = Field(
+        ..., description="image | file | voice | video | document"
+    )
+    name: str = Field(..., description="Filename")
+    url: str | None = Field(None, description="URL or data URI")
+    local_path: str | None = Field(None, description="Server-side local path for uploaded files")
+    upload_id: str | None = Field(None, description="Upload identifier returned by /api/upload")
+    size: int | None = Field(None, description="Attachment size in bytes")
+    mime_type: str | None = Field(None, description="MIME type")
+
+    def to_chat_attachment_record(self) -> ChatAttachmentRecord:
+        payload: dict[str, Any] = {
+            "type": self.type,
+            "name": self.name,
+            "url": self.url,
+            "localPath": self.local_path,
+            "uploadId": self.upload_id,
+            "previewUrl": self.url if self.type == "image" and self.url else None,
+            "size": self.size,
+            "mimeType": self.mime_type,
+            "uploadStatus": "uploaded",
+        }
+        return ChatAttachmentRecord.model_validate(
+            {key: value for key, value in payload.items() if value is not None}
+        )
+
+    def to_chat_attachment_dict(self) -> dict[str, Any]:
+        return self.to_chat_attachment_record().to_history_dict()
+
+
 class ChatRequest(BaseModel):
     """Chat request body."""
 
@@ -119,21 +196,6 @@ class ChatRequest(BaseModel):
         max_length=128,
         pattern=r"^[A-Za-z0-9_\-:.@]{0,128}$",
     )
-
-class AttachmentInfo(BaseModel):
-    """Attachment metadata."""
-
-    type: str = Field(..., description="image | file | voice")
-    name: str = Field(..., description="Filename")
-    url: str | None = Field(None, description="URL or data URI")
-    local_path: str | None = Field(None, description="Server-side local path for uploaded files")
-    upload_id: str | None = Field(None, description="Upload identifier returned by /api/upload")
-    size: int | None = Field(None, description="Attachment size in bytes")
-    mime_type: str | None = Field(None, description="MIME type")
-
-
-# Fix forward reference
-ChatRequest.model_rebuild()
 
 
 class ChatControlRequest(BaseModel):

--- a/src/openakita/orgs/command_service.py
+++ b/src/openakita/orgs/command_service.py
@@ -162,8 +162,8 @@ class OrgCommandRequest:
     """Extra IM destinations to mirror final result / cancellation to."""
     user_facing_content: str | None = None
     """Optional content to persist/render when run content contains hidden attachment text."""
-    input_attachments: list[dict[str, Any]] = field(default_factory=list)
-    """User-uploaded attachments shown in the command console history."""
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    """User-uploaded attachments persisted with the command console message."""
 
 
 def set_command_service(service: OrgCommandService | None) -> None:
@@ -283,7 +283,7 @@ class OrgCommandService:
             request.org_id,
             request.target_node_id,
             user_facing_content,
-            input_attachments=request.input_attachments,
+            attachments=request.attachments,
         )
         self._mirror_command_to_distributed_surfaces(
             request,
@@ -302,7 +302,7 @@ class OrgCommandService:
             replace_existing=request.replace_existing,
             continue_previous=request.continue_previous,
             forward_to=list(request.forward_to),
-            input_attachments=list(request.input_attachments),
+            attachments=list(request.attachments),
         )
         self._schedule_run(
             run_request,
@@ -999,7 +999,7 @@ class OrgCommandService:
         target_node_id: str | None,
         content: str,
         *,
-        input_attachments: list[dict[str, Any]] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
     ) -> None:
         sm = self._session_manager
         if not sm:
@@ -1014,8 +1014,8 @@ class OrgCommandService:
             )
             if session:
                 meta: dict[str, Any] = {}
-                if input_attachments:
-                    meta["input_attachments"] = list(input_attachments)
+                if attachments:
+                    meta["attachments"] = list(attachments)
                 session.add_message("user", content, **meta)
                 sm.mark_dirty()
         except Exception as exc:

--- a/tests/orgs/test_command_service.py
+++ b/tests/orgs/test_command_service.py
@@ -199,7 +199,7 @@ def test_submit_persists_visible_content_and_runs_enriched_content(persisted_org
             org_id=persisted_org.id,
             content="请总结\n\n--- 文件: notes.txt ---\nsecret\n--- 文件结束 ---",
             user_facing_content="请总结",
-            input_attachments=[
+            attachments=[
                 {
                     "type": "file",
                     "name": "notes.txt",
@@ -212,7 +212,7 @@ def test_submit_persists_visible_content_and_runs_enriched_content(persisted_org
 
     service._bridge_persist_user_message.assert_called_once()
     assert service._bridge_persist_user_message.call_args.args[2] == "请总结"
-    assert service._bridge_persist_user_message.call_args.kwargs["input_attachments"][0]["name"] == "notes.txt"
+    assert service._bridge_persist_user_message.call_args.kwargs["attachments"][0]["name"] == "notes.txt"
     run_request = service._schedule_run.call_args.args[0]
     assert "secret" in run_request.content
     assert run_request.user_facing_content == "请总结"

--- a/tests/unit/test_chat_view_session_isolation.py
+++ b/tests/unit/test_chat_view_session_isolation.py
@@ -98,6 +98,20 @@ def test_backend_todo_snapshot_refreshes_existing_plan_card():
     assert "patches.todo = backend.todo" in source
 
 
+def test_hydration_treats_attachments_as_structured_history():
+    chat_source = CHAT_VIEW.read_text(encoding="utf-8")
+    helper_source = CHAT_HELPERS.read_text(encoding="utf-8")
+
+    assert "msg.attachments?.length ? 20 + msg.attachments.length : 0" in chat_source
+    assert "function attachmentSignature" in helper_source
+    assert "attachmentSignature(msg.attachments)" in helper_source
+    assert "attachmentSignature(prev.attachments) === attachmentSignature(msg.attachments)" in helper_source
+    assert "function mergeMissingAttachments" in helper_source
+    assert "const backendWithLocalAttachments = mergeMissingAttachments(cleanBackend, cleanLocal)" in helper_source
+    assert "attachments?: ChatAttachment[] | null" in helper_source
+    assert "patches.attachments = attachmentBackend.attachments" in helper_source
+
+
 def test_backend_history_patch_keeps_single_sequence_fallback():
     """Backend-history -> local-message patching must consume each backend
     assistant entry **at most once** (a single Set tracks claimed ones), and

--- a/tests/unit/test_session_history_attachments.py
+++ b/tests/unit/test_session_history_attachments.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from openakita.api.routes.chat import _history_attachments_from_request
+from openakita.api.routes.sessions import AppendBatchRequest, _history_entry
+from openakita.api.schemas import AttachmentInfo, ChatAttachmentRecord
+
+
+def test_request_attachments_are_serialized_as_chat_history_records():
+    attachments = [
+        AttachmentInfo(
+            type="image",
+            name="diagram.png",
+            url="data:image/png;base64,abc",
+            local_path="D:/tmp/diagram.png",
+            upload_id="upload-1",
+            size=123,
+            mime_type="image/png",
+        )
+    ]
+
+    assert _history_attachments_from_request(attachments) == [
+        {
+            "type": "image",
+            "name": "diagram.png",
+            "url": "data:image/png;base64,abc",
+            "localPath": "D:/tmp/diagram.png",
+            "uploadId": "upload-1",
+            "previewUrl": "data:image/png;base64,abc",
+            "size": 123,
+            "mimeType": "image/png",
+            "uploadStatus": "uploaded",
+        }
+    ]
+
+
+def test_session_history_exposes_only_canonical_attachments_field():
+    session = SimpleNamespace(last_active=datetime.fromisoformat("2026-01-01T00:00:00"))
+    entry = _history_entry(
+        session,
+        "conv-1",
+        0,
+        {
+            "role": "user",
+            "content": "see image",
+            "timestamp": "2026-01-01T00:00:00",
+            "attachments": [
+                {
+                    "type": "image",
+                    "name": "diagram.png",
+                    "url": "data:image/png;base64,abc",
+                    "previewUrl": "data:image/png;base64,abc",
+                    "uploadStatus": "uploaded",
+                }
+            ],
+            "input_attachments": [{"name": "legacy.png"}],
+        },
+    )
+
+    assert entry["attachments"][0]["name"] == "diagram.png"
+    assert "input_attachments" not in entry
+
+
+def test_append_session_messages_accepts_canonical_chat_attachments():
+    body = AppendBatchRequest.model_validate(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "",
+                    "attachments": [
+                        {
+                            "type": "image",
+                            "name": "shot.png",
+                            "url": "data:image/png;base64,abc",
+                            "previewUrl": "data:image/png;base64,abc",
+                            "uploadStatus": "uploaded",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
+    assert body.messages[0].attachments
+    assert body.messages[0].attachments[0].to_history_dict()["previewUrl"].startswith("data:")
+
+
+def test_chat_attachment_record_rejects_snake_case_history_fields():
+    with pytest.raises(ValidationError):
+        ChatAttachmentRecord.model_validate(
+            {
+                "type": "image",
+                "name": "shot.png",
+                "local_path": "D:/tmp/shot.png",
+            }
+        )


### PR DESCRIPTION
## Summary
- Persist chat attachments as canonical structured session-history data.
- Preserve attachments during frontend hydration, backend patching, duplicate detection, and image preview rendering.

## Tests
- uv run pytest tests/unit/test_session_history_attachments.py tests/unit/test_chat_view_session_isolation.py tests/orgs/test_command_service.py
- npm run build