### PR TITLE
Fix session drafts to sync as persisted conversations

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -111,6 +111,107 @@ function _asFiniteCount(value: unknown): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
 }
 
+function _hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function _timestampMs(value: unknown, fallback = Date.now()): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function _sessionConversationFromPayload(raw: Record<string, unknown>): ChatConversation | null {
+  const idRaw = typeof raw.id === "string" ? raw.id : raw.conversation_id;
+  const id = typeof idRaw === "string" ? idRaw.trim() : "";
+  if (!id) return null;
+
+  const titleRaw = typeof raw.title === "string" ? raw.title.trim() : "";
+  const conv: ChatConversation = {
+    id,
+    title: titleRaw || "对话",
+    lastMessage: typeof raw.lastMessage === "string" ? raw.lastMessage : "",
+    timestamp: _timestampMs(raw.timestamp),
+    messageCount: _asFiniteCount(raw.messageCount),
+  };
+  if (typeof raw.titleGenerated === "boolean") conv.titleGenerated = raw.titleGenerated;
+  if (typeof raw.titleManuallySet === "boolean") conv.titleManuallySet = raw.titleManuallySet;
+  if (typeof raw.pinned === "boolean") conv.pinned = raw.pinned;
+  if (typeof raw.agentProfileId === "string" && raw.agentProfileId) {
+    conv.agentProfileId = raw.agentProfileId;
+  }
+  if (_hasOwn(raw, "endpointId")) {
+    conv.endpointId = typeof raw.endpointId === "string" && raw.endpointId ? raw.endpointId : undefined;
+  }
+  if (_hasOwn(raw, "endpointPolicy")) {
+    conv.endpointPolicy = raw.endpointPolicy === "require" ? "require" : "prefer";
+  }
+  if (_hasOwn(raw, "orgMode")) conv.orgMode = Boolean(raw.orgMode);
+  if (_hasOwn(raw, "orgId")) {
+    conv.orgId = typeof raw.orgId === "string" && raw.orgId ? raw.orgId : undefined;
+  }
+  if (_hasOwn(raw, "orgNodeId")) {
+    conv.orgNodeId = typeof raw.orgNodeId === "string" && raw.orgNodeId ? raw.orgNodeId : undefined;
+  }
+  return conv;
+}
+
+function _mergeSessionConversation(
+  local: ChatConversation,
+  incoming: ChatConversation,
+  options: { timestampMode?: "backend" | "max" } = {},
+): ChatConversation {
+  const incomingRaw = incoming as unknown as Record<string, unknown>;
+  const incomingManual = incoming.titleManuallySet === true;
+  const localManual = local.titleManuallySet === true;
+  const title = incomingManual
+    ? (incoming.title || local.title || "对话")
+    : localManual
+      ? (local.title || incoming.title || "对话")
+      : (incoming.title || local.title || "对话");
+  const titleManuallySet = incomingManual || localManual;
+  const titleGenerated = titleManuallySet
+    ? false
+    : incoming.titleGenerated !== undefined
+      ? Boolean(incoming.titleGenerated)
+      : Boolean(local.titleGenerated);
+  const timestamp = options.timestampMode === "backend"
+    ? (incoming.timestamp || local.timestamp || Date.now())
+    : (Math.max(local.timestamp || 0, incoming.timestamp || 0) || Date.now());
+
+  const merged: ChatConversation = {
+    ...local,
+    title,
+    titleGenerated,
+    titleManuallySet,
+    lastMessage: incoming.lastMessage || local.lastMessage,
+    timestamp,
+    messageCount: Math.max(local.messageCount || 0, incoming.messageCount || 0),
+  };
+
+  if (_hasOwn(incomingRaw, "pinned")) merged.pinned = incoming.pinned;
+  if (_hasOwn(incomingRaw, "agentProfileId") && incoming.agentProfileId) {
+    merged.agentProfileId = incoming.agentProfileId;
+  }
+  if (_hasOwn(incomingRaw, "endpointId")) merged.endpointId = incoming.endpointId;
+  if (_hasOwn(incomingRaw, "endpointPolicy")) merged.endpointPolicy = incoming.endpointPolicy;
+  if (_hasOwn(incomingRaw, "orgMode")) merged.orgMode = incoming.orgMode;
+  if (_hasOwn(incomingRaw, "orgId")) merged.orgId = incoming.orgId;
+  if (_hasOwn(incomingRaw, "orgNodeId")) merged.orgNodeId = incoming.orgNodeId;
+  return merged;
+}
+
+function _upsertSessionConversation(
+  prev: ChatConversation[],
+  incoming: ChatConversation,
+  options: { timestampMode?: "backend" | "max" } = {},
+): ChatConversation[] {
+  const idx = prev.findIndex((c) => c.id === incoming.id);
+  if (idx < 0) return [incoming, ...prev];
+  const next = [...prev];
+  next[idx] = _mergeSessionConversation(prev[idx], incoming, options);
+  return next;
+}
+
 const SECURITY_DECISION_VALUES: readonly SecurityDecision[] = [
   "allow_once",
   "allow_session",
@@ -1712,8 +1813,6 @@ export function ChatView({
     if (!convId) return;
     const conv = conversations.find((c) => c.id === convId);
     if (!conv) return;
-    // Avoid creating empty backend sessions just because the user explored selectors.
-    if ((conv.messageCount || 0) === 0 && messages.length === 0) return;
 
     const timer = setTimeout(() => {
       safeFetch(`${apiBaseUrl}/api/sessions/${encodeURIComponent(convId)}/ui-state`, {
@@ -1737,7 +1836,6 @@ export function ChatView({
     selectedOrgId,
     selectedOrgNodeId,
     conversations,
-    messages.length,
     apiBaseUrl,
   ]);
 
@@ -1822,45 +1920,21 @@ export function ChatView({
         }
         if (backendSessions.length === 0) return;
 
-        const restoredConvs: ChatConversation[] = backendSessions.map((s) => ({
-          id: s.id,
-          title: s.title || "对话",
-          lastMessage: s.lastMessage || "",
-          timestamp: s.timestamp,
-          messageCount: s.messageCount || 0,
-          agentProfileId: s.agentProfileId,
-          endpointId: s.endpointId,
-          endpointPolicy: s.endpointPolicy,
-          orgMode: s.orgMode,
-          orgId: s.orgId,
-          orgNodeId: s.orgNodeId,
-        }));
+        const restoredConvs: ChatConversation[] = backendSessions
+          .map((s) => _sessionConversationFromPayload(s as Record<string, unknown>))
+          .filter((c): c is ChatConversation => Boolean(c));
 
         setConversations((prev) => {
           const prevMap = new Map(prev.map((c) => [c.id, c]));
           const mergedFromBackend: ChatConversation[] = restoredConvs.map((b) => {
             const local = prevMap.get(b.id);
             if (!local) return b;
-            return {
-              ...local,
-              title: local.titleGenerated ? local.title : (b.title || local.title || "对话"),
-              lastMessage: b.lastMessage || local.lastMessage,
-              // 后端时间戳现以"最后一条真实消息"为准（见后端 #628 修复），是列表
-              // 排序/显示的权威值。这里**不能**再无脑 Math.max：早期被旧逻辑
-              // 污染（≈打开时刻）并缓存进 localStorage 的 local.timestamp 会被
-              // Math.max 永久锁住，导致升级后时间与顺序仍然不对。只有正在流式
-              // 输出的会话保留本地乐观值，避免对账瞬间把活跃会话往下挪。
-              timestamp: streamContexts.current.has(b.id)
-                ? Math.max(local.timestamp || 0, b.timestamp || 0)
-                : (b.timestamp || local.timestamp || 0),
-              messageCount: Math.max(local.messageCount || 0, b.messageCount || 0),
-              agentProfileId: b.agentProfileId || local.agentProfileId,
-              endpointId: b.endpointId || local.endpointId,
-              endpointPolicy: b.endpointPolicy || local.endpointPolicy,
-              orgMode: b.orgMode ?? local.orgMode,
-              orgId: b.orgId || local.orgId,
-              orgNodeId: b.orgNodeId || local.orgNodeId,
-            };
+            // 后端时间戳现以"最后一条真实消息"为准（见后端 #628 修复），是列表
+            // 排序/显示的权威值。只有正在流式输出的会话保留本地乐观值，避免
+            // 对账瞬间把活跃会话往下挪。
+            return _mergeSessionConversation(local, b, {
+              timestampMode: streamContexts.current.has(b.id) ? "max" : "backend",
+            });
           });
           const backendIds = new Set(restoredConvs.map((c) => c.id));
           const localOnly = prev.filter((c) => !backendIds.has(c.id));
@@ -1951,13 +2025,32 @@ export function ChatView({
           const idx = prev.findIndex(c => c.id === convId);
           if (idx >= 0) {
             const updated = [...prev];
-            updated[idx] = { ...updated[idx], title: title || updated[idx].title, lastMessage: preview || updated[idx].lastMessage, timestamp: Math.max(updated[idx].timestamp || 0, ts), messageCount: (updated[idx].messageCount || 0) + 1 };
+            const current = updated[idx];
+            updated[idx] = {
+              ...current,
+              title: title && !current.titleManuallySet ? title : current.title,
+              lastMessage: preview || current.lastMessage,
+              timestamp: Math.max(current.timestamp || 0, ts),
+              messageCount: (current.messageCount || 0) + 1,
+            };
             return updated;
           }
           return [{ id: convId, title: title || preview.slice(0, 20) || "对话", lastMessage: preview, timestamp: ts, messageCount: 1 }, ...prev];
         });
         if (!activeConvIdRef.current) {
           activateConversation(convId);
+        }
+      } else if (
+        event === "chat:session_update"
+        || event === "chat:conversation_created"
+        || event === "chat:conversation_upsert"
+      ) {
+        const incoming = _sessionConversationFromPayload(d);
+        if (incoming) {
+          setConversations((prev) => _upsertSessionConversation(prev, incoming));
+          if (!activeConvIdRef.current) {
+            activateConversation(incoming.id);
+          }
         }
       } else if (event === "chat:conversation_deleted") {
         setConversations((prev) => {
@@ -1972,13 +2065,27 @@ export function ChatView({
           setMessages([]);
         }
       } else if (event === "chat:title_update") {
-        const title = d.title as string;
-        if (title) {
-          setConversations((prev) => prev.map(c => {
-            if (c.id !== convId) return c;
-            if (c.titleManuallySet) return c;
-            return { ...c, title, titleGenerated: true };
-          }));
+        const incoming = _hasOwn(d, "id") ? _sessionConversationFromPayload(d) : null;
+        if (incoming) {
+          setConversations((prev) => _upsertSessionConversation(prev, incoming));
+        } else {
+          const title = typeof d.title === "string" ? d.title.trim() : "";
+          if (title) {
+            setConversations((prev) => prev.map((c) => {
+              if (c.id !== convId) return c;
+              if (c.titleManuallySet) return c;
+              return { ...c, title, titleGenerated: true, titleManuallySet: false };
+            }));
+          }
+        }
+      } else if (event === "chat:pin_update") {
+        const incoming = _hasOwn(d, "id") ? _sessionConversationFromPayload(d) : null;
+        if (incoming) {
+          setConversations((prev) => _upsertSessionConversation(prev, incoming));
+        } else if (typeof d.pinned === "boolean") {
+          setConversations((prev) => prev.map((c) =>
+            c.id === convId ? { ...c, pinned: d.pinned as boolean } : c
+          ));
         }
       }
     });
@@ -2520,6 +2627,7 @@ export function ChatView({
   // ── 新建对话 ──
   const newConversation = useCallback(() => {
     const id = genId();
+    const createdAt = Date.now();
     if (activeConvId) {
       const ctx = streamContexts.current.get(activeConvId);
       const msgsToSave = ctx?.isStreaming ? ctx.messages : messages;
@@ -2537,16 +2645,45 @@ export function ChatView({
     setOrgMode(false);
     setSelectedOrgId(null);
     setSelectedOrgNodeId(null);
-    setConversations((prev) => [{
+    const draftConversation: ChatConversation = {
       id,
       title: "新对话",
       lastMessage: "",
-      timestamp: Date.now(),
+      timestamp: createdAt,
       messageCount: 0,
       agentProfileId: selectedAgent,
       orgMode: false,
-    }, ...prev]);
-  }, [activeConvId, messages, selectedAgent, setInputValue, activateConversation]);
+    };
+    setConversations((prev) => [draftConversation, ...prev]);
+    if (serviceRunning) {
+      void safeFetch(`${apiBaseUrl}/api/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationId: id,
+          title: "新对话",
+          titleManuallySet: false,
+          titleGenerated: false,
+          agentProfileId: selectedAgent,
+          endpointId: null,
+          endpointPolicy: "prefer",
+          orgMode: false,
+          orgId: null,
+          orgNodeId: null,
+        }),
+      }).then(async (res) => {
+        if (!res.ok) return;
+        const data = await res.json().catch(() => null);
+        if (!data || typeof data !== "object" || data.ok === false) return;
+        const incoming = _sessionConversationFromPayload(data as Record<string, unknown>);
+        if (incoming) {
+          setConversations((prev) => _upsertSessionConversation(prev, incoming));
+        }
+      }).catch((err) => {
+        logger.warn("[chat]", "create conversation session failed", { convId: id, err });
+      });
+    }
+  }, [activeConvId, messages, selectedAgent, serviceRunning, apiBaseUrl, activateConversation]);
 
   // ── 删除对话（实际执行） ──
   const doDeleteConversation = useCallback(async (convId: string) => {
@@ -2615,23 +2752,71 @@ export function ChatView({
 
   // ── 置顶/取消置顶 ──
   const togglePinConversation = useCallback((convId: string) => {
+    const pinned = !latestConversationsRef.current.find((c) => c.id === convId)?.pinned;
     setConversations((prev) => prev.map((c) =>
-      c.id === convId ? { ...c, pinned: !c.pinned } : c
+      c.id === convId ? { ...c, pinned } : c
     ));
+    void safeFetch(`${apiBaseUrl}/api/sessions/${encodeURIComponent(convId)}/pin`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned }),
+    }).then(async (res) => {
+      if (!res.ok) return;
+      const data = await res.json().catch(() => null);
+      if (data && data.ok !== false && typeof data.pinned === "boolean") {
+        setConversations((prev) => prev.map((c) =>
+          c.id === convId ? { ...c, pinned: data.pinned } : c
+        ));
+      }
+    }).catch((err) => {
+      logger.warn("chat", "persist conversation pin failed", { convId, err });
+    });
     setCtxMenu(null);
-  }, []);
+  }, [apiBaseUrl, latestConversationsRef]);
 
   // ── 重命名确认 ──
   const confirmRename = useCallback((convId: string, newTitle: string) => {
     const title = newTitle.trim();
     if (title) {
       setConversations((prev) => prev.map((c) =>
-        c.id === convId ? { ...c, title, titleManuallySet: true } : c
+        c.id === convId ? { ...c, title, titleManuallySet: true, titleGenerated: false } : c
       ));
+      void safeFetch(`${apiBaseUrl}/api/sessions/${encodeURIComponent(convId)}/title`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, titleManuallySet: true, titleGenerated: false }),
+      }).then(async (res) => {
+        if (!res.ok) {
+          logger.warn("[chat]", "persist conversation title failed", { convId, status: res.status });
+          return;
+        }
+        const data = await res.json().catch(() => null);
+        if (data && data.ok === false) {
+          logger.warn("[chat]", "persist conversation title skipped", { convId, reason: data.reason });
+        } else if (data && data.ok !== false) {
+          setConversations((prev) => prev.map((c) =>
+            c.id === convId
+              ? {
+                  ...c,
+                  title: typeof data.title === "string" && data.title.trim() ? data.title : c.title,
+                  titleManuallySet: data.titleManuallySet === undefined
+                    ? c.titleManuallySet
+                    : Boolean(data.titleManuallySet),
+                  titleGenerated: data.titleGenerated === undefined
+                    ? c.titleGenerated
+                    : Boolean(data.titleGenerated),
+                  pinned: typeof data.pinned === "boolean" ? data.pinned : c.pinned,
+                }
+              : c
+          ));
+        }
+      }).catch((err) => {
+        logger.warn("[chat]", "persist conversation title failed", { convId, err });
+      });
     }
     setRenamingId(null);
     setRenameText("");
-  }, []);
+  }, [apiBaseUrl]);
 
   // ── 发送消息（overrideText 用于 ask_user 回复等场景，绕过 inputText；targetConvId 用于自动出队等需要指定目标会话的场景） ──
   // displayContent: 当发送给 API 的原文（如 JSON）不适合直接展示时，可指定用户气泡中的显示文本
@@ -4554,7 +4739,7 @@ export function ChatView({
             : c
         );
         const conv = updated.find((c) => c.id === thisConvId);
-        if (appendUserMessage && conv && !conv.titleGenerated && (conv.messageCount || 0) <= 2) {
+        if (appendUserMessage && conv && !conv.titleManuallySet && !conv.titleGenerated && (conv.messageCount || 0) <= 2) {
           (async () => {
             try {
               const res = await safeFetch(`${apiBase}/api/sessions/generate-title`, {
@@ -4566,7 +4751,18 @@ export function ChatView({
               const data = await res.json();
               if (data.title) {
                 setConversations((p) => p.map((c) =>
-                  c.id === thisConvId ? { ...c, title: data.title, titleGenerated: true } : c
+                  c.id === thisConvId
+                    ? (
+                        c.titleManuallySet
+                          ? c
+                          : {
+                              ...c,
+                              title: data.title,
+                              titleGenerated: data.titleGenerated !== false,
+                              titleManuallySet: false,
+                            }
+                      )
+                    : c
                 ));
               }
             } catch { /* fallback: keep truncated title */ }

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -1,6 +1,7 @@
 """
 Sessions route: GET /api/sessions, GET /api/sessions/{conversation_id}/history,
-DELETE /api/sessions/{conversation_id}, POST /api/sessions/generate-title
+POST /api/sessions, DELETE /api/sessions/{conversation_id},
+PATCH /api/sessions/{conversation_id}/title, POST /api/sessions/generate-title
 
 提供桌面端 session 恢复能力：前端启动时可从后端加载对话列表和历史消息。
 """
@@ -27,6 +28,10 @@ router = APIRouter()
 _ID_PATTERN = re.compile(r"^[A-Za-z0-9_\-:.@]{1,128}$")
 _DEFAULT_HISTORY_LIMIT = 80
 _MAX_HISTORY_LIMIT = 200
+_META_CONVERSATION_TITLE = "conversation_title"
+_META_TITLE_MANUALLY_SET = "title_manually_set"
+_META_TITLE_GENERATED = "title_generated"
+_META_PINNED = "pinned"
 
 
 def _validate_id(value: str, field: str) -> None:
@@ -62,6 +67,62 @@ class SessionUiStateRequest(BaseModel):
     org_mode: bool = Field(False, alias="orgMode")
     org_id: str | None = Field(None, alias="orgId", max_length=128)
     org_node_id: str | None = Field(None, alias="orgNodeId", max_length=128)
+
+
+class SessionCreateRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    conversation_id: str = Field(..., alias="conversationId", min_length=1, max_length=128)
+    title: str = Field("新对话", max_length=120, description="Initial conversation title")
+    title_manually_set: bool = Field(False, alias="titleManuallySet")
+    title_generated: bool = Field(False, alias="titleGenerated")
+    pinned: bool = Field(False, description="Whether the conversation is pinned")
+    agent_profile_id: str | None = Field(None, alias="agentProfileId", max_length=128)
+    endpoint_id: str | None = Field(None, alias="endpointId", max_length=200)
+    endpoint_policy: Literal["prefer", "require"] = Field("prefer", alias="endpointPolicy")
+    org_mode: bool = Field(False, alias="orgMode")
+    org_id: str | None = Field(None, alias="orgId", max_length=128)
+    org_node_id: str | None = Field(None, alias="orgNodeId", max_length=128)
+
+
+class SessionTitleRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    title: str = Field(..., min_length=1, max_length=120, description="会话标题")
+    title_manually_set: bool = Field(True, alias="titleManuallySet")
+    title_generated: bool = Field(False, alias="titleGenerated")
+
+
+class SessionPinRequest(BaseModel):
+    pinned: bool = Field(..., description="Whether the conversation is pinned")
+
+
+def _normalize_title(title: str, *, fallback: str | None = None) -> str:
+    normalized = " ".join(str(title or "").split()).strip()
+    if normalized:
+        return normalized
+    return fallback or ""
+
+
+def _apply_session_ui_state(
+    session,
+    *,
+    endpoint_id: str | None,
+    endpoint_policy: Literal["prefer", "require"],
+    org_mode: bool,
+    org_id: str | None,
+    org_node_id: str | None,
+) -> None:
+    session.set_metadata("selected_endpoint", endpoint_id or "")
+    session.set_metadata("endpoint_policy", endpoint_policy if endpoint_id else "prefer")
+    session.set_metadata(
+        "ui_org_state",
+        {
+            "orgMode": bool(org_mode and org_id),
+            "orgId": org_id or "",
+            "orgNodeId": org_node_id or "",
+        },
+    )
 
 
 def _visible_history_messages(session) -> list[tuple[int, dict]]:
@@ -124,6 +185,62 @@ def _last_activity_ms(session, visible_msgs: list[dict]) -> int:
         return int(base.timestamp() * 1000)
     except Exception:
         return 0
+
+
+def _session_list_item(session, visible_msgs: list[dict] | None = None, last_ms: int | None = None) -> dict:
+    """Serialize one session for conversation-list sync surfaces."""
+    if visible_msgs is None:
+        visible_msgs = [m for _, m in _visible_history_messages(session)]
+    if last_ms is None:
+        last_ms = _last_activity_ms(session, visible_msgs)
+
+    user_msgs = [m for m in visible_msgs if m.get("role") == "user"]
+    first_user = user_msgs[0] if user_msgs else None
+    fallback_title = ""
+    if first_user:
+        content = first_user.get("content", "")
+        fallback_title = content[:30] if isinstance(content, str) else ""
+    if getattr(session, "channel", "") == "desktop" and session.get_metadata("source_channel"):
+        fallback_title = (
+            getattr(session, "chat_name", "")
+            or getattr(session, "display_name", "")
+            or fallback_title
+        )
+
+    stored_title = session.get_metadata(_META_CONVERSATION_TITLE)
+    stored_title = stored_title.strip() if isinstance(stored_title, str) else ""
+    title_manually_set = bool(stored_title and session.get_metadata(_META_TITLE_MANUALLY_SET))
+    title_generated = bool(stored_title and session.get_metadata(_META_TITLE_GENERATED))
+    title = stored_title or fallback_title
+
+    last_msg_content = ""
+    if visible_msgs:
+        last_content = visible_msgs[-1].get("content", "")
+        if isinstance(last_content, str):
+            last_msg_content = last_content[:100]
+
+    selected_endpoint = session.get_metadata("selected_endpoint") or ""
+    endpoint_policy = session.get_metadata("endpoint_policy") or "prefer"
+    ui_org_state = session.get_metadata("ui_org_state") or {}
+    if not isinstance(ui_org_state, dict):
+        ui_org_state = {}
+
+    return {
+        "id": session.chat_id,
+        "title": title or "对话",
+        "titleGenerated": title_generated,
+        "titleManuallySet": title_manually_set,
+        "pinned": bool(session.get_metadata(_META_PINNED)),
+        "lastMessage": last_msg_content,
+        "timestamp": last_ms,
+        "messageCount": len(visible_msgs),
+        "agentProfileId": getattr(session.context, "agent_profile_id", "default"),
+        "endpointId": selected_endpoint or None,
+        "endpointPolicy": endpoint_policy if selected_endpoint else "prefer",
+        "orgMode": bool(ui_org_state.get("orgMode") and ui_org_state.get("orgId")),
+        "orgId": ui_org_state.get("orgId") or None,
+        "orgNodeId": ui_org_state.get("orgNodeId") or None,
+    }
 
 
 _BACKFILL_DONE_FLAG = "_history_backfilled"
@@ -375,42 +492,7 @@ async def list_sessions(request: Request, channel: str = "desktop"):
 
     result = []
     for s, visible_msgs, last_ms in prepared:
-        user_msgs = [m for m in visible_msgs if m.get("role") == "user"]
-        first_user = user_msgs[0] if user_msgs else None
-        title = ""
-        if first_user:
-            content = first_user.get("content", "")
-            title = content[:30] if isinstance(content, str) else ""
-        if getattr(s, "channel", "") == "desktop" and s.get_metadata("source_channel"):
-            title = getattr(s, "chat_name", "") or getattr(s, "display_name", "") or title
-
-        last_msg_content = ""
-        if visible_msgs:
-            last_content = visible_msgs[-1].get("content", "")
-            if isinstance(last_content, str):
-                last_msg_content = last_content[:100]
-
-        selected_endpoint = s.get_metadata("selected_endpoint") or ""
-        endpoint_policy = s.get_metadata("endpoint_policy") or "prefer"
-        ui_org_state = s.get_metadata("ui_org_state") or {}
-        if not isinstance(ui_org_state, dict):
-            ui_org_state = {}
-
-        result.append(
-            {
-                "id": s.chat_id,
-                "title": title or "对话",
-                "lastMessage": last_msg_content,
-                "timestamp": last_ms,
-                "messageCount": len(visible_msgs),
-                "agentProfileId": getattr(s.context, "agent_profile_id", "default"),
-                "endpointId": selected_endpoint or None,
-                "endpointPolicy": endpoint_policy if selected_endpoint else "prefer",
-                "orgMode": bool(ui_org_state.get("orgMode") and ui_org_state.get("orgId")),
-                "orgId": ui_org_state.get("orgId") or None,
-                "orgNodeId": ui_org_state.get("orgNodeId") or None,
-            }
-        )
+        result.append(_session_list_item(s, visible_msgs, last_ms))
 
     data_epoch = ""
     wac = getattr(request.app.state, "web_access_config", None)
@@ -418,6 +500,89 @@ async def list_sessions(request: Request, channel: str = "desktop"):
         data_epoch = wac.data_epoch
 
     return {"sessions": result, "data_epoch": data_epoch, "ready": True}
+
+
+@router.post("/api/sessions")
+async def create_session(
+    request: Request,
+    body: SessionCreateRequest,
+    channel: str = "desktop",
+    user_id: str = "desktop_user",
+):
+    """Create or update the list metadata for a first-class conversation.
+
+    This endpoint intentionally owns the "empty draft conversation" case so
+    title/pin/UI-state updates do not need to create missing sessions as a side
+    effect.
+    """
+    conversation_id = body.conversation_id.strip()
+    _validate_id(conversation_id, "conversation_id")
+    _validate_id(channel, "channel")
+    _validate_id(user_id, "user_id")
+    session_manager = getattr(request.app.state, "session_manager", None)
+    if not session_manager:
+        raise HTTPException(status_code=503, detail="Session manager unavailable")
+
+    existing = session_manager.get_session(
+        channel=channel,
+        chat_id=conversation_id,
+        user_id=user_id,
+        create_if_missing=False,
+    )
+    session = existing or session_manager.get_session(
+        channel=channel,
+        chat_id=conversation_id,
+        user_id=user_id,
+        create_if_missing=True,
+    )
+    if session is None:
+        raise HTTPException(status_code=500, detail="failed to create session")
+
+    agent_profile_id = (body.agent_profile_id or "").strip()
+    if agent_profile_id:
+        session.context.agent_profile_id = agent_profile_id
+
+    stored_title = session.get_metadata(_META_CONVERSATION_TITLE)
+    title = _normalize_title(body.title, fallback="新对话")
+    if not isinstance(stored_title, str) or not stored_title.strip():
+        manually_set = bool(body.title_manually_set)
+        session.set_metadata(_META_CONVERSATION_TITLE, title)
+        session.set_metadata(_META_TITLE_MANUALLY_SET, manually_set)
+        session.set_metadata(_META_TITLE_GENERATED, False if manually_set else bool(body.title_generated))
+
+    if existing is None or body.pinned:
+        session.set_metadata(_META_PINNED, bool(body.pinned))
+
+    _apply_session_ui_state(
+        session,
+        endpoint_id=body.endpoint_id,
+        endpoint_policy=body.endpoint_policy,
+        org_mode=body.org_mode,
+        org_id=body.org_id,
+        org_node_id=body.org_node_id,
+    )
+    session_manager.mark_dirty()
+    try:
+        session_manager.persist()
+    except Exception as exc:
+        logger.warning("[Sessions API] Failed to persist created session: %s", exc)
+
+    summary = _session_list_item(session)
+    logger.info(
+        "[Sessions API] session upserted conversation_id=%s title=%r message_count=%s pinned=%s",
+        conversation_id,
+        summary["title"],
+        summary["messageCount"],
+        summary["pinned"],
+    )
+    await _broadcast_session_event(
+        "chat:session_update",
+        {
+            "conversation_id": conversation_id,
+            **summary,
+        },
+    )
+    return {"ok": True, "created": existing is None, **summary}
 
 
 @router.post("/api/sessions/{conversation_id}/ui-state")
@@ -444,15 +609,13 @@ async def update_session_ui_state(
     )
     if session is None:
         return {"ok": False, "reason": "session_not_found"}
-    session.set_metadata("selected_endpoint", body.endpoint_id or "")
-    session.set_metadata("endpoint_policy", body.endpoint_policy if body.endpoint_id else "prefer")
-    session.set_metadata(
-        "ui_org_state",
-        {
-            "orgMode": bool(body.org_mode and body.org_id),
-            "orgId": body.org_id or "",
-            "orgNodeId": body.org_node_id or "",
-        },
+    _apply_session_ui_state(
+        session,
+        endpoint_id=body.endpoint_id,
+        endpoint_policy=body.endpoint_policy,
+        org_mode=body.org_mode,
+        org_id=body.org_id,
+        org_node_id=body.org_node_id,
     )
     session_manager.mark_dirty()
     try:
@@ -460,6 +623,116 @@ async def update_session_ui_state(
     except Exception as exc:
         logger.warning("[Sessions API] Failed to persist UI state: %s", exc)
     return {"ok": True}
+
+
+@router.patch("/api/sessions/{conversation_id}/title")
+async def update_session_title(
+    request: Request,
+    conversation_id: str,
+    body: SessionTitleRequest,
+    channel: str = "desktop",
+    user_id: str = "desktop_user",
+):
+    """Persist a user-facing conversation title in session metadata."""
+    _validate_id(conversation_id, "conversation_id")
+    _validate_id(channel, "channel")
+    _validate_id(user_id, "user_id")
+    session_manager = getattr(request.app.state, "session_manager", None)
+    if not session_manager:
+        raise HTTPException(status_code=503, detail="Session manager unavailable")
+
+    title = _normalize_title(body.title)
+    if not title:
+        raise HTTPException(status_code=422, detail="title must not be empty")
+
+    session = session_manager.get_session(
+        channel=channel,
+        chat_id=conversation_id,
+        user_id=user_id,
+        create_if_missing=False,
+    )
+    if session is None:
+        return {"ok": False, "reason": "session_not_found"}
+
+    manually_set = bool(body.title_manually_set)
+    generated = False if manually_set else bool(body.title_generated)
+    session.set_metadata(_META_CONVERSATION_TITLE, title)
+    session.set_metadata(_META_TITLE_MANUALLY_SET, manually_set)
+    session.set_metadata(_META_TITLE_GENERATED, generated)
+    session_manager.mark_dirty()
+    try:
+        session_manager.persist()
+    except Exception as exc:
+        logger.warning("[Sessions API] Failed to persist title: %s", exc)
+
+    summary = _session_list_item(session)
+    logger.info(
+        "[Sessions API] title updated conversation_id=%s title=%r manual=%s generated=%s pinned=%s",
+        conversation_id,
+        summary["title"],
+        summary["titleManuallySet"],
+        summary["titleGenerated"],
+        summary["pinned"],
+    )
+    await _broadcast_session_event(
+        "chat:title_update",
+        {
+            "conversation_id": conversation_id,
+            **summary,
+        },
+    )
+    return {"ok": True, **summary}
+
+
+@router.patch("/api/sessions/{conversation_id}/pin")
+async def update_session_pin(
+    request: Request,
+    conversation_id: str,
+    body: SessionPinRequest,
+    channel: str = "desktop",
+    user_id: str = "desktop_user",
+):
+    """Persist conversation pinning so all clients show the same list grouping."""
+    _validate_id(conversation_id, "conversation_id")
+    _validate_id(channel, "channel")
+    _validate_id(user_id, "user_id")
+    session_manager = getattr(request.app.state, "session_manager", None)
+    if not session_manager:
+        raise HTTPException(status_code=503, detail="Session manager unavailable")
+
+    session = session_manager.get_session(
+        channel=channel,
+        chat_id=conversation_id,
+        user_id=user_id,
+        create_if_missing=False,
+    )
+    if session is None:
+        return {"ok": False, "reason": "session_not_found"}
+
+    pinned = bool(body.pinned)
+    session.set_metadata(_META_PINNED, pinned)
+    session_manager.mark_dirty()
+    try:
+        session_manager.persist()
+    except Exception as exc:
+        logger.warning("[Sessions API] Failed to persist pin state: %s", exc)
+
+    summary = _session_list_item(session)
+    logger.info(
+        "[Sessions API] pin updated conversation_id=%s pinned=%s title=%r manual=%s",
+        conversation_id,
+        summary["pinned"],
+        summary["title"],
+        summary["titleManuallySet"],
+    )
+    await _broadcast_session_event(
+        "chat:pin_update",
+        {
+            "conversation_id": conversation_id,
+            **summary,
+        },
+    )
+    return {"ok": True, **summary}
 
 
 @router.get("/api/sessions/{conversation_id}/history")
@@ -693,6 +966,35 @@ async def append_session_messages(
 @router.post("/api/sessions/generate-title")
 async def generate_title(request: Request, body: GenerateTitleRequest):
     """Use LLM to generate a concise conversation title from the first message."""
+    session = None
+    session_manager = getattr(request.app.state, "session_manager", None)
+    if body.conversation_id:
+        _validate_id(body.conversation_id, "conversation_id")
+        if session_manager:
+            session = session_manager.get_session(
+                channel="desktop",
+                chat_id=body.conversation_id,
+                user_id="desktop_user",
+                create_if_missing=False,
+            )
+            stored_title = session.get_metadata(_META_CONVERSATION_TITLE) if session else ""
+            if (
+                isinstance(stored_title, str)
+                and stored_title.strip()
+                and session
+                and session.get_metadata(_META_TITLE_MANUALLY_SET)
+            ):
+                logger.info(
+                    "[Sessions API] generated title skipped conversation_id=%s reason=manual_title title=%r",
+                    body.conversation_id,
+                    stored_title.strip(),
+                )
+                return {
+                    "title": stored_title.strip(),
+                    "titleGenerated": False,
+                    "titleManuallySet": True,
+                }
+
     agent = getattr(request.app.state, "agent", None)
     if not agent:
         return {"title": body.message[:20] or "新对话"}
@@ -732,14 +1034,50 @@ async def generate_title(request: Request, body: GenerateTitleRequest):
         if not title or len(title) > 30:
             title = body.message[:20] or "新对话"
         if body.conversation_id:
-            await _broadcast_session_event(
-                "chat:title_update",
-                {
-                    "conversation_id": body.conversation_id,
-                    "title": title,
-                },
-            )
-        return {"title": title}
+            stored_title = session.get_metadata(_META_CONVERSATION_TITLE) if session else ""
+            if (
+                isinstance(stored_title, str)
+                and stored_title.strip()
+                and session
+                and session.get_metadata(_META_TITLE_MANUALLY_SET)
+            ):
+                logger.info(
+                    "[Sessions API] generated title skipped conversation_id=%s reason=manual_title title=%r",
+                    body.conversation_id,
+                    stored_title.strip(),
+                )
+                return {
+                    "title": stored_title.strip(),
+                    "titleGenerated": False,
+                    "titleManuallySet": True,
+                }
+            if session:
+                session.set_metadata(_META_CONVERSATION_TITLE, title)
+                session.set_metadata(_META_TITLE_MANUALLY_SET, False)
+                session.set_metadata(_META_TITLE_GENERATED, True)
+                if session_manager:
+                    session_manager.mark_dirty()
+                    try:
+                        session_manager.persist()
+                    except Exception as exc:
+                        logger.warning("[Sessions API] Failed to persist generated title: %s", exc)
+                summary = _session_list_item(session)
+                event_payload = {"conversation_id": body.conversation_id, **summary}
+                logger.info(
+                    "[Sessions API] generated title updated conversation_id=%s title=%r",
+                    body.conversation_id,
+                    title,
+                )
+                await _broadcast_session_event(
+                    "chat:title_update",
+                    event_payload,
+                )
+            else:
+                logger.info(
+                    "[Sessions API] generated title skipped conversation_id=%s reason=session_not_found",
+                    body.conversation_id,
+                )
+        return {"title": title, "titleGenerated": True, "titleManuallySet": False}
     except Exception as e:
         logger.warning(f"[Sessions] Title generation failed: {e}")
         return {"title": body.message[:20] or "新对话"}

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -303,18 +303,31 @@ def _find_web_dist() -> Path | None:
     """Locate the web frontend dist directory.
 
     Search order:
-    1. openakita/web/ (pip wheel install & PyInstaller bundle)
-    2. apps/setup-center/dist-web/ (development)
+    1. apps/setup-center/dist-web/ (development source checkout)
+    2. openakita/web/ (pip wheel install & PyInstaller bundle)
     """
     # Inside the installed package
     pkg_web = Path(__file__).parent.parent / "web"
-    if (pkg_web / "index.html").exists():
-        return pkg_web
 
     # Development: relative to project root
     dev_web = Path(__file__).parent.parent.parent.parent / "apps" / "setup-center" / "dist-web"
+
+    return _select_web_dist(pkg_web=pkg_web, dev_web=dev_web)
+
+
+def _select_web_dist(*, pkg_web: Path, dev_web: Path) -> Path | None:
+    """Choose the web frontend assets directory.
+
+    In editable/source checkouts both directories may exist: ``pkg_web`` holds
+    staged release assets, while ``dev_web`` is what ``npm run build:web``
+    updates. Prefer ``dev_web`` so local backend runs do not serve stale staged
+    assets after frontend changes.
+    """
     if (dev_web / "index.html").exists():
         return dev_web
+
+    if (pkg_web / "index.html").exists():
+        return pkg_web
 
     return None
 

--- a/tests/unit/test_sessions_history_route.py
+++ b/tests/unit/test_sessions_history_route.py
@@ -116,6 +116,7 @@ def test_session_list_returns_conversation_ui_state(tmp_path):
     session = manager.get_session("desktop", "conv1", "desktop_user")
     session.add_message("user", "hello")
     session.set_metadata("selected_endpoint", "deepseek")
+    session.set_metadata("pinned", True)
     session.set_metadata(
         "ui_org_state",
         {"orgMode": True, "orgId": "org_company", "orgNodeId": "pm"},
@@ -125,6 +126,7 @@ def test_session_list_returns_conversation_ui_state(tmp_path):
     body = TestClient(app).get("/api/sessions").json()
 
     assert body["sessions"][0]["endpointId"] == "deepseek"
+    assert body["sessions"][0]["pinned"] is True
     assert body["sessions"][0]["orgMode"] is True
     assert body["sessions"][0]["orgId"] == "org_company"
     assert body["sessions"][0]["orgNodeId"] == "pm"
@@ -173,3 +175,217 @@ def test_update_session_ui_state_does_not_create_empty_session(tmp_path):
     assert (
         manager.get_session("desktop", "missing", "desktop_user", create_if_missing=False) is None
     )
+
+
+def test_update_session_title_persists_and_list_prefers_manual_title(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    session = manager.get_session("desktop", "conv1", "desktop_user")
+    session.add_message("user", "first message fallback")
+    app.state.session_manager = manager
+
+    client = TestClient(app)
+    resp = client.patch(
+        "/api/sessions/conv1/title",
+        json={"title": "  Custom   Title  ", "titleManuallySet": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["title"] == "Custom Title"
+    assert body["titleGenerated"] is False
+    assert body["titleManuallySet"] is True
+    assert body["pinned"] is False
+    assert session.get_metadata("conversation_title") == "Custom Title"
+    assert session.get_metadata("title_manually_set") is True
+    assert session.get_metadata("title_generated") is False
+
+    body = client.get("/api/sessions").json()
+
+    assert body["sessions"][0]["title"] == "Custom Title"
+    assert body["sessions"][0]["titleManuallySet"] is True
+    assert body["sessions"][0]["titleGenerated"] is False
+
+    reloaded = SessionManager(storage_path=tmp_path)
+    persisted = reloaded.get_session("desktop", "conv1", "desktop_user", create_if_missing=False)
+    assert persisted is not None
+    assert persisted.get_metadata("conversation_title") == "Custom Title"
+
+
+def test_update_session_title_does_not_create_missing_session(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    app.state.session_manager = manager
+
+    resp = TestClient(app).patch(
+        "/api/sessions/missing/title",
+        json={"title": "Custom Title"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "reason": "session_not_found"}
+    assert (
+        manager.get_session("desktop", "missing", "desktop_user", create_if_missing=False) is None
+    )
+
+
+def test_create_session_persists_empty_conversation_as_list_item(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    app.state.session_manager = manager
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "conversationId": "draft1",
+            "title": "新对话",
+            "titleManuallySet": False,
+            "agentProfileId": "research",
+            "endpointId": "deepseek",
+            "endpointPolicy": "require",
+            "orgMode": True,
+            "orgId": "org_ops",
+            "orgNodeId": "pm",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["created"] is True
+    assert body["id"] == "draft1"
+    assert body["title"] == "新对话"
+    assert body["titleGenerated"] is False
+    assert body["titleManuallySet"] is False
+    assert body["pinned"] is False
+    assert body["messageCount"] == 0
+    assert body["lastMessage"] == ""
+    assert body["agentProfileId"] == "research"
+    assert body["endpointId"] == "deepseek"
+    assert body["endpointPolicy"] == "require"
+    assert body["orgMode"] is True
+    assert body["orgId"] == "org_ops"
+    assert body["orgNodeId"] == "pm"
+
+    listed = client.get("/api/sessions").json()["sessions"]
+    assert [s["id"] for s in listed] == ["draft1"]
+    assert listed[0]["messageCount"] == 0
+
+    session = manager.get_session("desktop", "draft1", "desktop_user", create_if_missing=False)
+    assert session is not None
+    assert session.context.agent_profile_id == "research"
+    assert session.get_metadata("conversation_title") == "新对话"
+    assert session.get_metadata("selected_endpoint") == "deepseek"
+    assert session.get_metadata("endpoint_policy") == "require"
+    assert session.get_metadata("ui_org_state") == {
+        "orgMode": True,
+        "orgId": "org_ops",
+        "orgNodeId": "pm",
+    }
+
+    reloaded = SessionManager(storage_path=tmp_path)
+    persisted = reloaded.get_session("desktop", "draft1", "desktop_user", create_if_missing=False)
+    assert persisted is not None
+    assert persisted.get_metadata("conversation_title") == "新对话"
+    assert persisted.context.agent_profile_id == "research"
+
+
+def test_update_session_title_does_not_create_missing_session_with_legacy_query(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    app.state.session_manager = manager
+
+    resp = TestClient(app).patch(
+        "/api/sessions/missing/title",
+        params={"create_if_missing": True},
+        json={"title": "Custom Title"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "reason": "session_not_found"}
+    assert (
+        manager.get_session("desktop", "missing", "desktop_user", create_if_missing=False) is None
+    )
+
+
+def test_update_session_pin_persists_and_list_returns_pinned(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    session = manager.get_session("desktop", "conv1", "desktop_user")
+    session.add_message("user", "hello")
+    session.set_metadata("conversation_title", "Pinned Title")
+    session.set_metadata("title_manually_set", True)
+    session.set_metadata("title_generated", False)
+    app.state.session_manager = manager
+
+    resp = TestClient(app).patch(
+        "/api/sessions/conv1/pin",
+        json={"pinned": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["pinned"] is True
+    assert body["title"] == "Pinned Title"
+    assert body["titleManuallySet"] is True
+    assert body["titleGenerated"] is False
+    assert session.get_metadata("pinned") is True
+    assert TestClient(app).get("/api/sessions").json()["sessions"][0]["pinned"] is True
+
+    reloaded = SessionManager(storage_path=tmp_path)
+    persisted = reloaded.get_session("desktop", "conv1", "desktop_user", create_if_missing=False)
+    assert persisted is not None
+    assert persisted.get_metadata("pinned") is True
+
+
+def test_update_session_pin_does_not_create_missing_session_by_default(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    app.state.session_manager = manager
+
+    resp = TestClient(app).patch(
+        "/api/sessions/missing/pin",
+        json={"pinned": True},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "reason": "session_not_found"}
+    assert (
+        manager.get_session("desktop", "missing", "desktop_user", create_if_missing=False) is None
+    )
+
+
+def test_generate_title_preserves_manual_session_title(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    session = manager.get_session("desktop", "conv1", "desktop_user")
+    session.add_message("user", "first message fallback")
+    session.set_metadata("conversation_title", "Manual Title")
+    session.set_metadata("title_manually_set", True)
+    session.set_metadata("title_generated", False)
+    app.state.session_manager = manager
+
+    resp = TestClient(app).post(
+        "/api/sessions/generate-title",
+        json={"message": "new prompt", "conversation_id": "conv1"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "title": "Manual Title",
+        "titleGenerated": False,
+        "titleManuallySet": True,
+    }
+    assert session.get_metadata("conversation_title") == "Manual Title"
+    assert session.get_metadata("title_manually_set") is True
+    assert session.get_metadata("title_generated") is False

--- a/tests/unit/test_web_dist_selection.py
+++ b/tests/unit/test_web_dist_selection.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openakita.api.server import _select_web_dist
+
+
+def _write_web_dist(path: Path) -> None:
+    path.mkdir(parents=True)
+    (path / "index.html").write_text("<html></html>", encoding="utf-8")
+
+
+def test_select_web_dist_prefers_development_build_when_both_exist(tmp_path: Path) -> None:
+    pkg_web = tmp_path / "src" / "openakita" / "web"
+    dev_web = tmp_path / "apps" / "setup-center" / "dist-web"
+    _write_web_dist(pkg_web)
+    _write_web_dist(dev_web)
+
+    assert _select_web_dist(pkg_web=pkg_web, dev_web=dev_web) == dev_web
+
+
+def test_select_web_dist_falls_back_to_package_assets(tmp_path: Path) -> None:
+    pkg_web = tmp_path / "src" / "openakita" / "web"
+    dev_web = tmp_path / "apps" / "setup-center" / "dist-web"
+    _write_web_dist(pkg_web)
+
+    assert _select_web_dist(pkg_web=pkg_web, dev_web=dev_web) == pkg_web
+
+
+def test_select_web_dist_returns_none_when_assets_are_missing(tmp_path: Path) -> None:
+    assert _select_web_dist(
+        pkg_web=tmp_path / "src" / "openakita" / "web",
+        dev_web=tmp_path / "apps" / "setup-center" / "dist-web",
+    ) is None


### PR DESCRIPTION
## Summary
- Add a first-class sessions API path for empty draft conversations so desktop and web can sync them before the first message.
- Persist manual/generated titles and pin state through session metadata, while keeping title/pin updates from implicitly creating sessions.
- Prefer the development web bundle in source checkouts so local web runs serve the freshly built UI.

## Tests
- `uv run --frozen --no-sync pytest tests/unit/test_sessions_history_route.py tests/unit/test_web_dist_selection.py`
- `uv run --frozen --no-sync ruff check src/openakita/api/routes/sessions.py src/openakita/api/server.py tests/unit/test_sessions_history_route.py tests/unit/test_web_dist_selection.py`
- `npm run build`
- `npm run build:web`