### PR TITLE
scope session history to the active agent profile

### DIFF
--- a/apps/setup-center/src/components/__tests__/FileAttachmentCard.preview.test.tsx
+++ b/apps/setup-center/src/components/__tests__/FileAttachmentCard.preview.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, act, waitFor, fireEvent } from "@testing-library/react";
 
-const saveAttachment = vi.fn(async () => {});
+const saveAttachment = vi.fn(async (..._args: unknown[]) => {});
 vi.mock("../../platform", () => ({
   saveAttachment: (...a: unknown[]) => saveAttachment(...a),
   showInFolder: vi.fn(),
@@ -11,12 +11,12 @@ vi.mock("../../platform", () => ({
 vi.mock("../../platform/auth", () => ({ getAccessToken: () => "test-token" }));
 vi.mock("../../views/chat/hooks/useMdModules", () => ({ useMdModules: () => null }));
 
-const safeFetch = vi.fn(async () => ({
+const safeFetch = vi.fn(async (..._args: unknown[]) => ({
   ok: true,
   status: 200,
   text: async () => "# 标题\n\n正文内容ABC",
 } as unknown as Response));
-vi.mock("../../providers", () => ({ safeFetch: (...a: unknown[]) => safeFetch(...(a as [string])) }));
+vi.mock("../../providers", () => ({ safeFetch: (...a: unknown[]) => safeFetch(...a) }));
 
 import { FileAttachmentCard } from "../FileAttachmentCard";
 

--- a/apps/setup-center/src/components/__tests__/OrgChatPanel.finalReport.test.tsx
+++ b/apps/setup-center/src/components/__tests__/OrgChatPanel.finalReport.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+import { render, act, fireEvent, waitFor } from "@testing-library/react";
 
 // --- v2 stream shim (same shape as OrgChatPanel.v2.test) --------------------
 vi.mock("../../api/v2Stream", () => {

--- a/src/openakita/agent/__init__.py
+++ b/src/openakita/agent/__init__.py
@@ -28,9 +28,6 @@ from .capabilities import (
 )
 from .confirmation import (
     ConfirmationDecision,
-    PendingRiskConfirmation,
-    PendingRiskConfirmationStore,
-    get_confirmation_store,
     normalize_confirmation_answer,
 )
 from .context import (
@@ -457,6 +454,11 @@ _LAZY_REASONING_EXPORTS = {
     "ReasoningEngine": "ReasoningEngine",
     "ReasoningDecision": "Decision",
 }
+_LAZY_CONFIRMATION_EXPORTS = {
+    "PendingRiskConfirmation",
+    "PendingRiskConfirmationStore",
+    "get_confirmation_store",
+}
 
 
 def __getattr__(name: str):  # PEP 562 module-level lazy attribute access
@@ -466,5 +468,11 @@ def __getattr__(name: str):  # PEP 562 module-level lazy attribute access
 
         value = getattr(_reasoning, target)
         globals()[name] = value  # cache so __getattr__ runs at most once per name
+        return value
+    if name in _LAZY_CONFIRMATION_EXPORTS:
+        from openakita.core import confirmation_state as _confirmation_state
+
+        value = getattr(_confirmation_state, name)
+        globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/openakita/agent/confirmation.py
+++ b/src/openakita/agent/confirmation.py
@@ -10,6 +10,14 @@ read paths share one in-memory store.
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openakita.core.confirmation_state import (
+        PendingRiskConfirmation,
+        PendingRiskConfirmationStore,
+        get_confirmation_store,
+    )
 
 
 class ConfirmationDecision(str, Enum):  # noqa: UP042 — preserved as-is from the legacy module so str+Enum vs StrEnum behaviour differences (e.g. ``repr`` / ``format``) cannot leak into existing callers; cleanup belongs in a separate refactor commit, not in this byte-faithful MOVE.
@@ -47,11 +55,18 @@ def normalize_confirmation_answer(answer: str) -> ConfirmationDecision:
     return ConfirmationDecision.UNKNOWN
 
 
-from openakita.core.confirmation_state import (  # noqa: E402
-    PendingRiskConfirmation,
-    PendingRiskConfirmationStore,
-    get_confirmation_store,
-)
+def __getattr__(name: str) -> Any:
+    if name in {
+        "PendingRiskConfirmation",
+        "PendingRiskConfirmationStore",
+        "get_confirmation_store",
+    }:
+        from openakita.core import confirmation_state as _confirmation_state
+
+        value = getattr(_confirmation_state, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "ConfirmationDecision",

--- a/src/openakita/agents/orchestrator.py
+++ b/src/openakita/agents/orchestrator.py
@@ -1711,11 +1711,15 @@ def _persist_sub_agent_record(
         "started_at": datetime.fromtimestamp(start_time).isoformat(),
         "completed_at": datetime.now().isoformat(),
     }
+    ctx = getattr(session, "context", None)
+    parent_profile_id = (
+        getattr(ctx, "agent_profile_id", "default") if ctx is not None else "default"
+    ) or "default"
+    record["parent_agent_profile_id"] = parent_profile_id
 
     record["output_files"] = _extract_output_files(record)
     record["work_summary"] = _build_work_summary(record)
 
-    ctx = getattr(session, "context", None)
     if ctx is not None and hasattr(ctx, "sub_agent_records"):
         _MAX_SUB_AGENT_RECORDS = 50
         ctx.sub_agent_records.append(record)

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -25,7 +25,13 @@ from openakita.core.engine_bridge import engine_stream, is_dual_loop, to_engine
 from openakita.core.security_actions import execute_controlled_action
 from openakita.core.trusted_paths import grant_session_trust
 
-from ..schemas import AttachmentInfo, ChatAttachmentRecord, ChatAnswerRequest, ChatControlRequest, ChatRequest
+from ..schemas import (
+    AttachmentInfo,
+    ChatAnswerRequest,
+    ChatAttachmentRecord,
+    ChatControlRequest,
+    ChatRequest,
+)
 from .conversation_lifecycle import get_lifecycle_manager
 
 logger = logging.getLogger(__name__)
@@ -201,10 +207,6 @@ def _attach_todo_snapshot_meta(
             meta["progress_events"] = journal
         if snapshot and snapshot.get("steps"):
             meta["todo"] = snapshot
-    except Exception:
-        pass
-
-
     except Exception:
         pass
 
@@ -983,6 +985,8 @@ def _apply_agent_profile(session: object, new_profile_id: str) -> bool:
         }
     )
     ctx.agent_profile_id = new_profile_id
+    if hasattr(ctx, "mark_topic_boundary"):
+        ctx.mark_topic_boundary()
     logger.info(f"[Chat API] Agent profile switched: {old_profile_id!r} -> {new_profile_id!r}")
     return True
 
@@ -3065,6 +3069,8 @@ async def chat_sync(request: Request, body: ChatRequest):
                 )
                 if session is not None:
                     apply_classification_to_session(session, classify_entry("api-sync"))
+                    if body.agent_profile_id:
+                        _apply_agent_profile(session, body.agent_profile_id)
                     user_attachments = _history_attachments_from_request(body.attachments)
                     meta = {"attachments": user_attachments} if user_attachments else {}
                     session.add_message("user", body.message or "", **meta)

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -1338,6 +1338,8 @@ class MessageGateway:
             }
         )
         ctx.agent_profile_id = p.id
+        if hasattr(ctx, "mark_topic_boundary"):
+            ctx.mark_topic_boundary()
         self.session_manager.mark_dirty()
         logger.info(f"[IM] Agent switched: {old_id!r} -> {agent_id!r} for {session.session_key}")
 
@@ -1426,6 +1428,8 @@ class MessageGateway:
             }
         )
         ctx.agent_profile_id = reset_target
+        if hasattr(ctx, "mark_topic_boundary"):
+            ctx.mark_topic_boundary()
         self.session_manager.mark_dirty()
         logger.info(f"[IM] Agent reset to {reset_target} for {session.session_key}")
 
@@ -1486,6 +1490,8 @@ class MessageGateway:
                         "timestamp": datetime.now().isoformat(),
                     }
                 )
+                if hasattr(session.context, "mark_topic_boundary"):
+                    session.context.mark_topic_boundary()
             self.session_manager.mark_dirty()
             logger.info(f"[IM] Applied bot default agent: {bot_agent} for {session.session_key}")
 

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -3543,7 +3543,19 @@ class Agent:
         session_context = None
         if session:
             try:
-                sub_records = getattr(session.context, "sub_agent_records", None) or []
+                session_ctx = getattr(session, "context", None)
+                active_profile_id = (
+                    getattr(session_ctx, "agent_profile_id", "default") if session_ctx else "default"
+                ) or "default"
+                get_records_for_agent = (
+                    getattr(session_ctx, "get_sub_agent_records_for_agent", None)
+                    if session_ctx
+                    else None
+                )
+                if callable(get_records_for_agent):
+                    sub_records = get_records_for_agent(active_profile_id)
+                else:
+                    sub_records = getattr(session_ctx, "sub_agent_records", None) or []
                 session_config = getattr(session, "config", None)
                 session_context = {
                     "session_id": session.id,
@@ -5105,6 +5117,27 @@ class Agent:
         # 如果直接操作 session.context.messages 的活引用，边界消息会永久积累导致
         # 连续 user 角色消息 → API 报错 / 模型混乱 / 工具重复执行
         session_messages = list(session_messages)
+        active_agent_profile_id = "default"
+        if session is not None and hasattr(session, "context"):
+            active_agent_profile_id = (
+                getattr(session.context, "agent_profile_id", "default") or "default"
+            )
+            filter_for_agent = getattr(session.context, "filter_messages_for_agent", None)
+            if callable(filter_for_agent):
+                before_filter_count = len(session_messages)
+                session_messages = filter_for_agent(
+                    session_messages,
+                    active_agent_profile_id,
+                )
+                if len(session_messages) != before_filter_count:
+                    logger.info(
+                        "[Session:%s] Agent profile history scoped: %d -> %d "
+                        "(profile=%s)",
+                        session_id,
+                        before_filter_count,
+                        len(session_messages),
+                        active_agent_profile_id,
+                    )
         topic_changed = False
         _channel = getattr(session, "channel", None) if session else None
         _is_im = _channel and _channel not in ("cli", "desktop")
@@ -5286,7 +5319,15 @@ class Agent:
 
         # 10.5 注入子 Agent 委派结果摘要到最后一条 assistant 消息
         if session and hasattr(session, "context"):
-            sub_records = getattr(session.context, "sub_agent_records", None)
+            get_records_for_agent = getattr(
+                session.context,
+                "get_sub_agent_records_for_agent",
+                None,
+            )
+            if callable(get_records_for_agent):
+                sub_records = get_records_for_agent(active_agent_profile_id)
+            else:
+                sub_records = getattr(session.context, "sub_agent_records", None)
             if sub_records and messages:
                 from .policy_v2.prompt_hardening import wrap_external_content
 
@@ -7488,7 +7529,19 @@ class Agent:
         session = self._current_session
         if not session:
             return ""
-        records = getattr(getattr(session, "context", None), "sub_agent_records", None)
+        session_ctx = getattr(session, "context", None)
+        active_profile_id = (
+            getattr(session_ctx, "agent_profile_id", "default") if session_ctx else "default"
+        ) or "default"
+        get_records_for_agent = (
+            getattr(session_ctx, "get_sub_agent_records_for_agent", None)
+            if session_ctx
+            else None
+        )
+        if callable(get_records_for_agent):
+            records = get_records_for_agent(active_profile_id)
+        else:
+            records = getattr(session_ctx, "sub_agent_records", None)
         if not records:
             return ""
         summaries = [r.get("work_summary", "") for r in records if r.get("work_summary")]

--- a/src/openakita/core/_brain_legacy.py
+++ b/src/openakita/core/_brain_legacy.py
@@ -89,7 +89,9 @@ class Brain:
         model: str | None = None,
         max_tokens: int | None = None,
     ):
-        from ..llm.client import LLMClient  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        from ..llm.client import (
+            LLMClient,  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        )
         # Compiler circuit breaker (P-RC-4 extraction).
         self._compiler_breaker = CompilerCircuitBreaker()
 
@@ -165,7 +167,9 @@ class Brain:
 
     def _init_compiler_client(self) -> None:
         """从配置加载 Prompt Compiler 专属 LLMClient"""
-        from ..llm.client import LLMClient  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        from ..llm.client import (
+            LLMClient,  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        )
         try:
             _, compiler_eps, _, _ = load_endpoints_config()
             if compiler_eps:
@@ -197,7 +201,9 @@ class Brain:
         Returns:
             True 表示成功重载，False 表示无变化或失败。
         """
-        from ..llm.client import LLMClient  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        from ..llm.client import (
+            LLMClient,  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        )
         try:
             _, compiler_eps, _, _ = load_endpoints_config()
             if compiler_eps:
@@ -375,8 +381,10 @@ class Brain:
             ``{"type": "error", "message": str}``（仅严重失败时）
         """
         # 延迟导入避免与 stream_accumulator 形成循环依赖
+        from ..llm.client import (
+            LLMClient,  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
+        )
         from .stream_accumulator import StreamAccumulator
-        from ..llm.client import LLMClient  # local import: break core/agent/llm cycle (P-RC-11 P11.2)
 
         messages = [Message(role="user", content=[TextBlock(text=prompt)])]
         sys_prompt = system or ""

--- a/src/openakita/core/errors.py
+++ b/src/openakita/core/errors.py
@@ -21,6 +21,11 @@ Do not add new code here.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openakita.agent.errors import UserCancelledError
+
 __all__ = ["UserCancelledError"]
 
 

--- a/src/openakita/core/reasoning_engine.py
+++ b/src/openakita/core/reasoning_engine.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 from openakita.config import settings
 from openakita.core import ReasoningEngine
+from openakita.core._reasoning_engine_legacy import (  # noqa: E402
+    _execute_riskgate_tool_confirmation,
+    _open_riskgate_tool_confirmation,
+)
 
 # The cancel-resume helpers (Issue #608) read these module-scoped names off the
 # legacy ``core.reasoning_engine`` module; upstream tests reference them as
@@ -27,10 +31,6 @@ from openakita.core import ReasoningEngine
 from openakita.core.cancel_cleanup import (  # noqa: E402
     DEFAULT_TTL_SECONDS,
     RESUME_HINT_FRESHNESS_SECONDS,
-)
-from openakita.core._reasoning_engine_legacy import (  # noqa: E402
-    _execute_riskgate_tool_confirmation,
-    _open_riskgate_tool_confirmation,
 )
 
 __all__ = [

--- a/src/openakita/memory/storage.py
+++ b/src/openakita/memory/storage.py
@@ -1137,9 +1137,9 @@ class MemoryStorage:
             return False
         with self._lock:
             try:
-                cursor = self._conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+                self._conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
                 self._conn.commit()
-                return cursor.rowcount > 0
+                return True
             except Exception as e:
                 if _is_db_locked(e):
                     raise

--- a/src/openakita/orgs/runtime.py
+++ b/src/openakita/orgs/runtime.py
@@ -43,7 +43,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from .blackboard import BlackboardBackendProtocol
@@ -200,7 +200,9 @@ def _describe_recent_event(
         art = ev.get("artifact_path") or ""
         if art:
             try:
-                bits.append(f"交付 {Path(str(art)).name}")
+                name = PureWindowsPath(str(art)).name
+                if name:
+                    bits.append(f"交付 {name}")
             except (ValueError, OSError):
                 pass
         return "，".join(bits)

--- a/src/openakita/orgs/scoped_subsystems.py
+++ b/src/openakita/orgs/scoped_subsystems.py
@@ -171,7 +171,7 @@ class OrgScopedScheduler(OrgScopedRegistry):
                     continue
         return out
 
-    def for_org(self, org_id: str) -> "OrgScopedScheduler":
+    def for_org(self, org_id: str) -> OrgScopedScheduler:
         return self
 
 

--- a/src/openakita/runtime/state_graph/guards/unbacked_action.py
+++ b/src/openakita/runtime/state_graph/guards/unbacked_action.py
@@ -34,11 +34,10 @@ from __future__ import annotations
 
 import re
 
+from ....tools.tool_result import successful_tool_effect_actions
 from ._verb_tool_map import CLAIMED_TOOL_TO_FRAGMENTS, VERB_TO_TOOL_FRAGMENTS
 from .recap_context import RECAP_NEAR_RE, is_recap_context
 from .tool_failure_ack import successful_tool_names
-
-from ....tools.tool_result import successful_tool_effect_actions
 
 __all__ = [
     "action_claim_re",

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -21,6 +21,28 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 DEDUP_TIME_WINDOW_SECONDS = 30
+AGENT_SCOPED_MESSAGE_ROLES = frozenset({"user", "assistant", "tool"})
+
+
+def _normalize_agent_profile_id(value: Any) -> str:
+    text = str(value or "default").strip()
+    return text or "default"
+
+
+def _message_agent_profile_id(message: dict) -> str:
+    raw = message.get("agent_profile_id") if isinstance(message, dict) else None
+    if raw is None or str(raw).strip() == "":
+        return ""
+    return _normalize_agent_profile_id(raw)
+
+
+def _record_parent_agent_profile_id(record: dict) -> str:
+    if not isinstance(record, dict):
+        return ""
+    raw = record.get("parent_agent_profile_id") or record.get("session_agent_profile_id")
+    if raw is None or str(raw).strip() == "":
+        return ""
+    return _normalize_agent_profile_id(raw)
 
 
 def is_duplicate_message(
@@ -34,6 +56,7 @@ def is_duplicate_message(
     content = candidate.get("content")
     if not role or content is None:
         return False
+    candidate_profile = _message_agent_profile_id(candidate)
 
     candidate_ts = None
     raw_ts = candidate.get("timestamp")
@@ -47,6 +70,10 @@ def is_duplicate_message(
     for msg in reversed(existing_messages[-8:]):
         if msg.get("role") != role or msg.get("content") != content:
             continue
+        existing_profile = _message_agent_profile_id(msg)
+        if candidate_profile or existing_profile:
+            if candidate_profile != existing_profile:
+                continue
 
         if msg is last_message:
             return True
@@ -216,7 +243,13 @@ class SessionContext:
             metadata = dict(metadata)
             msg_ts = metadata.get("timestamp") or now.isoformat()
             metadata["timestamp"] = msg_ts
+            if role in AGENT_SCOPED_MESSAGE_ROLES and not metadata.get("agent_profile_id"):
+                metadata["agent_profile_id"] = _normalize_agent_profile_id(
+                    self.agent_profile_id
+                )
             candidate = {"role": role, "content": content, "timestamp": msg_ts}
+            if metadata.get("agent_profile_id"):
+                candidate["agent_profile_id"] = metadata["agent_profile_id"]
             if is_duplicate_message(self.messages, candidate):
                 return False
 
@@ -251,6 +284,11 @@ class SessionContext:
                 决定渲染样式。
         """
         with self._msg_lock:
+            metadata = dict(metadata)
+            if role in AGENT_SCOPED_MESSAGE_ROLES and not metadata.get("agent_profile_id"):
+                metadata["agent_profile_id"] = _normalize_agent_profile_id(
+                    self.agent_profile_id
+                )
             self.messages.append(
                 {
                     "role": role,
@@ -346,6 +384,90 @@ class SessionContext:
             except (ValueError, TypeError):
                 pass
         return self.messages
+
+    def filter_messages_for_agent(
+        self,
+        messages: list[dict],
+        agent_profile_id: str | None = None,
+    ) -> list[dict]:
+        """Return only the history that belongs to the active agent profile.
+
+        Legacy sessions created before profile tagging have ambiguous ownership.
+        Untagged turns are replayed only while the session has never recorded a
+        profile switch. Once a session switches agents, untagged user/assistant
+        turns are not fed into profile-scoped LLM history.
+        """
+        source = list(messages or [])
+        if not source:
+            return []
+
+        profile_id = _normalize_agent_profile_id(agent_profile_id or self.agent_profile_id)
+        has_profile_tags = any(_message_agent_profile_id(msg) for msg in source)
+        has_switch_history = bool(self.agent_switch_history)
+        allow_legacy_untagged = not has_switch_history
+        if allow_legacy_untagged and not has_profile_tags:
+            return source
+
+        filtered: list[dict] = []
+        for msg in source:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            if role not in AGENT_SCOPED_MESSAGE_ROLES:
+                filtered.append(msg)
+                continue
+            msg_profile = _message_agent_profile_id(msg)
+            if msg_profile == profile_id or (not msg_profile and allow_legacy_untagged):
+                filtered.append(msg)
+        return filtered
+
+    def get_messages_for_agent(
+        self,
+        agent_profile_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """获取指定 agent profile 可见的消息历史。"""
+        messages = self.filter_messages_for_agent(self.messages, agent_profile_id)
+        if limit is not None:
+            try:
+                return messages[-int(limit) :]
+            except (ValueError, TypeError):
+                pass
+        return messages
+
+    def filter_sub_agent_records_for_agent(
+        self,
+        records: list[dict],
+        agent_profile_id: str | None = None,
+    ) -> list[dict]:
+        """Return sub-agent work records owned by the active parent profile."""
+        source = list(records or [])
+        if not source:
+            return []
+
+        profile_id = _normalize_agent_profile_id(agent_profile_id or self.agent_profile_id)
+        has_profile_tags = any(_record_parent_agent_profile_id(record) for record in source)
+        has_switch_history = bool(self.agent_switch_history)
+        allow_legacy_untagged = not has_switch_history
+        if allow_legacy_untagged and not has_profile_tags:
+            return source
+
+        return [
+            record
+            for record in source
+            if _record_parent_agent_profile_id(record) == profile_id
+            or (not _record_parent_agent_profile_id(record) and allow_legacy_untagged)
+        ]
+
+    def get_sub_agent_records_for_agent(
+        self,
+        agent_profile_id: str | None = None,
+    ) -> list[dict]:
+        """获取指定 agent profile 可见的子 agent 工作记录。"""
+        return self.filter_sub_agent_records_for_agent(
+            self.sub_agent_records,
+            agent_profile_id,
+        )
 
     def set_variable(self, key: str, value: Any) -> None:
         """设置会话变量"""

--- a/src/openakita/tools/handlers/persona.py
+++ b/src/openakita/tools/handlers/persona.py
@@ -18,6 +18,7 @@
 
 import logging
 import uuid
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from ...core.policy_v2 import ApprovalClass
@@ -149,7 +150,20 @@ class PersonaHandler:
                 logger.warning("[switch_persona] Session has no context")
                 return False
             old_id = getattr(ctx, "agent_profile_id", "default")
+            if old_id == profile.id:
+                return True
+            if hasattr(ctx, "agent_switch_history"):
+                ctx.agent_switch_history.append(
+                    {
+                        "from": old_id,
+                        "to": profile.id,
+                        "source": "switch_persona",
+                        "at": datetime.now(UTC).isoformat(),
+                    }
+                )
             ctx.agent_profile_id = profile.id
+            if hasattr(ctx, "mark_topic_boundary"):
+                ctx.mark_topic_boundary()
             logger.info(
                 f"[switch_persona] Switched agent_profile_id: {old_id} -> {profile.id} "
                 f"({profile.name})"

--- a/tests/unit/test_chat_apply_agent_profile.py
+++ b/tests/unit/test_chat_apply_agent_profile.py
@@ -49,6 +49,15 @@ class TestApplyAgentProfileHappyPath:
         assert entry["to"] == "content-creator"
         assert isinstance(entry["at"], str) and entry["at"]
 
+    def test_switch_marks_topic_boundary_at_current_history_position(self):
+        session = _make_session(profile_id="default")
+        session.context.add_message("user", "old default topic")
+
+        _apply_agent_profile(session, "content-creator")
+
+        assert session.context.topic_boundaries == [1]
+        assert session.context.current_topic_start == 1
+
     def test_switch_to_same_profile_is_noop_no_history(self):
         session = _make_session(profile_id="default")
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -91,6 +91,80 @@ class TestSessionCreation:
         assert restored.context.focus_terms == s.context.focus_terms
 
 
+class TestAgentProfileScopedHistory:
+    def test_add_message_stamps_active_agent_profile(self):
+        ctx = SessionContext(agent_profile_id="english")
+
+        added = ctx.add_message("user", "submit English homework")
+
+        assert added is True
+        assert ctx.messages[-1]["agent_profile_id"] == "english"
+
+    def test_duplicate_detection_keeps_same_text_from_different_profiles(self):
+        ctx = SessionContext(agent_profile_id="english")
+
+        assert ctx.add_message("user", "done") is True
+        ctx.agent_profile_id = "politics"
+
+        assert ctx.add_message("user", "done") is True
+        assert [m["agent_profile_id"] for m in ctx.messages] == ["english", "politics"]
+
+    def test_filter_messages_for_agent_excludes_other_profile_turns(self):
+        ctx = SessionContext(agent_profile_id="english")
+        ctx.add_message("user", "English homework")
+        ctx.add_message("assistant", "English feedback")
+        ctx.agent_profile_id = "politics"
+        ctx.add_message("user", "Politics textbook")
+        ctx.add_message("assistant", "Politics answer")
+
+        english = ctx.get_messages_for_agent("english")
+        politics = ctx.get_messages_for_agent("politics")
+
+        assert [m["content"] for m in english] == ["English homework", "English feedback"]
+        assert [m["content"] for m in politics] == ["Politics textbook", "Politics answer"]
+
+    def test_legacy_untagged_history_is_not_replayed_after_profile_switch(self):
+        ctx = SessionContext(agent_profile_id="english")
+        ctx.messages.extend(
+            [
+                {"role": "user", "content": "politics question"},
+                {"role": "assistant", "content": "politics answer"},
+            ]
+        )
+        ctx.agent_switch_history.append({"from": "default", "to": "english"})
+
+        assert ctx.get_messages_for_agent("english") == []
+
+    def test_legacy_single_profile_history_is_preserved_without_switches(self):
+        ctx = SessionContext(agent_profile_id="english")
+        ctx.messages.append({"role": "user", "content": "old English context"})
+
+        assert ctx.get_messages_for_agent("english") == ctx.messages
+
+    def test_legacy_single_profile_history_stays_visible_after_new_tagged_turn(self):
+        ctx = SessionContext(agent_profile_id="english")
+        ctx.messages.append({"role": "user", "content": "old English context"})
+        ctx.add_message("assistant", "new English feedback")
+
+        scoped = ctx.get_messages_for_agent("english")
+
+        assert [m["content"] for m in scoped] == [
+            "old English context",
+            "new English feedback",
+        ]
+
+    def test_sub_agent_records_are_scoped_to_parent_profile(self):
+        ctx = SessionContext(agent_profile_id="english")
+        ctx.sub_agent_records = [
+            {"parent_agent_profile_id": "english", "work_summary": "grammar review"},
+            {"parent_agent_profile_id": "politics", "work_summary": "civics review"},
+        ]
+
+        records = ctx.get_sub_agent_records_for_agent("english")
+
+        assert [r["work_summary"] for r in records] == ["grammar review"]
+
+
 class TestSessionPersistence:
     def test_save_sessions_uses_strict_atomic_json_write(self, tmp_path, monkeypatch):
         manager = SessionManager(storage_path=tmp_path / "sessions")


### PR DESCRIPTION
## Summary
- Tag session messages with the active agent profile and filter LLM history by that profile.
- Scope delegation summaries and sub-agent records to the parent profile to prevent cross-agent context bleed.
- Mark profile switches as topic boundaries across desktop, IM, bot-default, and persona switch paths.
- Keep RiskGate confirmation re-exports lazy so chat route imports work after rebasing onto the latest main split.
- Fix CI lint and setup-center test mock type errors exposed by the updated main baseline.
- Render org activity artifact names consistently when Linux runners receive Windows-style artifact paths.
- Preserve idempotent SQLite memory deletion semantics for missing memory rows.

## Tests
- `uv run --frozen pytest tests/unit/test_session.py tests/unit/test_chat_apply_agent_profile.py tests/unit/test_multi_agent.py -k "Session or sub_agent_records or agent_profile or TestAgentProfileScopedHistory or TestApplyAgentProfile"`
- `uv run --frozen pytest tests/unit/test_org_recent_event_describe.py`
- `Remove-Item Env:LOG_FORMAT -ErrorAction SilentlyContinue; uv run --frozen pytest tests/unit --maxfail=1`
- `uv run --frozen pytest tests/component/test_memory_manager.py tests/unit/test_unified_store.py tests/unit/test_memory_v4_migration_and_isolation.py -k "delete or TestSemanticMemoryCRUD"`
- `uv run --frozen pytest tests/component --maxfail=1`
- `uv run --frozen ruff check src/`
- `npm run build` in `apps/setup-center/`