### PR TITLE
fix todo history replay so closed plan cards do not revive after reload

### DIFF
--- a/apps/setup-center/src/types.ts
+++ b/apps/setup-center/src/types.ts
@@ -429,13 +429,14 @@ export type ChatProgressEvent =
   | {
       type: "todo_step_updated";
       seq?: number;
+      planId?: string;
       stepId?: string;
       stepIdx?: number;
       status?: ChatTodoStep["status"];
       result?: string | null;
     }
-  | { type: "todo_completed"; seq?: number }
-  | { type: "todo_cancelled"; seq?: number };
+  | { type: "todo_completed"; seq?: number; planId?: string }
+  | { type: "todo_cancelled"; seq?: number; planId?: string };
 
 export type PlanApprovalEvent = {
   conversation_id: string;

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -3236,6 +3236,40 @@ export function ChatView({
       };
       let currentPlan: ChatTodo | null = null;
       let currentProgressEvents: ChatProgressEvent[] = [];
+      const isActiveTodo = (todo?: ChatTodo | null) =>
+        !!todo && todo.status !== "completed" && todo.status !== "failed" && todo.status !== "cancelled";
+      const terminalizeTodo = (todo: ChatTodo, status: Extract<ChatTodo["status"], "completed" | "cancelled">): ChatTodo => {
+        const stepStatus = status === "cancelled" ? "cancelled" : "completed";
+        return {
+          ...todo,
+          status,
+          steps: todo.steps.map((step) =>
+            step.status === "pending" || step.status === "in_progress"
+              ? { ...step, status: stepStatus }
+              : step
+          ),
+        };
+      };
+      const eventPlanId = (event: { planId?: string; plan_id?: string }) => event.planId || event.plan_id || "";
+      const finalizeExistingTodo = (
+        status: Extract<ChatTodo["status"], "completed" | "cancelled">,
+        planId?: string,
+      ) => {
+        updateMessages((prev) => {
+          let targetIndex = -1;
+          for (let i = prev.length - 1; i >= 0; i -= 1) {
+            const todo = prev[i].todo;
+            if (!isActiveTodo(todo)) continue;
+            if (planId && todo!.id !== planId) continue;
+            targetIndex = i;
+            break;
+          }
+          if (targetIndex < 0) return prev;
+          return prev.map((m, i) =>
+            i === targetIndex && m.todo ? { ...m, todo: terminalizeTodo(m.todo, status) } : m
+          );
+        });
+      };
       let currentAsk: ChatAskUser | null = null;
       let currentAgent: string | null = null;
       let currentArtifacts: ChatArtifact[] = [];
@@ -3880,11 +3914,13 @@ export function ChatView({
               case "todo_step_updated":
                 if (currentPlan) {
                   const stepId = event.step_id || event.stepId;
+                  const planId = eventPlanId(event);
                   currentProgressEvents = [
                     ...currentProgressEvents,
                     {
                       type: "todo_step_updated",
                       seq: currentProgressEvents.length + 1,
+                      ...(planId ? { planId } : {}),
                       ...(stepId ? { stepId } : {}),
                       ...(event.stepIdx != null ? { stepIdx: event.stepIdx } : {}),
                       status: event.status as ChatTodoStep["status"],
@@ -3907,27 +3943,49 @@ export function ChatView({
                 }
                 break;
               case "todo_completed":
-                if (currentPlan) {
-                  currentProgressEvents = [
-                    ...currentProgressEvents,
-                    { type: "todo_completed", seq: currentProgressEvents.length + 1 },
-                  ];
-                  currentPlan = { ...currentPlan, status: "completed" } as ChatTodo;
-                  updateMessages((prev) => prev.map((m) =>
-                    m.id === assistantMsg.id ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] } : m
-                  ));
+                {
+                  const planId = eventPlanId(event);
+                  if (currentPlan) {
+                    currentProgressEvents = [
+                      ...currentProgressEvents,
+                      {
+                        type: "todo_completed",
+                        seq: currentProgressEvents.length + 1,
+                        ...(planId ? { planId } : {}),
+                      },
+                    ];
+                    currentPlan = { ...currentPlan, status: "completed" } as ChatTodo;
+                    updateMessages((prev) => prev.map((m) =>
+                      m.id === assistantMsg.id
+                        ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] }
+                        : m
+                    ));
+                  } else {
+                    finalizeExistingTodo("completed", planId);
+                  }
                 }
                 break;
               case "todo_cancelled":
-                if (currentPlan) {
-                  currentProgressEvents = [
-                    ...currentProgressEvents,
-                    { type: "todo_cancelled", seq: currentProgressEvents.length + 1 },
-                  ];
-                  currentPlan = { ...currentPlan, status: "cancelled" } as ChatTodo;
-                  updateMessages((prev) => prev.map((m) =>
-                    m.id === assistantMsg.id ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] } : m
-                  ));
+                {
+                  const planId = eventPlanId(event);
+                  if (currentPlan) {
+                    currentProgressEvents = [
+                      ...currentProgressEvents,
+                      {
+                        type: "todo_cancelled",
+                        seq: currentProgressEvents.length + 1,
+                        ...(planId ? { planId } : {}),
+                      },
+                    ];
+                    currentPlan = { ...currentPlan, status: "cancelled" } as ChatTodo;
+                    updateMessages((prev) => prev.map((m) =>
+                      m.id === assistantMsg.id
+                        ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] }
+                        : m
+                    ));
+                  } else {
+                    finalizeExistingTodo("cancelled", planId);
+                  }
                 }
                 break;
               case "plan_ready_for_approval":

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -160,9 +160,9 @@ export type StreamEvent =
   | { type: "source_used"; tool_name?: string; tool_use_id?: string; requested_url: string; final_url: string; hostname?: string; redirected?: boolean; from_cache?: boolean; status?: string; hint?: string; protocol_version?: number }
   | { type: "mcp_call"; tool_use_id?: string; server: string; tool: string; status?: "ok" | "error" | string; auto_connected?: boolean; reconnected?: boolean; error?: string; protocol_version?: number }
   | { type: "todo_created"; plan: ChatTodo; restored?: boolean }
-  | { type: "todo_step_updated"; stepId?: string; step_id?: string; stepIdx?: number; status: string; result?: string | null; protocol_version?: number }
-  | { type: "todo_completed" }
-  | { type: "todo_cancelled" }
+  | { type: "todo_step_updated"; planId?: string; plan_id?: string; stepId?: string; step_id?: string; stepIdx?: number; status: string; result?: string | null; protocol_version?: number }
+  | { type: "todo_completed"; planId?: string; plan_id?: string }
+  | { type: "todo_cancelled"; planId?: string; plan_id?: string }
   | { type: "plan_ready_for_approval"; data: { conversation_id: string; summary: string; plan_id: string; plan_file: string }; conversation_id?: string; plan_id?: string; plan_file?: string; protocol_version?: number }
   | { type: "ask_user"; question: string; options?: { id: string; label: string }[]; allow_multiple?: boolean; questions?: { id: string; prompt: string; options?: { id: string; label: string }[]; allow_multiple?: boolean }[]; confirmation_id?: string; risk_intent?: Record<string, unknown> }
   | { type: "user_insert"; content: string }

--- a/src/openakita/api/message_parts.py
+++ b/src/openakita/api/message_parts.py
@@ -80,6 +80,10 @@ def normalize_progress_event(event: dict | None, *, seq: int | None = None) -> d
     if seq is not None:
         out["seq"] = seq
 
+    plan_id = event.get("planId") or event.get("plan_id")
+    if plan_id:
+        out["planId"] = str(plan_id)
+
     if event_type == "todo_created":
         plan = serialize_plan_to_chat_todo(event.get("plan"))
         if not (plan and plan.get("steps")):

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -7,6 +7,7 @@ DELETE /api/sessions/{conversation_id}, POST /api/sessions/generate-title
 
 from __future__ import annotations
 
+import copy
 import logging
 import re
 from typing import Literal
@@ -349,6 +350,186 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     return entry
 
 
+_TODO_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+_TODO_CLOSING_EVENT_STATUS = {
+    "todo_completed": "completed",
+    "todo_cancelled": "cancelled",
+}
+_TODO_NON_TERMINAL_STEP_STATUSES = {"pending", "in_progress"}
+
+
+def _todo_id(todo: dict | None) -> str:
+    if not isinstance(todo, dict):
+        return ""
+    return str(todo.get("id") or "").strip()
+
+
+def _event_plan_id(event: dict) -> str:
+    return str(event.get("planId") or event.get("plan_id") or "").strip()
+
+
+def _remove_open_todo(open_order: list[str], plan_id: str) -> None:
+    try:
+        open_order.remove(plan_id)
+    except ValueError:
+        pass
+
+
+def _remember_open_todo(open_order: list[str], plan_id: str) -> None:
+    if not plan_id:
+        return
+    _remove_open_todo(open_order, plan_id)
+    open_order.append(plan_id)
+
+
+def _latest_open_todo_id(open_order: list[str], todos_by_id: dict[str, dict]) -> str:
+    while open_order:
+        plan_id = open_order[-1]
+        todo = todos_by_id.get(plan_id)
+        if isinstance(todo, dict) and todo.get("status") not in _TODO_TERMINAL_STATUSES:
+            return plan_id
+        open_order.pop()
+    return ""
+
+
+def _finalize_todo(todo: dict, status: str) -> dict:
+    out = copy.deepcopy(todo)
+    out["status"] = status
+    step_status = "cancelled" if status == "cancelled" else "completed"
+    for step in out.get("steps") or []:
+        if isinstance(step, dict) and step.get("status") in _TODO_NON_TERMINAL_STEP_STATUSES:
+            step["status"] = step_status
+    return out
+
+
+def _apply_todo_event(todo: dict, event: dict) -> dict:
+    out = copy.deepcopy(todo)
+    event_type = event.get("type")
+    if event_type == "todo_step_updated":
+        step_id = event.get("stepId")
+        step_idx = event.get("stepIdx")
+        for idx, step in enumerate(out.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            if (step_id and step.get("id") == step_id) or (
+                isinstance(step_idx, int) and idx == step_idx
+            ):
+                if event.get("status"):
+                    step["status"] = event["status"]
+                if "result" in event:
+                    step["result"] = event.get("result")
+                break
+    elif event_type in _TODO_CLOSING_EVENT_STATUS:
+        out = _finalize_todo(out, _TODO_CLOSING_EVENT_STATUS[event_type])
+    return out
+
+
+def _project_history_todo_final_states(visible: list[tuple[int, dict]]) -> dict[str, dict]:
+    """Infer final todo snapshots across assistant messages in one history.
+
+    Old sessions can contain an in-progress todo snapshot on one assistant
+    message and a later completion-only journal on another. The per-message
+    projection cannot connect those two records, so the history endpoint does
+    this cross-message pass before hydrating the UI.
+    """
+    from openakita.api.message_parts import (
+        normalize_chat_todo,
+        normalize_progress_events,
+        project_progress_events_to_todo,
+        serialize_plan_to_chat_todo,
+    )
+
+    todos_by_id: dict[str, dict] = {}
+    finalized_by_id: dict[str, dict] = {}
+    open_order: list[str] = []
+
+    for _idx, msg in visible:
+        progress_events = normalize_progress_events(msg.get("progress_events"))
+        projected = project_progress_events_to_todo(progress_events)
+        msg_todo = projected or (normalize_chat_todo(msg.get("todo")) if msg.get("todo") else None)
+
+        message_plan_id = _todo_id(msg_todo)
+        if message_plan_id:
+            todos_by_id[message_plan_id] = copy.deepcopy(msg_todo)
+            if msg_todo.get("status") in _TODO_TERMINAL_STATUSES:
+                finalized_by_id[message_plan_id] = copy.deepcopy(msg_todo)
+                _remove_open_todo(open_order, message_plan_id)
+            else:
+                _remember_open_todo(open_order, message_plan_id)
+
+        fallback_plan_id = message_plan_id or _latest_open_todo_id(open_order, todos_by_id)
+        terminal_targets: set[str] = set()
+
+        for event in progress_events:
+            event_type = event.get("type")
+            if event_type == "todo_created":
+                created = serialize_plan_to_chat_todo(event.get("plan"))
+                created_id = _todo_id(created)
+                if created_id:
+                    todos_by_id[created_id] = copy.deepcopy(created)
+                    _remember_open_todo(open_order, created_id)
+                    fallback_plan_id = created_id
+                continue
+
+            target_id = _event_plan_id(event) or fallback_plan_id
+            if not target_id:
+                target_id = _latest_open_todo_id(open_order, todos_by_id)
+            if not target_id or target_id not in todos_by_id:
+                continue
+
+            todos_by_id[target_id] = _apply_todo_event(todos_by_id[target_id], event)
+            if event_type in _TODO_CLOSING_EVENT_STATUS:
+                terminal_targets.add(target_id)
+
+        for target_id in terminal_targets:
+            finalized = todos_by_id.get(target_id)
+            if finalized:
+                finalized_by_id[target_id] = copy.deepcopy(finalized)
+            _remove_open_todo(open_order, target_id)
+
+    return finalized_by_id
+
+
+def _patch_entry_todo(entry: dict, todo: dict) -> None:
+    entry["todo"] = copy.deepcopy(todo)
+    parts = entry.get("parts")
+    if not isinstance(parts, list):
+        return
+    patched_parts: list[dict] = []
+    target_id = _todo_id(todo)
+    for part in parts:
+        if (
+            isinstance(part, dict)
+            and part.get("kind") == "plan"
+            and _todo_id(part.get("todo")) == target_id
+        ):
+            next_part = dict(part)
+            next_part["todo"] = copy.deepcopy(todo)
+            patched_parts.append(next_part)
+        else:
+            patched_parts.append(part)
+    entry["parts"] = patched_parts
+
+
+def _reconcile_history_todo_lifecycle(
+    entries: list[dict],
+    visible: list[tuple[int, dict]],
+) -> list[dict]:
+    finalized_by_id = _project_history_todo_final_states(visible)
+    if not finalized_by_id:
+        return entries
+
+    for entry in entries:
+        todo = entry.get("todo")
+        plan_id = _todo_id(todo)
+        finalized = finalized_by_id.get(plan_id)
+        if not (plan_id and finalized):
+            continue
+        if isinstance(todo, dict) and todo.get("status") != finalized.get("status"):
+            _patch_entry_todo(entry, finalized)
+    return entries
+
+
 @router.get("/api/sessions")
 async def list_sessions(request: Request, channel: str = "desktop"):
     """List sessions for a given channel (default: desktop).
@@ -507,12 +688,14 @@ async def get_session_history(
             "has_more_before": False,
         }
 
-    visible = _visible_history_messages(session)
+    all_visible = _visible_history_messages(session)
+    visible = all_visible
     if before is not None:
         visible = [(idx, msg) for idx, msg in visible if idx < before]
 
     page = visible[-limit:]
     result = [_history_entry(session, conversation_id, idx, msg) for idx, msg in page]
+    result = _reconcile_history_todo_lifecycle(result, all_visible)
     start_index = page[0][0] if page else None
     end_index = page[-1][0] if page else None
 
@@ -535,7 +718,7 @@ async def get_session_history(
 
     return {
         "messages": result,
-        "total": len(_visible_history_messages(session)),
+        "total": len(all_visible),
         "start_index": start_index,
         "end_index": end_index,
         "has_more_before": bool(page and any(idx < page[0][0] for idx, _ in visible)),

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -6634,9 +6634,19 @@ class Agent:
         # === 停止指令检测 ===
         message_lower = message.strip().lower()
         if message_lower in self.STOP_COMMANDS or message.strip() in self.STOP_COMMANDS:
+            _cancelled_plan_id = ""
+            try:
+                from ..tools.handlers.plan import get_active_plan_id
+
+                _cancelled_plan_id = get_active_plan_id(session_id) or ""
+            except Exception:
+                _cancelled_plan_id = ""
             self.cancel_current_task(f"用户发送停止指令: {message}", session_id=session_id)
             logger.info(f"[StopTask] User requested to stop (session={session_id}): {message}")
-            yield {"type": "todo_cancelled"}
+            _todo_cancelled_event = {"type": "todo_cancelled"}
+            if _cancelled_plan_id:
+                _todo_cancelled_event["planId"] = _cancelled_plan_id
+            yield _todo_cancelled_event
             yield {
                 "type": "text_delta",
                 "content": "✅ 好的，已停止当前任务。有什么其他需要帮助的吗？",

--- a/src/openakita/core/_reasoning_engine_legacy.py
+++ b/src/openakita/core/_reasoning_engine_legacy.py
@@ -5475,6 +5475,16 @@ class ReasoningEngine:
                         # 显式置 None（policy: side-channel hint 只反映 handler
                         # 内部产生的可纠正配置问题，不污染 user-initiated 中断）。
                         _stream_hint: ConfigHint | None = None
+                        _active_plan_id_before_tool = ""
+                        if tool_name in {"update_todo_step", "complete_todo"}:
+                            try:
+                                from ..tools.handlers.plan import get_active_plan_id
+
+                                _active_plan_id_before_tool = (
+                                    get_active_plan_id(conversation_id) or ""
+                                )
+                            except Exception:
+                                _active_plan_id_before_tool = ""
                         try:
                             tool_exec_task = asyncio.create_task(
                                 self._tool_executor.execute_tool_with_policy(
@@ -5705,13 +5715,28 @@ class ReasoningEngine:
                                 }
                         elif tool_name == "update_todo_step" and isinstance(tool_args, dict):
                             step_id = tool_args.get("step_id", "")
-                            yield {
+                            _todo_step_event = {
                                 "type": "todo_step_updated",
                                 "stepId": step_id,
                                 "status": tool_args.get("status", "completed"),
                             }
+                            if _active_plan_id_before_tool:
+                                _todo_step_event["planId"] = _active_plan_id_before_tool
+                            yield _todo_step_event
                         elif tool_name == "complete_todo":
-                            yield {"type": "todo_completed"}
+                            _complete_succeeded = False
+                            if _active_plan_id_before_tool:
+                                try:
+                                    from ..tools.handlers.plan import has_active_todo
+
+                                    _complete_succeeded = not has_active_todo(conversation_id)
+                                except Exception:
+                                    _complete_succeeded = result_text.startswith("✅ 计划")
+                            if _complete_succeeded:
+                                _todo_done_event = {"type": "todo_completed"}
+                                if _active_plan_id_before_tool:
+                                    _todo_done_event["planId"] = _active_plan_id_before_tool
+                                yield _todo_done_event
 
                         _tr_entry: dict = {
                             "type": "tool_result",

--- a/tests/unit/test_message_parts.py
+++ b/tests/unit/test_message_parts.py
@@ -159,6 +159,18 @@ def test_progress_event_journal_projects_latest_todo_state():
     assert todo["steps"][1]["result"] == "built"
 
 
+def test_normalize_progress_events_preserves_lifecycle_plan_id():
+    events = normalize_progress_events(
+        [
+            {"type": "todo_completed", "planId": "plan-1"},
+            {"type": "todo_cancelled", "plan_id": "plan-2"},
+        ]
+    )
+
+    assert events[0]["planId"] == "plan-1"
+    assert events[1]["planId"] == "plan-2"
+
+
 def test_build_message_parts_inlines_progress_event_journal_on_plan_part():
     events = normalize_progress_events(
         [

--- a/tests/unit/test_sessions_history_route.py
+++ b/tests/unit/test_sessions_history_route.py
@@ -5,6 +5,18 @@ from openakita.api.routes.sessions import router
 from openakita.sessions import SessionManager
 
 
+def _stale_todo() -> dict:
+    return {
+        "id": "plan_703",
+        "taskSummary": "卸载 thirdparty 备份软件并清理残留",
+        "status": "in_progress",
+        "steps": [
+            {"id": "step_1", "description": "停止服务", "status": "in_progress"},
+            {"id": "step_2", "description": "卸载程序", "status": "pending"},
+        ],
+    }
+
+
 def _client_with_session(tmp_path, message_count: int = 120) -> TestClient:
     app = FastAPI()
     app.include_router(router)
@@ -107,6 +119,54 @@ def test_history_backfill_skips_near_duplicate_turns(tmp_path):
     assert body["total"] == 2
     assert [m["content"] for m in body["messages"]] == ["same prompt", "done"]
     assert [m["content"] for m in session.context.messages].count("same prompt") == 1
+
+
+def test_history_reconciles_later_completion_only_todo_event(tmp_path):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    session = manager.get_session("desktop", "conv1", "desktop_user")
+    stale = _stale_todo()
+    session.add_message("user", "卸载 thirdparty")
+    session.add_message(
+        "assistant",
+        "开始计划",
+        todo=stale,
+        progress_events=[
+            {"type": "todo_created", "plan": stale},
+            {"type": "todo_step_updated", "stepId": "step_1", "status": "in_progress"},
+        ],
+    )
+    session.add_message("user", "这是工作软件，不要卸载")
+    session.add_message(
+        "assistant",
+        "计划已关闭",
+        progress_events=[
+            {"type": "todo_completed"},
+            {
+                "type": "todo_step_updated",
+                "stepId": "step_1",
+                "status": "completed",
+                "result": "已取消",
+            },
+            {
+                "type": "todo_step_updated",
+                "stepId": "step_2",
+                "status": "completed",
+                "result": "已取消",
+            },
+        ],
+    )
+    app.state.session_manager = manager
+
+    body = TestClient(app).get("/api/sessions/conv1/history").json()
+    created = next(m for m in body["messages"] if m["content"] == "开始计划")
+    plan_part = next(p for p in created["parts"] if p["kind"] == "plan")
+
+    assert created["todo"]["status"] == "completed"
+    assert [step["status"] for step in created["todo"]["steps"]] == ["completed", "completed"]
+    assert plan_part["todo"]["status"] == "completed"
+    assert body["active_todo"] is None
 
 
 def test_session_list_returns_conversation_ui_state(tmp_path):


### PR DESCRIPTION
## Summary
- Fixes #703.
- Reconcile todo lifecycle events across session history so stale in-progress plan snapshots do not revive after reload.
- Preserve plan ids on todo lifecycle events and close existing frontend plan cards when completion-only events arrive.

## Tests
- uv run --no-project pytest tests/unit/test_message_parts.py tests/unit/test_sessions_history_route.py
- uv run --no-project pytest tests/unit/test_chat_view_session_isolation.py
- uv run --no-project ruff check src\openakita\api\message_parts.py src\openakita\api\routes\sessions.py src\openakita\core\_reasoning_engine_legacy.py src\openakita\core\_agent_legacy.py tests\unit\test_message_parts.py tests\unit\test_sessions_history_route.py
- npm run build