### PR TITLE
Enable chat image overlay previews

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -6147,6 +6147,7 @@ export function ChatView({
                 key={`${att.name}-${att.type}-${idx}`}
                 att={att}
                 apiBaseUrl={apiBaseUrl}
+                onImagePreview={handleImagePreview}
                 onRemove={() => setPendingAttachments((prev) => prev.filter((_, i) => i !== idx))}
               />
             ))}

--- a/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
+++ b/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
@@ -4,35 +4,61 @@ import {
   IconX, IconMic, IconPlay, IconImage, IconPaperclip,
 } from "../../../icons";
 
-function resolvePreviewUrl(att: ChatAttachment, apiBaseUrl?: string): string {
-  const raw = att.previewUrl || att.url || "";
+function normalizeAttachmentUrl(raw: string, apiBaseUrl?: string): string {
   if (raw.startsWith("data:") || raw.startsWith("blob:")) return raw;
   if (raw.startsWith("http")) return appendAuthToken(raw);
   if (raw.startsWith("/")) return appendAuthToken(`${apiBaseUrl || ""}${raw}`);
-  if (raw) return raw;
-  if (att.localPath) {
-    return appendAuthToken(`${apiBaseUrl || ""}/api/files?path=${encodeURIComponent(att.localPath)}`);
+  return raw;
+}
+
+function resolvePreviewUrls(att: ChatAttachment, apiBaseUrl?: string): { displayUrl: string; downloadUrl: string } {
+  const displayRaw = att.previewUrl || att.url || "";
+  const downloadRaw = att.url || att.previewUrl || "";
+  const displayUrl = normalizeAttachmentUrl(displayRaw, apiBaseUrl);
+  const downloadUrl = normalizeAttachmentUrl(downloadRaw, apiBaseUrl);
+  if (displayUrl || downloadUrl) {
+    return { displayUrl: displayUrl || downloadUrl, downloadUrl: downloadUrl || displayUrl };
   }
-  return "";
+  if (att.localPath) {
+    const fileUrl = appendAuthToken(`${apiBaseUrl || ""}/api/files?path=${encodeURIComponent(att.localPath)}`);
+    return { displayUrl: fileUrl, downloadUrl: fileUrl };
+  }
+  return { displayUrl: "", downloadUrl: "" };
 }
 
 export function AttachmentPreview({
   att,
   onRemove,
   apiBaseUrl,
+  onImagePreview,
 }: {
   att: ChatAttachment;
   onRemove?: () => void;
   apiBaseUrl?: string;
+  onImagePreview?: (displayUrl: string, downloadUrl: string, name: string) => void;
 }) {
-  const previewUrl = att.type === "image" ? resolvePreviewUrl(att, apiBaseUrl) : "";
+  const { displayUrl: previewUrl, downloadUrl } = att.type === "image"
+    ? resolvePreviewUrls(att, apiBaseUrl)
+    : { displayUrl: "", downloadUrl: "" };
   if (att.type === "image" && previewUrl) {
     return (
       <div style={{ position: "relative", display: "inline-block" }}>
-        <img src={previewUrl} alt={att.name} style={{ width: 80, height: 80, objectFit: "cover", display: "block", borderRadius: 10, border: "1px solid var(--line)" }} />
+        <img
+          src={previewUrl}
+          alt={att.name}
+          role={onImagePreview ? "button" : undefined}
+          tabIndex={onImagePreview ? 0 : undefined}
+          style={{ width: 80, height: 80, objectFit: "cover", display: "block", borderRadius: 10, border: "1px solid var(--line)", cursor: onImagePreview ? "pointer" : "default" }}
+          onClick={() => onImagePreview?.(previewUrl, downloadUrl, att.name || "image")}
+          onKeyDown={(e) => {
+            if (!onImagePreview || (e.key !== "Enter" && e.key !== " ")) return;
+            e.preventDefault();
+            onImagePreview(previewUrl, downloadUrl, att.name || "image");
+          }}
+        />
         {onRemove && (
           <button
-            onClick={onRemove}
+            onClick={(e) => { e.stopPropagation(); onRemove(); }}
             style={{
               position: "absolute", top: -6, right: -6,
               width: 22, height: 22, borderRadius: 11,
@@ -55,7 +81,7 @@ export function AttachmentPreview({
     <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 28px 6px 10px", borderRadius: 10, border: "1px solid var(--line)", fontSize: 12 }}>
       {onRemove && (
         <button
-          onClick={onRemove}
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
           style={{
             position: "absolute", top: -6, right: -6,
             width: 22, height: 22, borderRadius: 11,

--- a/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
+++ b/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
@@ -93,7 +93,7 @@ export const FlatMessageItem = memo(function FlatMessageItem({
           {msg.attachments && msg.attachments.length > 0 && (
             <div style={{ marginBottom: 6 }}>
               {msg.attachments.map((att, i) => (
-                <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} />
+                <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} onImagePreview={onImagePreview} />
               ))}
             </div>
           )}
@@ -102,6 +102,8 @@ export const FlatMessageItem = memo(function FlatMessageItem({
             mdModules={mdModules}
             className="chatMdContent"
             streaming={!!msg.streaming}
+            apiBaseUrl={apiBaseUrl}
+            onImagePreview={onImagePreview}
           />
         </div>
       )}

--- a/apps/setup-center/src/views/chat/components/MarkdownContent.tsx
+++ b/apps/setup-center/src/views/chat/components/MarkdownContent.tsx
@@ -1,19 +1,32 @@
 import { useDeferredValue, useMemo, useRef, useState } from "react";
 import { useSmoothReveal } from "../hooks/useSmoothReveal";
 import type { MdModules } from "../utils/chatTypes";
+import { appendAuthToken } from "../utils/chatHelpers";
 
 const MARKDOWN_PREVIEW_CHAR_LIMIT = 40_000;
+
+function resolveMarkdownImageUrl(src: string, apiBaseUrl?: string): string {
+  if (!src) return "";
+  if (src.startsWith("data:") || src.startsWith("blob:")) return src;
+  if (src.startsWith("http")) return appendAuthToken(src);
+  if (src.startsWith("/")) return appendAuthToken(`${apiBaseUrl || ""}${src}`);
+  return src;
+}
 
 export function MarkdownContent({
   content,
   mdModules,
   className,
   streaming = false,
+  apiBaseUrl,
+  onImagePreview,
 }: {
   content: string;
   mdModules?: MdModules | null;
   className?: string;
   streaming?: boolean;
+  apiBaseUrl?: string;
+  onImagePreview?: (displayUrl: string, downloadUrl: string, name: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   // Track whether THIS mounted instance has ever seen streaming=true.
@@ -39,11 +52,45 @@ export function MarkdownContent({
   // 可丢弃正在进行的上一帧渲染重来、并在主线程忙时让位给打字/滚动，
   // 从根上压平"逐 token 重解析重提交"的卡顿（记忆化只治 KaTeX，这个治整棵树）。
   const renderContent = useDeferredValue(revealed);
+  const markdownComponents = useMemo(() => {
+    if (!onImagePreview) return undefined;
+    return {
+      img: ({ node: _node, src, alt, title, ...props }: any) => {
+        const imageUrl = resolveMarkdownImageUrl(String(src || ""), apiBaseUrl);
+        return (
+          <img
+            {...props}
+            src={imageUrl}
+            alt={alt || ""}
+            title={title}
+            role={imageUrl ? "button" : undefined}
+            tabIndex={imageUrl ? 0 : undefined}
+            style={{ ...(props.style || {}), cursor: imageUrl ? "pointer" : props.style?.cursor }}
+            onClick={(e) => {
+              props.onClick?.(e);
+              if (!imageUrl || e.defaultPrevented) return;
+              onImagePreview(imageUrl, imageUrl, alt || title || "image");
+            }}
+            onKeyDown={(e) => {
+              props.onKeyDown?.(e);
+              if (!imageUrl || e.defaultPrevented || (e.key !== "Enter" && e.key !== " ")) return;
+              e.preventDefault();
+              onImagePreview(imageUrl, imageUrl, alt || title || "image");
+            }}
+          />
+        );
+      },
+    };
+  }, [apiBaseUrl, onImagePreview]);
 
   return (
     <div className={className}>
       {mdModules ? (
-        <mdModules.ReactMarkdown remarkPlugins={mdModules.remarkPlugins} rehypePlugins={mdModules.rehypePlugins}>
+        <mdModules.ReactMarkdown
+          remarkPlugins={mdModules.remarkPlugins}
+          rehypePlugins={mdModules.rehypePlugins}
+          components={markdownComponents}
+        >
           {renderContent}
         </mdModules.ReactMarkdown>
       ) : (

--- a/apps/setup-center/src/views/chat/components/MessageBubble.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageBubble.tsx
@@ -105,7 +105,7 @@ export const MessageBubble = memo(function MessageBubble({
         {msg.attachments && msg.attachments.length > 0 && (
           <div style={{ marginBottom: 8 }}>
             {msg.attachments.map((att: ChatAttachment, i: number) => (
-              <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} />
+              <AttachmentPreview key={i} att={att} apiBaseUrl={apiBaseUrl} onImagePreview={onImagePreview} />
             ))}
           </div>
         )}
@@ -163,6 +163,8 @@ export const MessageBubble = memo(function MessageBubble({
               mdModules={mdModules}
               className={isUser ? "chatMdContent chatMdContentUser" : "chatMdContent"}
               streaming={!!msg.streaming}
+              apiBaseUrl={apiBaseUrl}
+              onImagePreview={onImagePreview}
             />
           )
         )}

--- a/apps/setup-center/src/views/chat/components/MessageParts.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageParts.tsx
@@ -88,6 +88,8 @@ export function MessageParts({
                 mdModules={mdModules}
                 className="chatMdContent"
                 streaming={streaming}
+                apiBaseUrl={apiBaseUrl}
+                onImagePreview={onImagePreview}
               />
             ) : null;
           case "tools":

--- a/apps/setup-center/src/views/chat/components/__tests__/AttachmentPreview.test.tsx
+++ b/apps/setup-center/src/views/chat/components/__tests__/AttachmentPreview.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AttachmentPreview } from "../AttachmentPreview";
+
+describe("AttachmentPreview image lightbox trigger", () => {
+  it("opens the image preview when an image thumbnail is clicked", () => {
+    const onImagePreview = vi.fn();
+    const dataUrl = "data:image/png;base64,queued";
+
+    render(
+      <AttachmentPreview
+        att={{ type: "image", name: "queued.png", previewUrl: dataUrl, url: dataUrl }}
+        onImagePreview={onImagePreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "queued.png" }));
+
+    expect(onImagePreview).toHaveBeenCalledTimes(1);
+    expect(onImagePreview).toHaveBeenCalledWith(dataUrl, dataUrl, "queued.png");
+  });
+
+  it("does not open the image preview when the remove button is clicked", () => {
+    const onImagePreview = vi.fn();
+    const onRemove = vi.fn();
+    const dataUrl = "data:image/png;base64,pending";
+    const { container } = render(
+      <AttachmentPreview
+        att={{ type: "image", name: "pending.png", previewUrl: dataUrl, url: dataUrl }}
+        onImagePreview={onImagePreview}
+        onRemove={onRemove}
+      />,
+    );
+
+    const removeButton = container.querySelector("button");
+    expect(removeButton).not.toBeNull();
+    fireEvent.click(removeButton as HTMLButtonElement);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onImagePreview).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Enable chat image thumbnails and Markdown images to open the existing full-screen overlay preview.
- Wire pending, sent, restored, and structured chat image paths into the shared lightbox behavior.

## Tests
- `npm run test:run -- src/views/chat/components/__tests__/AttachmentPreview.test.tsx`
- `npm run build`