### PR TITLE
Reject unbacked action completion claims without tool calls

### DIFF
--- a/src/openakita/core/_reasoning_engine_legacy.py
+++ b/src/openakita/core/_reasoning_engine_legacy.py
@@ -601,6 +601,9 @@ from openakita.runtime.state_graph.guards.conversation_state import (
 from openakita.runtime.state_graph.guards.conversation_state import (
     looks_like_waiting_for_user_response as _looks_like_waiting_for_user_response,
 )
+from openakita.runtime.state_graph.guards.recap_context import (  # noqa: E402
+    RECAP_NEAR_RE as _RECAP_NEAR_RE,
+)
 
 # Extracted to runtime/state_graph/guards/recap_context.py (P-RC-5 P5.4);
 # re-exported here under the legacy private name for backward compat.
@@ -678,6 +681,12 @@ _INLINE_TOOL_CALL_RE = re.compile(
     r"\b((?:" + "|".join(re.escape(p) for p in _TEXT_TOOL_CALL_PATTERNS) + r")[a-z0-9_]+)\s*\(",
 )
 
+_TEXTUAL_TOOL_EXECUTION_CLAIM_RE = re.compile(
+    r"(?:调用|执行)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\([^)]{0,600}\)"
+    r"\s*(?:\.{3}|…|，|,|\s)*(?:完成|成功|已完成)",
+    re.IGNORECASE,
+)
+
 
 def _detect_text_toolcall_block(text: str) -> list[str]:
     """返回以纯文本伪调用形式出现的工具名（去重、排序）。
@@ -724,6 +733,43 @@ def _guard_text_toolcall_block(
     if intent == "REPLY":
         return []
     return _detect_text_toolcall_block(text or "")
+
+
+def _looks_like_no_tool_completion_claim(
+    text: str,
+    action_claim_re: re.Pattern[str],
+) -> bool:
+    """Detect final-answer text that claims an external action already ran."""
+    if not text:
+        return False
+
+    def _is_recap_match(match: re.Match[str]) -> bool:
+        half = 48
+        start = max(0, match.start() - half)
+        end = min(len(text), match.end() + half)
+        return bool(_RECAP_NEAR_RE.search(text[start:end]))
+
+    def _is_negated_mention(match: re.Match[str]) -> bool:
+        before = text[max(0, match.start() - 18) : match.start()]
+        return bool(
+            re.search(
+                r"(?:并?不(?:是|代表|应|该|要|允许|能)?|不能|不应|不要|"
+                r"没有|未|并非|而非|非(?:声称|表示)?|避免(?:说|写|使用)?)"
+                r"[`\"'“”‘’\s：:，,。；;、-]{0,8}$",
+                before,
+            )
+        )
+
+    patterns = (
+        action_claim_re,
+        _get_action_done_re(),
+        _TEXTUAL_TOOL_EXECUTION_CLAIM_RE,
+    )
+    return any(
+        not _is_recap_match(match) and not _is_negated_mention(match)
+        for pattern in patterns
+        for match in pattern.finditer(text)
+    )
 
 
 class ReasoningEngine:
@@ -7961,11 +8007,19 @@ class ReasoningEngine:
                 max_no_tool_retries,
             )
 
+        _ACTION_CLAIM_RE = _get_action_claim_re()
+        _txt = (stripped_text or "").strip()
+        _has_no_tool_completion_claim = _looks_like_no_tool_completion_claim(
+            _txt,
+            _ACTION_CLAIM_RE,
+        )
+
         if (
             intent == "REPLY"
             and stripped_text
             and len(stripped_text.strip()) > 10
             and not tool_evidence_required
+            and not _has_no_tool_completion_claim
         ):
             logger.info(
                 "[IntentTag] REPLY intent with substantial text, "
@@ -7978,8 +8032,6 @@ class ReasoningEngine:
         # look like an action-claim hallucination (e.g. "已帮你保存/删除/发送…"
         # without any actual tool calls). This keeps tools available without
         # forcing them into pure explanation or creative-writing turns.
-        _ACTION_CLAIM_RE = _get_action_claim_re()
-        _txt = (stripped_text or "").strip()
 
         # P1 修复：拦截「伪 tool_call 文本块」。LLM 偶尔会把工具调用写成
         # ```tool_call\norg_accept_deliverable(...)\n``` 这样的 Markdown 文本，
@@ -8024,10 +8076,67 @@ class ReasoningEngine:
                 max_no_tool_retries,
             )
 
+        has_todo_pending = self._has_active_todo_pending(conversation_id)
+        should_force_no_tool_action = intent == "ACTION" or (
+            _has_no_tool_completion_claim
+            and (max_no_tool_retries > 0 or tool_evidence_required or has_todo_pending)
+        )
+        if should_force_no_tool_action:
+            effective_max_no_tool_retries = max_no_tool_retries
+            if has_todo_pending and effective_max_no_tool_retries < 1:
+                effective_max_no_tool_retries = 1
+
+            no_tool_call_count += 1
+            if no_tool_call_count <= effective_max_no_tool_retries:
+                reason = (
+                    "ACTION intent declared"
+                    if intent == "ACTION"
+                    else "action-completion claim emitted"
+                )
+                logger.warning(
+                    "[IntentTag] %s but no tool calls — forcing retry (%s/%s)",
+                    reason,
+                    no_tool_call_count,
+                    effective_max_no_tool_retries,
+                )
+                if stripped_text:
+                    working_messages.append(
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": stripped_text}],
+                            "reasoning_content": decision.thinking_content or None,
+                        }
+                    )
+                retry_msg = (
+                    "[系统] ⚠️ 你刚才声称已经执行/完成了外部操作，"
+                    "但本轮没有真正发起任何工具调用（tool_calls=0）。"
+                    "文字里的“调用 run_shell(... )...完成”或“已删除/已验证”不会被执行。\n"
+                    "请立即发起真实 tool_calls 完成用户请求；如果不需要执行工具，"
+                    "请明确说明这是历史回顾或建议，不要使用完成态措辞。"
+                )
+                working_messages.append({"role": "user", "content": retry_msg})
+                return (
+                    working_messages,
+                    no_tool_call_count,
+                    verify_incomplete_count,
+                    no_confirmation_text_count,
+                    effective_max_no_tool_retries,
+                )
+
+            logger.warning(
+                "[IntentTag] No-tool action claim retry budget exhausted — "
+                "returning non-deceptive failure instead of original text"
+            )
+            return (
+                "⚠️ 本轮没有检测到任何真实工具调用，因此我不能确认外部操作已经完成。"
+                "上一次回复中的完成态描述没有工具凭证支持，未作为执行结果采信。"
+                "请重新发送指令，或允许我调用对应工具后再继续。"
+            )
+
         if (
             intent is None
             and _txt
-            and not _ACTION_CLAIM_RE.search(_txt)
+            and not _has_no_tool_completion_claim
             and not tool_evidence_required
         ):
             logger.info(
@@ -8042,68 +8151,29 @@ class ReasoningEngine:
         # 旧逻辑：4 种触发条件（evidence_required / ACTION / REPLY 短文本 / 无 intent）
         #         全都走 ForceToolCall 重试，导致大量 token 浪费 + text_replace 抖动 +
         #         OrgRuntime 误判 task_failed。
-        # 新逻辑：只对"真幻觉"（LLM 显式声明 [ACTION] 意图但 tool_calls=0）做重试。
-        #         其他三种条件全部降级为 log-only，把 LLM 输出原样返回，由阶段 0 的
-        #         disclaimer 路径 + 阶段 3 的 _check_source_tag_consistency() 后置检测
-        #         给出柔性提示。
+        # 新逻辑：对显式 [ACTION] 或动作完成声明（含文本化工具执行轨迹）做重试。
+        #         其他条件仍降级为 log-only，由阶段 0 disclaimer + 阶段 3
+        #         _check_source_tag_consistency() 后置检测给出柔性提示。
         # ----------------------------------------------------------------
 
-        # 真幻觉：ACTION 意图被显式声明 + tool_calls=0 → 重试
-        if intent == "ACTION":
-            no_tool_call_count += 1
-            if no_tool_call_count <= max_no_tool_retries:
-                logger.warning(
-                    "[IntentTag] ACTION intent declared but no tool calls — "
-                    "true hallucination, forcing retry "
-                    f"({no_tool_call_count}/{max_no_tool_retries})"
-                )
-                if stripped_text:
-                    working_messages.append(
-                        {
-                            "role": "assistant",
-                            "content": [{"type": "text", "text": stripped_text}],
-                            "reasoning_content": decision.thinking_content or None,
-                        }
-                    )
-                retry_msg = (
-                    "[系统] ⚠️ 你声明了 [ACTION] 意图但没有调用任何工具。"
-                    "请立即调用所需的工具来完成用户请求，不要只描述你会做什么。"
-                )
-                working_messages.append({"role": "user", "content": retry_msg})
-                return (
-                    working_messages,
-                    no_tool_call_count,
-                    verify_incomplete_count,
-                    no_confirmation_text_count,
-                    max_no_tool_retries,
-                )
-            # ACTION 重试用尽 → fall-through 到下方 disclaimer 路径
-            logger.warning(
-                "[IntentTag] ACTION retry budget exhausted, falling through to disclaimer path"
+        # No hard-action claim remained. Other no-tool cases stay on the soft
+        # source-disclaimer path to avoid reintroducing organization deadlocks.
+        if tool_evidence_required:
+            logger.info(
+                "[ToolEvidence] No tool calls but evidence recommended — "
+                "softly noted, not retrying (relying on 阶段 3 source-tag check)"
+            )
+        elif intent == "REPLY":
+            logger.info(
+                f"[IntentTag] REPLY intent with short text "
+                f"({len(stripped_text or '')} chars), "
+                f"tool_calls=0 — accepting as-is"
             )
         else:
-            # 三种"非真幻觉"情况：log-only 软提示，不重试，让原文返回
-            if tool_evidence_required:
-                logger.info(
-                    "[ToolEvidence] No tool calls but evidence recommended — "
-                    "softly noted, not retrying (relying on 阶段 3 source-tag check)"
-                )
-            elif intent == "REPLY":
-                logger.info(
-                    f"[IntentTag] REPLY intent with short text "
-                    f"({len(stripped_text or '')} chars), "
-                    f"tool_calls=0 — accepting as-is"
-                )
-            elif intent is None and _ACTION_CLAIM_RE.search(_txt or ""):
-                logger.info(
-                    "[IntentTag] No intent + action-claim text + tool_calls=0 — "
-                    "accepting (post-check will warn if claims are unbacked)"
-                )
-            else:
-                logger.info(
-                    f"[IntentTag] Edge case (intent={intent or 'NONE'}, "
-                    f"text_len={len(stripped_text or '')}) — accepting as-is"
-                )
+            logger.info(
+                f"[IntentTag] Edge case (intent={intent or 'NONE'}, "
+                f"text_len={len(stripped_text or '')}) — accepting as-is"
+            )
 
         # 追问次数用尽。
         # P0-2 阶段 0（修正版）：不再硬替换 LLM 文本、不再设 _last_exit_reason="tool_evidence_missing"

--- a/src/openakita/runtime/state_graph/guards/unbacked_action.py
+++ b/src/openakita/runtime/state_graph/guards/unbacked_action.py
@@ -79,6 +79,18 @@ VERB_TO_EFFECT_ACTIONS: dict[str, tuple[str, ...]] = {
 _TOOL_LIKE_IDENTIFIER = r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b"
 
 
+def _is_negated_action_mention(text: str, start: int) -> bool:
+    before = text[max(0, start - 18) : start]
+    return bool(
+        re.search(
+            r"(?:并?不(?:是|代表|应|该|要|允许|能)?|不能|不应|不要|"
+            r"没有|未|并非|而非|非(?:声称|表示)?|避免(?:说|写|使用)?)"
+            r"[`\"'“”‘’\s：:，,。；;、-]{0,8}$",
+            before,
+        )
+    )
+
+
 def action_claim_re() -> re.Pattern[str]:
     """Compiled regex that detects Chinese action-claim phrases.
 
@@ -129,6 +141,8 @@ def claimed_tool_names(text: str) -> list[str]:
     names: list[str] = []
     for pat in patterns:
         for match in pat.finditer(text):
+            if _is_negated_action_mention(text, match.start()):
+                continue
             name = str(match.group(1) or "").lower()
             if name and name not in names:
                 names.append(name)
@@ -143,6 +157,7 @@ def extract_unbacked_verbs(
 ) -> list[str]:
     """Return action verbs whose claim is not backed by any successful tool call."""
     prefix_pat = re.compile(r"(?:已[经]?|成功|顺利|我已经|我已)(?:帮你?|为你|给你)?")
+    successful_tools_lower = {t.lower() for t in successful_tools}
     effect_actions = set(successful_actions or successful_tool_effect_actions(tool_results))
     unbacked: list[str] = []
 
@@ -155,9 +170,17 @@ def extract_unbacked_verbs(
 
     for verb, actions in VERB_TO_EFFECT_ACTIONS.items():
         verb_pat = re.compile(rf"{prefix_pat.pattern}{re.escape(verb)}")
-        if not verb_pat.search(text):
+        match = verb_pat.search(text)
+        if not match:
             continue
-        if set(actions) & effect_actions:
+        if _is_negated_action_mention(text, match.start()):
+            continue
+        fragments = VERB_TO_TOOL_FRAGMENTS.get(verb, ())
+        backed_by_action = bool(set(actions) & effect_actions)
+        backed_by_tool_name = any(
+            any(frag in t for frag in fragments) for t in successful_tools_lower
+        )
+        if backed_by_action or backed_by_tool_name:
             continue
         if is_recap_context(text, verb):
             continue
@@ -176,9 +199,18 @@ def extract_unbacked_verbs(
                 rf"{re.escape(tool_name)}",
                 re.IGNORECASE,
             )
-            if not (tool_claim_pat.search(text) or reverse_claim_pat.search(text)):
+            tool_claim_match = tool_claim_pat.search(text)
+            reverse_claim_match = reverse_claim_pat.search(text)
+            if not (tool_claim_match or reverse_claim_match):
                 continue
-            if any(any(frag in t for frag in fragments) for t in successful_tools):
+            if (
+                tool_claim_match and _is_negated_action_mention(text, tool_claim_match.start())
+            ) or (
+                reverse_claim_match
+                and _is_negated_action_mention(text, reverse_claim_match.start())
+            ):
+                continue
+            if any(any(frag in t for frag in fragments) for t in successful_tools_lower):
                 continue
             if is_recap_context(text, tool_name):
                 continue
@@ -188,9 +220,12 @@ def extract_unbacked_verbs(
             if verb in unbacked:
                 continue
             verb_pat = re.compile(rf"{prefix_pat.pattern}{re.escape(verb)}")
-            if not verb_pat.search(text):
+            match = verb_pat.search(text)
+            if not match:
                 continue
-            if any(any(frag in t for frag in fragments) for t in successful_tools):
+            if _is_negated_action_mention(text, match.start()):
+                continue
+            if any(any(frag in t for frag in fragments) for t in successful_tools_lower):
                 continue
             if is_recap_context(text, verb):
                 continue
@@ -231,6 +266,8 @@ def guard_unbacked_action_claim(
             successful_actions=set(),
             tool_results=tool_results,
         )
+        if not unbacked:
+            return text
         verbs_str = "/".join(unbacked[:3]) if unbacked else "外部动作"
         memory_hint = (
             "当前没有检测到长期记忆写入凭证，所以请勿据此认定已写入长期记忆。"
@@ -263,5 +300,3 @@ def guard_unbacked_action_claim(
         "如需重试请明确告知。"
     )
     return text.rstrip() + warning
-
-

--- a/tests/runtime/state_graph/guards/test_unbacked_action.py
+++ b/tests/runtime/state_graph/guards/test_unbacked_action.py
@@ -1,4 +1,4 @@
-﻿"""Tests for runtime/state_graph/guards/unbacked_action."""
+"""Tests for runtime/state_graph/guards/unbacked_action."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ def _legacy():
         _extract_unbacked_verbs,
         _guard_unbacked_action_claim,
     )
+
     return _extract_unbacked_verbs, _guard_unbacked_action_claim
 
 
@@ -48,6 +49,11 @@ def test_extract_passes_when_recap_window() -> None:
     assert "\u4fdd\u5b58" not in extract_unbacked_verbs(text, set())
 
 
+def test_extract_ignores_negated_quoted_action_phrase() -> None:
+    text = '报告如实说明了"无需删除，路径不存在"，而非声称"已删除"。'
+    assert extract_unbacked_verbs(text, set()) == []
+
+
 def test_extract_flags_claim_without_backing_tool() -> None:
     text = "\u5df2\u4fdd\u5b58\u4e86"  # "already saved"
     unbacked = extract_unbacked_verbs(text, set())
@@ -75,6 +81,11 @@ def test_guard_appends_banner_when_no_tools_at_all() -> None:
 
 def test_guard_returns_text_unchanged_when_recap_only() -> None:
     text = "[17:30] \u4e4b\u524d\u5df2\u4fdd\u5b58\u4e86"
+    assert guard_unbacked_action_claim(text, []) == text
+
+
+def test_guard_returns_text_unchanged_for_negated_action_mention() -> None:
+    text = '报告如实说明了"无需删除，路径不存在"，而非声称"已删除"。'
     assert guard_unbacked_action_claim(text, []) == text
 
 
@@ -120,7 +131,11 @@ def test_guard_silent_when_update_backed_by_profile_tool() -> None:
         ("", [], None),
         ("hello", [], None),
         ("\u5df2\u4fdd\u5b58\u4e86", [], None),
-        ("\u5df2\u5220\u9664\u4e86", ["get_tool_info"], [{"tool_name": "get_tool_info", "is_error": False}]),
+        (
+            "\u5df2\u5220\u9664\u4e86",
+            ["get_tool_info"],
+            [{"tool_name": "get_tool_info", "is_error": False}],
+        ),
         ("\u4e4b\u524d\u5df2\u4fdd\u5b58", [], None),
     ],
 )

--- a/tests/unit/test_action_claim_recap_guard.py
+++ b/tests/unit/test_action_claim_recap_guard.py
@@ -8,7 +8,11 @@ claim is anchored by a timestamp (`[17:30]`) or an explicit recap adverb
 (之前 / 刚才 / 历史 / 上文 / 上次 / 先前 / 此前 / ...).
 """
 
-from openakita.core._reasoning_engine_legacy import _extract_unbacked_verbs, _guard_unbacked_action_claim, _is_recap_context
+from openakita.core._reasoning_engine_legacy import (
+    _extract_unbacked_verbs,
+    _guard_unbacked_action_claim,
+    _is_recap_context,
+)
 
 
 def test_recap_with_timestamp_is_detected():

--- a/tests/unit/test_reasoning_engine_user_handoff.py
+++ b/tests/unit/test_reasoning_engine_user_handoff.py
@@ -6,9 +6,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from openakita.core.agent_state import AgentState
 from openakita.agent.reasoning import Decision, DecisionType, ReasoningEngine
 from openakita.core._reasoning_engine_legacy import _looks_like_waiting_for_user_response
+from openakita.core.agent_state import AgentState
 
 
 def test_detects_user_handoff_blocker_text():
@@ -320,6 +320,205 @@ async def test_plain_short_analysis_without_tools_is_accepted():
 
     assert result == reply
     assert working_messages == []
+
+
+@pytest.mark.asyncio
+async def test_historical_action_recap_without_tools_is_still_accepted():
+    """Recapping earlier tool work must not be treated as a fresh no-tool claim."""
+    engine = ReasoningEngine(
+        brain=None,
+        tool_executor=None,
+        context_manager=None,
+        response_handler=AsyncMock(),
+        agent_state=AgentState(),
+    )
+    working_messages: list[dict] = []
+    reply = (
+        "根据对话历史：\n"
+        "- [17:26] 我已为你保存了项目代号 SEAGULL\n"
+        "- 刚才已读取配置文件并汇总了结果\n"
+    )
+
+    result = await engine._handle_final_answer(
+        decision=Decision(type=DecisionType.FINAL_ANSWER, text_content=reply),
+        working_messages=working_messages,
+        original_messages=[{"role": "user", "content": "复述一下刚才做了什么"}],
+        tools_executed_in_task=False,
+        executed_tool_names=[],
+        delivery_receipts=[],
+        all_tool_results=[],
+        no_tool_call_count=0,
+        verify_incomplete_count=0,
+        no_confirmation_text_count=0,
+        max_no_tool_retries=2,
+        max_verify_retries=1,
+        max_confirmation_text_retries=1,
+        base_force_retries=2,
+        conversation_id="recap-no-tool",
+        tool_evidence_required=False,
+    )
+
+    assert result == reply.rstrip()
+    assert working_messages == []
+
+
+@pytest.mark.asyncio
+async def test_negated_action_phrase_without_tools_is_not_forced_retry():
+    """Quoted negation like "not '已删除'" is not a completion claim."""
+    engine = ReasoningEngine(
+        brain=None,
+        tool_executor=None,
+        context_manager=None,
+        response_handler=AsyncMock(),
+        agent_state=AgentState(),
+    )
+    working_messages: list[dict] = []
+    reply = (
+        "根据本会话历史：目标路径不存在。"
+        "报告如实说明了“无需删除，路径不存在”，而非声称“已删除”。[来源:历史]"
+    )
+
+    result = await engine._handle_final_answer(
+        decision=Decision(type=DecisionType.FINAL_ANSWER, text_content=reply),
+        working_messages=working_messages,
+        original_messages=[{"role": "user", "content": "复述一下刚才做了什么，不要执行工具"}],
+        tools_executed_in_task=False,
+        executed_tool_names=[],
+        delivery_receipts=[],
+        all_tool_results=[],
+        no_tool_call_count=0,
+        verify_incomplete_count=0,
+        no_confirmation_text_count=0,
+        max_no_tool_retries=1,
+        max_verify_retries=1,
+        max_confirmation_text_retries=1,
+        base_force_retries=1,
+        conversation_id="negated-action-mention",
+        tool_evidence_required=False,
+    )
+
+    assert result == reply
+    assert working_messages == []
+
+
+@pytest.mark.asyncio
+async def test_action_completion_claim_without_tools_forces_retry():
+    """Issue #702: action tasks must not accept "已删除/已验证" text with tool_calls=0."""
+    engine = ReasoningEngine(
+        brain=None,
+        tool_executor=None,
+        context_manager=None,
+        response_handler=AsyncMock(),
+        agent_state=AgentState(),
+    )
+    working_messages: list[dict] = []
+    reply = (
+        "# 卸载完成报告\n"
+        "| 路径 | 状态 |\n"
+        "| D:\\Boaosoft\\CellCtrl | ✅ 已删 |\n"
+        "[来源:工具] 全部 7 个真实 PowerShell 命令已通过独立验证。"
+    )
+
+    result = await engine._handle_final_answer(
+        decision=Decision(type=DecisionType.FINAL_ANSWER, text_content=reply),
+        working_messages=working_messages,
+        original_messages=[{"role": "user", "content": "请全部删除这个软件"}],
+        tools_executed_in_task=False,
+        executed_tool_names=[],
+        delivery_receipts=[],
+        all_tool_results=[],
+        no_tool_call_count=0,
+        verify_incomplete_count=0,
+        no_confirmation_text_count=0,
+        max_no_tool_retries=2,
+        max_verify_retries=1,
+        max_confirmation_text_retries=1,
+        base_force_retries=2,
+        conversation_id="issue-702",
+        tool_evidence_required=False,
+    )
+
+    assert isinstance(result, tuple)
+    assert result[1] == 1
+    assert working_messages[-1]["role"] == "user"
+    assert "tool_calls=0" in working_messages[-1]["content"]
+    assert "真实 tool_calls" in working_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_textual_tool_execution_claim_without_tools_forces_retry():
+    """Text like "调用 run_shell(...)...完成" is not a real tool call."""
+    engine = ReasoningEngine(
+        brain=None,
+        tool_executor=None,
+        context_manager=None,
+        response_handler=AsyncMock(),
+        agent_state=AgentState(),
+    )
+    working_messages: list[dict] = []
+    reply = (
+        "调用 get_todo_status()...完成 (897 字符)"
+        "调用 run_shell(command, description, block_timeout_ms)...完成 (3849 字符)\n"
+        "任务计划窗口已关闭。"
+    )
+
+    result = await engine._handle_final_answer(
+        decision=Decision(type=DecisionType.FINAL_ANSWER, text_content=reply),
+        working_messages=working_messages,
+        original_messages=[{"role": "user", "content": "请关闭这个任务计划窗口"}],
+        tools_executed_in_task=False,
+        executed_tool_names=[],
+        delivery_receipts=[],
+        all_tool_results=[],
+        no_tool_call_count=0,
+        verify_incomplete_count=0,
+        no_confirmation_text_count=0,
+        max_no_tool_retries=2,
+        max_verify_retries=1,
+        max_confirmation_text_retries=1,
+        base_force_retries=2,
+        conversation_id="issue-702-textual",
+        tool_evidence_required=False,
+    )
+
+    assert isinstance(result, tuple)
+    assert "文字里的“调用 run_shell" in working_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_action_completion_claim_without_tools_blocks_after_retry_budget():
+    """After retry budget is exhausted, do not return the deceptive original text."""
+    engine = ReasoningEngine(
+        brain=None,
+        tool_executor=None,
+        context_manager=None,
+        response_handler=AsyncMock(),
+        agent_state=AgentState(),
+    )
+    reply = "D:\\Boaosoft 已删除，注册表已清理。[来源:工具]"
+
+    result = await engine._handle_final_answer(
+        decision=Decision(type=DecisionType.FINAL_ANSWER, text_content=reply),
+        working_messages=[],
+        original_messages=[{"role": "user", "content": "请全部删除这个软件"}],
+        tools_executed_in_task=False,
+        executed_tool_names=[],
+        delivery_receipts=[],
+        all_tool_results=[],
+        no_tool_call_count=1,
+        verify_incomplete_count=0,
+        no_confirmation_text_count=0,
+        max_no_tool_retries=1,
+        max_verify_retries=1,
+        max_confirmation_text_retries=1,
+        base_force_retries=1,
+        conversation_id="issue-702-budget",
+        tool_evidence_required=False,
+    )
+
+    assert isinstance(result, str)
+    assert "没有检测到任何真实工具调用" in result
+    assert "D:\\Boaosoft 已删除" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reject no-tool final answers that claim completed external actions or textual tool executions.
- Preserve historical recaps and negated quoted action phrases while keeping unbacked-action guards aligned with real tool evidence.

## Tests
- `uv run --no-project --with pytest pytest tests/unit/test_reasoning_engine_user_handoff.py -q`
- `uv run --no-project --with pytest pytest tests/runtime/state_graph/guards/test_unbacked_action.py tests/unit/test_action_claim_recap_guard.py tests/runtime/state_graph/guards/test_recap_context.py tests/runtime/state_graph/guards/test_verb_tool_map.py -q`
- `uv run --no-project --with ruff ruff check src/openakita/core/_reasoning_engine_legacy.py src/openakita/runtime/state_graph/guards/unbacked_action.py tests/unit/test_reasoning_engine_user_handoff.py tests/runtime/state_graph/guards/test_unbacked_action.py tests/unit/test_action_claim_recap_guard.py`
- `uv run --no-project --with ruff ruff format --check src/openakita/core/_reasoning_engine_legacy.py src/openakita/runtime/state_graph/guards/unbacked_action.py tests/unit/test_reasoning_engine_user_handoff.py tests/runtime/state_graph/guards/test_unbacked_action.py tests/unit/test_action_claim_recap_guard.py`

Fixes #701 #702