### PR TITLE
fix release desktop builds to generate updater signatures for Linux artifacts

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -73,10 +73,10 @@ jobs:
           # 与 mac-x64 / linux-arm64，发版前必须切回 full 才能信任。
           FULL='{"include":[
             {"platform":"windows-latest","bundles":"nsis","suffix":"windows-x64","target_platform":"win-x64"},
-            {"platform":"ubuntu-22.04","bundles":"deb","suffix":"ubuntu22-amd64","target_platform":"linux-x64"},
-            {"platform":"ubuntu-22.04-arm","bundles":"deb","suffix":"ubuntu22-arm64","target_platform":"linux-arm64"},
-            {"platform":"ubuntu-24.04","bundles":"deb","suffix":"ubuntu24-amd64","target_platform":"linux-x64"},
-            {"platform":"ubuntu-24.04-arm","bundles":"deb","suffix":"ubuntu24-arm64","target_platform":"linux-arm64"},
+            {"platform":"ubuntu-22.04","bundles":"deb,appimage","suffix":"ubuntu22-amd64","target_platform":"linux-x64"},
+            {"platform":"ubuntu-22.04-arm","bundles":"deb,appimage","suffix":"ubuntu22-arm64","target_platform":"linux-arm64"},
+            {"platform":"ubuntu-24.04","bundles":"deb,appimage","suffix":"ubuntu24-amd64","target_platform":"linux-x64"},
+            {"platform":"ubuntu-24.04-arm","bundles":"deb,appimage","suffix":"ubuntu24-arm64","target_platform":"linux-arm64"},
             {"platform":"macos-latest","bundles":"app","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin","suffix":"macos-arm64","target_platform":"mac-arm64"},
             {"platform":"macos-15-intel","bundles":"app","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin","suffix":"macos-x64","target_platform":"mac-x64"}
           ]}'
@@ -86,7 +86,7 @@ jobs:
           # full rationale.
           SMOKE='{"include":[
             {"platform":"windows-latest","bundles":"nsis","suffix":"windows-x64","target_platform":"win-x64"},
-            {"platform":"ubuntu-24.04","bundles":"deb","suffix":"ubuntu24-amd64","target_platform":"linux-x64"},
+            {"platform":"ubuntu-24.04","bundles":"deb,appimage","suffix":"ubuntu24-amd64","target_platform":"linux-x64"},
             {"platform":"macos-latest","bundles":"app","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin","suffix":"macos-arm64","target_platform":"mac-arm64"}
           ]}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,23 +215,23 @@ jobs:
             target_platform: "win-x64"
           # Linux Ubuntu 22.04
           - platform: ubuntu-22.04
-            bundles: "deb"
+            bundles: "deb,appimage"
             args: ""
             suffix: "ubuntu22-amd64"
             target_platform: "linux-x64"
           - platform: ubuntu-22.04-arm
-            bundles: "deb"
+            bundles: "deb,appimage"
             args: ""
             suffix: "ubuntu22-arm64"
             target_platform: "linux-arm64"
           # Linux Ubuntu 24.04
           - platform: ubuntu-24.04
-            bundles: "deb"
+            bundles: "deb,appimage"
             args: ""
             suffix: "ubuntu24-amd64"
             target_platform: "linux-x64"
           - platform: ubuntu-24.04-arm
-            bundles: "deb"
+            bundles: "deb,appimage"
             args: ""
             suffix: "ubuntu24-arm64"
             target_platform: "linux-arm64"

--- a/apps/setup-center/src-tauri/tauri.conf.json
+++ b/apps/setup-center/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
       "resources/openakita-server/",
       "resources/bootstrap/"
     ],
+    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "Entitlements.plist",
       "signingIdentity": "-",


### PR DESCRIPTION
## Summary
- Re-enable Tauri updater artifact creation so release builds generate updater signatures.
- Build Linux AppImage bundles alongside deb packages in release and dryrun workflows so updater signatures are available for validation.

## Tests
- `git diff --check -- .github/workflows/release-dryrun.yml .github/workflows/release.yml apps/setup-center/src-tauri/tauri.conf.json`
- `uv run --no-sync python -c "import pathlib, yaml; [yaml.safe_load(pathlib.Path(p).read_text(encoding='utf-8')) for p in ['.github/workflows/release.yml', '.github/workflows/release-dryrun.yml']]; print('workflow YAML OK')"`
- `node -e "JSON.parse(require('fs').readFileSync('apps/setup-center/src-tauri/tauri.conf.json','utf8')); console.log('tauri.conf.json OK')"`