### PR TITLE
fix chat todo lifecycle to keep floating progress authoritative after final answers

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -1276,6 +1276,15 @@ export function ChatView({
   const mergeActiveTodo = useCallback(
     (msgs: ChatMessage[], activeTodo: ChatTodo | null | undefined): ChatMessage[] => {
       if (!activeTodo || !activeTodo.steps?.length) return msgs;
+      const matchingLocalTodo = [...msgs].reverse().find((m) => m.todo?.id === activeTodo.id)?.todo;
+      if (
+        matchingLocalTodo &&
+        (matchingLocalTodo.status === "completed" ||
+          matchingLocalTodo.status === "failed" ||
+          matchingLocalTodo.status === "cancelled")
+      ) {
+        return msgs;
+      }
       let lastAssistant = -1;
       for (let i = msgs.length - 1; i >= 0; i -= 1) {
         if (msgs[i].role === "assistant") { lastAssistant = i; break; }
@@ -4139,7 +4148,7 @@ export function ChatView({
                         ...(planId ? { planId } : {}),
                       },
                     ];
-                    currentPlan = { ...currentPlan, status: "completed" } as ChatTodo;
+                    currentPlan = terminalizeTodo(currentPlan, "completed");
                     updateMessages((prev) => prev.map((m) =>
                       m.id === assistantMsg.id
                         ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] }
@@ -4162,7 +4171,7 @@ export function ChatView({
                         ...(planId ? { planId } : {}),
                       },
                     ];
-                    currentPlan = { ...currentPlan, status: "cancelled" } as ChatTodo;
+                    currentPlan = terminalizeTodo(currentPlan, "cancelled");
                     updateMessages((prev) => prev.map((m) =>
                       m.id === assistantMsg.id
                         ? { ...m, todo: { ...currentPlan! }, progressEvents: [...currentProgressEvents] }
@@ -4530,15 +4539,37 @@ export function ChatView({
                     };
                   }
                 }
-                if (currentPlan && currentPlan.status === "in_progress") {
-                  currentPlan = { ...(currentPlan as ChatTodo), status: "completed" as const };
+                let shouldTerminalizePlan = false;
+                if (
+                  currentPlan &&
+                  currentPlan.status === "in_progress" &&
+                  currentAsk === null &&
+                  !pendingApprovalRef.current
+                ) {
+                  shouldTerminalizePlan = true;
+                  const plan = currentPlan;
+                  const planId = plan.id || "";
+                  const alreadyRecordedCompletion = currentProgressEvents.some(
+                    (ev) => ev.type === "todo_completed" && (!planId || !ev.planId || ev.planId === planId),
+                  );
+                  if (!alreadyRecordedCompletion) {
+                    currentProgressEvents = [
+                      ...currentProgressEvents,
+                      {
+                        type: "todo_completed",
+                        seq: currentProgressEvents.length + 1,
+                        ...(planId ? { planId } : {}),
+                      },
+                    ];
+                  }
+                  currentPlan = terminalizeTodo(plan, "completed");
                 }
-                updateMessages((prev) => {
+                if (shouldTerminalizePlan) updateMessages((prev) => {
                   const hasStaleTodo = prev.some((m) => m.id !== assistantMsg.id && m.todo && m.todo.status !== "completed" && m.todo.status !== "failed" && m.todo.status !== "cancelled");
                   if (!hasStaleTodo) return prev;
                   return prev.map((m) =>
                     m.id !== assistantMsg.id && m.todo && m.todo.status !== "completed" && m.todo.status !== "failed" && m.todo.status !== "cancelled"
-                      ? { ...m, todo: { ...m.todo, status: "completed" as const } }
+                      ? { ...m, todo: terminalizeTodo(m.todo, "completed") }
                       : m
                   );
                 });
@@ -5033,6 +5064,14 @@ export function ChatView({
       }).catch(() => {});
     }
   }, [pendingApproval, apiBase]);
+
+  const handlePlanStepAction = useCallback((action: "skip" | "retry", stepIdx: number, description: string) => {
+    const msg = action === "skip"
+      ? `请跳过当前步骤（第 ${stepIdx + 1} 步：${description}），直接进入下一步。`
+      : `请重试这一步（第 ${stepIdx + 1} 步：${description}）。`;
+    setInputValue(msg);
+    inputRef.current?.focus();
+  }, [setInputValue]);
 
   // ── 停止生成 ──
   const stopStreaming = useCallback((targetConvId?: string) => {
@@ -6256,12 +6295,7 @@ export function ChatView({
             hasMoreBefore={historyPage.hasMoreBefore}
             loadingOlder={historyPage.loadingOlder}
             onLoadOlder={loadOlderMessages}
-            onPlanStepAction={(action, stepIdx, description) => {
-              const msg = action === "skip"
-                ? `请跳过当前步骤（第 ${stepIdx + 1} 步：${description}），直接进入下一步。`
-                : `请重试这一步（第 ${stepIdx + 1} 步：${description}）。`;
-              setInputValue(msg);
-            }}
+            onPlanStepAction={handlePlanStepAction}
             onAtBottomChange={(atBottom) => { isMessageListAtBottomRef.current = atBottom; }}
             onActiveUserMessageChange={outlineItems.length > 0 ? setActiveOutlineId : undefined}
             onAskAnswer={handleAskAnswer}
@@ -6324,7 +6358,7 @@ export function ChatView({
         {/* 浮动 Plan 进度条 —— 贴在输入框上方，仅显示进行中的 plan */}
         {(() => {
           const activePlan = [...messages].reverse().find((m) => m.todo && m.todo.status !== "completed" && m.todo.status !== "failed" && m.todo.status !== "cancelled")?.todo;
-          return activePlan ? <FloatingPlanBar plan={activePlan} /> : null;
+          return activePlan ? <FloatingPlanBar plan={activePlan} onStepAction={handlePlanStepAction} /> : null;
         })()}
 
         {/* Read-only protection banner */}

--- a/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
+++ b/apps/setup-center/src/views/chat/components/FlatMessageItem.tsx
@@ -74,9 +74,9 @@ export const FlatMessageItem = memo(function FlatMessageItem({
   // Local "view process" reveal can override the global hide-chain toggle for
   // this one bubble.
   const effShowChain = showChain || revealChain;
-  // Keep the streaming loading indicator up only while nothing else renders, so
-  // it never double-stacks under a plan / ask_user / artifact card and never
-  // lingers as a fake spinner when the chain is hidden (showChain=off).
+  // Keep the streaming loading indicator up until the model has produced
+  // normal output. Todo progress is rendered in the floating bar, so it must
+  // not suppress the regular stream affordances.
   const hasBody = isAssistant && hasRenderableBody(msg, parts, effShowChain, bodyContent);
   // Avoid a blank completed bubble when the only thing produced was a chain the
   // user chose to hide — surface a plain one-line handle into the process. Gate

--- a/apps/setup-center/src/views/chat/components/FloatingPlanBar.tsx
+++ b/apps/setup-center/src/views/chat/components/FloatingPlanBar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type * as React from "react";
 import { useTranslation } from "react-i18next";
 import type { ChatTodo, ChatTodoStep } from "../utils/chatTypes";
 import {
@@ -6,7 +7,18 @@ import {
   IconCircle, IconMinus, IconX,
 } from "../../../icons";
 
-function FloatingTodoStepItem({ step, idx }: { step: ChatTodoStep; idx: number }) {
+type PlanStepAction = "skip" | "retry";
+
+function FloatingTodoStepItem({
+  step,
+  idx,
+  onStepAction,
+}: {
+  step: ChatTodoStep;
+  idx: number;
+  onStepAction?: (action: PlanStepAction, stepIdx: number, description: string) => void;
+}) {
+  const { t } = useTranslation();
   const icon =
     step.status === "completed" ? <IconCheck size={13} /> :
     step.status === "in_progress" ? <IconPlay size={11} /> :
@@ -30,12 +42,32 @@ function FloatingTodoStepItem({ step, idx }: { step: ChatTodoStep; idx: number }
       <div className="floatingTodoStepContent">
         <span style={{ opacity: step.status === "skipped" || step.status === "cancelled" ? 0.5 : 1 }}>{idx + 1}. {descText}</span>
         {resultText && <div className="floatingTodoStepResult">{resultText}</div>}
+        {onStepAction && step.status === "in_progress" && (
+          <div style={{ display: "flex", gap: 6, marginTop: 5 }}>
+            <button
+              type="button"
+              onClick={() => onStepAction("skip", idx, descText)}
+              title={t("chat.plan.skipHint", {
+                defaultValue: "在输入框生成「跳过此步」的请求",
+              }) as string}
+              style={floatingPlanActionBtnStyle}
+            >
+              {t("chat.plan.skip", { defaultValue: "跳过此步" })}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
-export function FloatingPlanBar({ plan }: { plan: ChatTodo }) {
+export function FloatingPlanBar({
+  plan,
+  onStepAction,
+}: {
+  plan: ChatTodo;
+  onStepAction?: (action: PlanStepAction, stepIdx: number, description: string) => void;
+}) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const completed = plan.steps.filter((s) => s.status === "completed").length;
@@ -75,6 +107,21 @@ export function FloatingPlanBar({ plan }: { plan: ChatTodo }) {
         <div className="floatingTodoActive">
           <span className="floatingTodoActiveIcon"><IconPlay size={11} /></span>
           <span className="floatingTodoActiveText">{activeIdx + 1}/{total} {activeDesc}</span>
+          {onStepAction && activeStep.status === "in_progress" && activeDesc && activeIdx >= 0 && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onStepAction("skip", activeIdx, activeDesc);
+              }}
+              title={t("chat.plan.skipHint", {
+                defaultValue: "在输入框生成「跳过此步」的请求",
+              }) as string}
+              style={{ ...floatingPlanActionBtnStyle, marginLeft: "auto", flexShrink: 0 }}
+            >
+              {t("chat.plan.skip", { defaultValue: "跳过此步" })}
+            </button>
+          )}
         </div>
       )}
       {!expanded && allDone && (
@@ -87,10 +134,25 @@ export function FloatingPlanBar({ plan }: { plan: ChatTodo }) {
       {expanded && (
         <div className="floatingTodoSteps">
           {plan.steps.map((step, idx) => (
-            <FloatingTodoStepItem key={step.id || idx} step={step} idx={idx} />
+            <FloatingTodoStepItem
+              key={step.id || idx}
+              step={step}
+              idx={idx}
+              onStepAction={onStepAction}
+            />
           ))}
         </div>
       )}
     </div>
   );
 }
+
+const floatingPlanActionBtnStyle: React.CSSProperties = {
+  fontSize: 11,
+  padding: "2px 8px",
+  borderRadius: 6,
+  border: "1px solid var(--line)",
+  background: "transparent",
+  cursor: "pointer",
+  color: "var(--muted)",
+};

--- a/apps/setup-center/src/views/chat/components/MessageBubble.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageBubble.tsx
@@ -67,9 +67,9 @@ export const MessageBubble = memo(function MessageBubble({
   // for this one bubble, so the effective value drives both rendering and the
   // emptiness check.
   const effShowChain = showChain || revealChain;
-  // Drives the streaming loading indicator: keep it visible only while the
-  // bubble has nothing else to render (covers showChain=off where the chain is
-  // hidden, without double-stacking under a plan / ask_user / artifact card).
+  // Drives the streaming loading indicator: keep it visible until the model
+  // has produced normal output. Todo progress is rendered in the floating bar,
+  // so it must not suppress the regular stream affordances.
   const hasBody = isAssistant && hasRenderableBody(msg, parts, effShowChain, bodyContent);
   // A finished assistant turn that renders nothing visible yet still hides a
   // reasoning chain (global toggle off) would otherwise be a blank bubble —

--- a/apps/setup-center/src/views/chat/components/MessageParts.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageParts.tsx
@@ -6,7 +6,6 @@ import { AskUserBlock } from "./AskUser";
 import { AskUserSummary } from "./AskUserSummary";
 import { ErrorCard } from "./ErrorCard";
 import { SourceStrip } from "./SourceStrip";
-import { PlanCard } from "./PlanCard";
 import { MCPCallStrip } from "./MCPCallStrip";
 import { MarkdownContent } from "./MarkdownContent";
 
@@ -14,8 +13,10 @@ import { MarkdownContent } from "./MarkdownContent";
  * Ordered renderer for an assistant message's `MessagePart[]`.
  *
  * This is the single rendering path shared by both display modes
- * (`FlatMessageItem` and `MessageBubble`), so plan / answered-ask_user /
- * image cards render and re-hydrate identically regardless of the chosen mode.
+ * (`FlatMessageItem` and `MessageBubble`), so answered-ask_user / image cards
+ * render and re-hydrate identically regardless of the chosen mode. Todo/plan
+ * progress is rendered by the floating bar above the composer, not inside each
+ * assistant message.
  * Heavy text blocks read their payload from the flat message fields; the parts
  * array only carries ordering (and small inlined data for plan / attachment /
  * ask_user).
@@ -74,12 +75,8 @@ export function MessageParts({
             return <SourceStrip key={part.id} sources={msg.sources} conversationId={conversationId} httpApiBase={httpApiBase} />;
           case "mcp":
             return <MCPCallStrip key={part.id} calls={msg.mcpCalls} />;
-          case "plan": {
-            const todo = part.todo || msg.todo;
-            return todo && todo.steps?.length > 0 ? (
-              <PlanCard key={part.id} plan={todo} onStepAction={onPlanStepAction} />
-            ) : null;
-          }
+          case "plan":
+            return null;
           case "text":
             return bodyContent ? (
               <MarkdownContent

--- a/apps/setup-center/src/views/chat/components/__tests__/FloatingPlanBar.test.tsx
+++ b/apps/setup-center/src/views/chat/components/__tests__/FloatingPlanBar.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FloatingPlanBar } from "../FloatingPlanBar";
+
+describe("FloatingPlanBar step actions", () => {
+  it("emits skip for the active step from the collapsed bar", () => {
+    const onStepAction = vi.fn();
+
+    render(
+      <FloatingPlanBar
+        plan={{
+          id: "plan-1",
+          taskSummary: "Ship",
+          status: "in_progress",
+          steps: [
+            { id: "s1", description: "Inspect files", status: "completed" },
+            { id: "s2", description: "Patch UI", status: "in_progress" },
+          ],
+        }}
+        onStepAction={onStepAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "跳过此步" }));
+
+    expect(onStepAction).toHaveBeenCalledWith("skip", 1, "Patch UI");
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/__tests__/messageParts.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/messageParts.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage, ChatTodo } from "../chatTypes";
+import { hasRenderableBody, resolveMessageParts } from "../messageParts";
+
+const todo: ChatTodo = {
+  id: "plan-1",
+  taskSummary: "Ship the feature",
+  status: "in_progress",
+  steps: [
+    { id: "s1", description: "Inspect", status: "completed" },
+    { id: "s2", description: "Patch", status: "in_progress" },
+  ],
+};
+
+describe("message parts projection", () => {
+  it("heals explicit todo-only parts with normal text and tool blocks", () => {
+    const msg: ChatMessage = {
+      id: "m1",
+      role: "assistant",
+      content: "Done",
+      timestamp: 1,
+      todo,
+      toolCalls: [
+        {
+          id: "tool-1",
+          tool: "read_file",
+          args: { path: "src/app.ts" },
+          result: "ok",
+          status: "done",
+        },
+      ],
+      parts: [{ kind: "plan", id: "plan:plan-1", todo }],
+    };
+
+    expect(resolveMessageParts(msg).map((part) => part.kind)).toEqual(["plan", "text", "tools"]);
+  });
+
+  it("heals explicit todo-only parts with a hidden reasoning chain marker", () => {
+    const msg: ChatMessage = {
+      id: "m2",
+      role: "assistant",
+      content: "",
+      timestamp: 1,
+      todo,
+      thinkingChain: [
+        {
+          iteration: 1,
+          collapsed: false,
+          hasThinking: false,
+          toolCalls: [],
+          entries: [{ kind: "text", content: "About to inspect files" }],
+        },
+      ],
+      parts: [{ kind: "plan", id: "plan:plan-1", todo }],
+    };
+
+    expect(resolveMessageParts(msg).map((part) => part.kind)).toEqual(["reasoning", "plan"]);
+  });
+
+  it("does not treat plan cards as assistant message body", () => {
+    const msg: ChatMessage = {
+      id: "m3",
+      role: "assistant",
+      content: "",
+      timestamp: 1,
+      todo,
+      parts: [{ kind: "plan", id: "plan:plan-1", todo }],
+    };
+    const parts = resolveMessageParts(msg);
+
+    expect(hasRenderableBody(msg, parts, true, "")).toBe(false);
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/chatHelpers.ts
+++ b/apps/setup-center/src/views/chat/utils/chatHelpers.ts
@@ -229,12 +229,23 @@ export function saveMessagesToStorage(key: string, msgs: ChatMessage[], maxMessa
   const windowed = maxMessages > 0 && msgs.length > maxMessages ? msgs.slice(-maxMessages) : msgs;
   // streamFallback is kept on purpose (see sanitizeStoredMessages) so an
   // interrupted bubble stays flagged across reloads until reconciled.
-  const base = windowed.map(({ streaming, streamStatus, ...rest }) => rest);
+  const base = windowed.map(({
+    streaming: _streaming,
+    streamStatus: _streamStatus,
+    parts: _parts,
+    ...rest
+  }) => rest);
   try {
     localStorage.setItem(key, JSON.stringify(base));
     return true;
   } catch {
-    const slim = windowed.map(({ streaming, streamStatus, thinkingChain, ...rest }) => rest);
+    const slim = windowed.map(({
+      streaming: _streaming,
+      streamStatus: _streamStatus,
+      thinkingChain: _thinkingChain,
+      parts: _parts,
+      ...rest
+    }) => rest);
     try {
       localStorage.setItem(key, JSON.stringify(slim));
       return true;

--- a/apps/setup-center/src/views/chat/utils/messageParts.ts
+++ b/apps/setup-center/src/views/chat/utils/messageParts.ts
@@ -141,11 +141,6 @@ export function coerceMessageParts(raw: unknown, msg: ChatMessage): MessagePart[
 }
 
 /**
- * Resolve the parts to render for a message: prefer an explicit (backend or
- * persisted) `parts`, otherwise derive from flat fields. Always self-heals
- * attachment/plan/ask payloads from flat fields when the marker omitted them.
- */
-/**
  * Does this assistant message currently have at least one part that will
  * actually render something visible, given the chosen `showChain` mode and the
  * already-stripped `bodyContent`?
@@ -177,10 +172,8 @@ export function hasRenderableBody(
         return !!msg.sources && msg.sources.length > 0;
       case "mcp":
         return !!msg.mcpCalls && msg.mcpCalls.length > 0;
-      case "plan": {
-        const todo = part.todo || msg.todo;
-        return !!todo && !!todo.steps && todo.steps.length > 0;
-      }
+      case "plan":
+        return false;
       case "text":
         return !!bodyContent;
       case "tools":
@@ -197,6 +190,51 @@ export function hasRenderableBody(
   });
 }
 
+function mergeWithDerivedParts(explicit: MessagePart[], msg: ChatMessage): MessagePart[] {
+  const derived = deriveMessageParts(msg);
+  if (derived.length === 0) return explicit;
+
+  const usedExplicit = new Set<number>();
+  const takeExplicit = (derivedPart: MessagePart): MessagePart => {
+    const idx = explicit.findIndex((part, i) => !usedExplicit.has(i) && part.kind === derivedPart.kind);
+    if (idx < 0) return derivedPart;
+    usedExplicit.add(idx);
+    const part = explicit[idx];
+    if (part.kind === "plan") {
+      return {
+        ...part,
+        todo: part.todo || (derivedPart.kind === "plan" ? derivedPart.todo : undefined),
+        progressEvents:
+          part.progressEvents || (derivedPart.kind === "plan" ? derivedPart.progressEvents : undefined),
+      };
+    }
+    if (part.kind === "attachment") {
+      return {
+        ...part,
+        artifact: part.artifact || (derivedPart.kind === "attachment" ? derivedPart.artifact : undefined),
+      };
+    }
+    if (part.kind === "ask_user") {
+      return {
+        ...part,
+        ask: part.ask || (derivedPart.kind === "ask_user" ? derivedPart.ask : undefined),
+      };
+    }
+    return part;
+  };
+
+  const merged = derived.map(takeExplicit);
+  const extras = explicit.filter((_, i) => !usedExplicit.has(i));
+  return extras.length > 0 ? [...merged, ...extras] : merged;
+}
+
+/**
+ * Resolve the parts to render for a message. Explicit backend/local markers
+ * can carry ordering and small inline payloads, but the message's flat fields
+ * remain authoritative for which normal output blocks exist. This prevents a
+ * partial plan/todo projection from suppressing text, tools, sources, or the
+ * reasoning chain.
+ */
 export function resolveMessageParts(msg: ChatMessage): MessagePart[] {
   const explicit = coerceMessageParts(msg.parts, msg);
   if (explicit) {
@@ -229,7 +267,7 @@ export function resolveMessageParts(msg: ChatMessage): MessagePart[] {
         ? [...healed.slice(0, insertBefore), planPart, ...healed.slice(insertBefore)]
         : [...healed, planPart];
     }
-    return healed;
+    return mergeWithDerivedParts(healed, msg);
   }
   return deriveMessageParts(msg);
 }

--- a/src/openakita/api/message_parts.py
+++ b/src/openakita/api/message_parts.py
@@ -125,6 +125,17 @@ def append_progress_event(events: list[dict] | None, event: dict | None) -> list
     return out
 
 
+def _terminalize_todo(todo: dict, status: str) -> dict:
+    """Return a todo snapshot with open steps closed for a terminal event."""
+    out = copy.deepcopy(todo)
+    out["status"] = status
+    step_status = "cancelled" if status == "cancelled" else "completed"
+    for step in out.get("steps") or []:
+        if isinstance(step, dict) and step.get("status") in {"pending", "in_progress"}:
+            step["status"] = step_status
+    return out
+
+
 def project_progress_events_to_todo(events: Any) -> dict | None:
     """Fold a persisted progress-event journal into the latest ChatTodo state."""
     todo: dict | None = None
@@ -160,9 +171,9 @@ def project_progress_events_to_todo(events: Any) -> dict | None:
                 else:
                     todo["status"] = "completed"
         elif event_type == "todo_completed":
-            todo["status"] = "completed"
+            todo = _terminalize_todo(todo, "completed")
         elif event_type == "todo_cancelled":
-            todo["status"] = "cancelled"
+            todo = _terminalize_todo(todo, "cancelled")
     return todo
 
 

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -211,6 +211,56 @@ def _attach_todo_snapshot_meta(
         pass
 
 
+def _complete_active_todo_after_final_answer(
+    conversation_id: str,
+    todo_snapshot: dict | None,
+    progress_events: list[dict] | None,
+) -> tuple[dict | None, list[dict]]:
+    """Finalize an active todo when a normal visible assistant answer ends the turn."""
+    next_events = list(progress_events or [])
+    if not conversation_id:
+        return todo_snapshot, next_events
+
+    try:
+        from ...tools.handlers.plan import (
+            complete_todo_after_final_answer,
+            get_active_plan_id,
+            get_todo_handler_for_session,
+            has_active_todo,
+        )
+        from ..message_parts import serialize_plan_to_chat_todo
+
+        if not has_active_todo(conversation_id):
+            return todo_snapshot, next_events
+
+        plan_id = get_active_plan_id(conversation_id) or ""
+        handler = get_todo_handler_for_session(conversation_id)
+        plan = handler.get_plan_for(conversation_id) if handler else None
+        seed_snapshot = serialize_plan_to_chat_todo(plan) if isinstance(plan, dict) else None
+
+        if not complete_todo_after_final_answer(conversation_id):
+            return todo_snapshot, next_events
+
+        next_snapshot = todo_snapshot or seed_snapshot
+        event_plan_id = plan_id or (seed_snapshot or {}).get("id") or ""
+        already_completed = any(
+            ev.get("type") == "todo_completed"
+            and (not event_plan_id or not ev.get("planId") or ev.get("planId") == event_plan_id)
+            for ev in next_events
+            if isinstance(ev, dict)
+        )
+        if not already_completed:
+            event: dict[str, Any] = {"type": "todo_completed"}
+            if event_plan_id:
+                event["planId"] = event_plan_id
+            next_events = _observe_progress_event_journal(next_events, event)
+            next_snapshot = _observe_todo_snapshot_event(next_snapshot, event)
+        return next_snapshot, next_events
+    except Exception:
+        logger.debug("[Chat API] final-answer todo completion failed", exc_info=True)
+        return todo_snapshot, next_events
+
+
 class _RiskAuthorizedReplay:
     """Sentinel returned by ``_handle_pending_risk_answer`` when the user has
     confirmed a high-risk action **but** the classification has no controlled
@@ -872,7 +922,9 @@ async def _cancel_running_chat_task(
     """
     conv_id = conversation_id or getattr(actual_agent, "_current_conversation_id", None)
     if not conv_id:
-        logger.info("[Chat API] %s cancel without conversation id; using legacy agent cancel", source)
+        logger.info(
+            "[Chat API] %s cancel without conversation id; using legacy agent cancel", source
+        )
         actual_agent.cancel_current_task(reason)
         return {"status": "ok", "action": "cancel", "reason": reason}
 
@@ -922,8 +974,7 @@ async def _cancel_running_chat_task(
             "conversation_id": conv_id,
             "busy": True,
             "message": (
-                "Lifecycle was busy but the agent turn already cleaned up; "
-                "nothing left to cancel"
+                "Lifecycle was busy but the agent turn already cleaned up; nothing left to cancel"
             ),
         }
 
@@ -1023,6 +1074,9 @@ def _schedule_background_save(
         bg_mcp_calls = list(collected_mcp_calls or [])
         bg_todo_snapshot = todo_snapshot
         bg_progress_events = list(progress_events or [])
+        bg_ask_user_seen = False
+        bg_pending_approval_seen = False
+        bg_plan_ready_for_approval_seen = False
         try:
             while not agent_queue.empty():
                 ev = agent_queue.get_nowait()
@@ -1042,6 +1096,12 @@ def _schedule_background_save(
                     bg_reply += ev["content"]
                 elif et == "text_replace" and "content" in ev:
                     bg_reply = ev["content"]
+                elif et == "ask_user":
+                    bg_ask_user_seen = True
+                elif et == "pending_approval":
+                    bg_pending_approval_seen = True
+                elif et == "plan_ready_for_approval":
+                    bg_plan_ready_for_approval_seen = True
         except Exception:
             pass
 
@@ -1054,6 +1114,17 @@ def _schedule_background_save(
                     meta["sources"] = bg_sources
                 if bg_mcp_calls:
                     meta["mcp_calls"] = bg_mcp_calls
+                if (
+                    conversation_id
+                    and not bg_ask_user_seen
+                    and not bg_pending_approval_seen
+                    and not bg_plan_ready_for_approval_seen
+                ):
+                    bg_todo_snapshot, bg_progress_events = _complete_active_todo_after_final_answer(
+                        conversation_id,
+                        bg_todo_snapshot,
+                        bg_progress_events,
+                    )
                 _attach_todo_snapshot_meta(
                     meta,
                     conversation_id=conversation_id,
@@ -1216,6 +1287,8 @@ async def _stream_chat(
     _agent_done = asyncio.Event()
     _agent_queue: asyncio.Queue = asyncio.Queue()
     _save_done = False
+    _pending_approval = False
+    _plan_ready_for_approval = False
     session = None
     conversation_id = chat_request.conversation_id or ""
     _BUSY_REFRESH_INTERVAL = 60.0
@@ -1474,6 +1547,8 @@ async def _stream_chat(
         _last_emit_ts = time.time()
         _agent_errored = False
         _agent_error_msg = ""
+        _pending_approval = False
+        _plan_ready_for_approval = False
 
         def _emit_via_coalescer(etype: str, edata: dict | None) -> list[str]:
             """Push one upstream event through the coalescer.
@@ -1581,6 +1656,10 @@ async def _stream_chat(
                 _ask_user_question = event.get("question", "")
                 _ask_user_options = event.get("options", [])
                 _ask_user_questions = event.get("questions", [])
+            elif event_type == "pending_approval":
+                _pending_approval = True
+            elif event_type == "plan_ready_for_approval":
+                _plan_ready_for_approval = True
 
             # Push the event through the coalescer.  For non-delta types
             # it bypasses immediately (potentially preceded by pending
@@ -1718,14 +1797,31 @@ async def _stream_chat(
             except Exception:
                 pass
 
+        _task = (
+            actual_agent.agent_state.current_task
+            if hasattr(actual_agent, "agent_state") and actual_agent.agent_state
+            else None
+        )
+        _task_cancelled = bool(_task and _task.cancelled)
         if not assistant_text_to_save:
-            _task = (
-                actual_agent.agent_state.current_task
-                if hasattr(actual_agent, "agent_state") and actual_agent.agent_state
-                else None
-            )
-            if _task and _task.cancelled:
+            if _task_cancelled:
                 assistant_text_to_save = "[任务已取消]"
+
+        if (
+            conversation_id
+            and assistant_text_to_save
+            and not _ask_user_question
+            and not _ask_user_questions
+            and not _pending_approval
+            and not _plan_ready_for_approval
+            and not _agent_errored
+            and not _task_cancelled
+        ):
+            _last_todo_snapshot, _progress_events = _complete_active_todo_after_final_answer(
+                conversation_id,
+                _last_todo_snapshot,
+                _progress_events,
+            )
 
         if session and assistant_text_to_save:
             try:
@@ -1886,6 +1982,20 @@ async def _stream_chat(
                     _deferred_timeline = _chain_timeline_builder.build()
                     if _deferred_timeline:
                         _deferred_meta["chain_timeline"] = _deferred_timeline
+                    if (
+                        conversation_id
+                        and not _ask_user_question
+                        and not _ask_user_questions
+                        and not _pending_approval
+                        and not _plan_ready_for_approval
+                    ):
+                        _last_todo_snapshot, _progress_events = (
+                            _complete_active_todo_after_final_answer(
+                                conversation_id,
+                                _last_todo_snapshot,
+                                _progress_events,
+                            )
+                        )
                     _attach_todo_snapshot_meta(
                         _deferred_meta,
                         conversation_id=conversation_id,
@@ -2327,7 +2437,6 @@ async def chat(request: Request, body: ChatRequest):
             status_code=400,
             content={"error": "empty_message", "message": "消息内容不能为空"},
         )
-
 
     try:
         pending_response = await _handle_pending_risk_answer(
@@ -3200,7 +3309,6 @@ async def chat_answer(request: Request, body: ChatAnswerRequest):
         "answer": body.answer,
         "hint": "No pending risk confirmation matched this conversation_id and answer.",
     }
-
 
 
 @router.get("/api/chat/busy")

--- a/src/openakita/tools/handlers/todo_handler.py
+++ b/src/openakita/tools/handlers/todo_handler.py
@@ -172,6 +172,18 @@ class PlanHandler:
             if not plan.get("summary"):
                 plan["summary"] = "用户主动取消"
             self._add_log("计划被用户取消", plan=plan)
+        elif action == "final_answer":
+            for step in steps:
+                status = step.get("status", "pending")
+                if status in ("in_progress", "pending"):
+                    step["status"] = "completed"
+                    step["result"] = step.get("result") or "(最终答复已生成)"
+                    step["completed_at"] = now
+            plan["status"] = "completed"
+            plan["completed_at"] = now
+            if not plan.get("summary"):
+                plan["summary"] = "任务结束，计划随最终答复自动完成"
+            self._add_log("计划随最终答复自动完成", plan=plan)
         else:  # auto_close
             for step in steps:
                 status = step.get("status", "pending")

--- a/src/openakita/tools/handlers/todo_state.py
+++ b/src/openakita/tools/handlers/todo_state.py
@@ -41,6 +41,7 @@ __all__ = [
     "clear_session_todo_state",
     "cleanup_session",
     "auto_close_todo",
+    "complete_todo_after_final_answer",
     "cancel_todo",
     "force_close_plan",
     "register_plan_handler",
@@ -232,6 +233,37 @@ def auto_close_todo(session_id: str) -> bool:
 
     handler.finalize_plan(plan, session_id, action="auto_close")
     logger.info(f"[Todo] Auto-closed todo for session {session_id}")
+
+    unregister_active_todo(session_id)
+    _emit_todo_lifecycle_event(session_id, "todo_completed", plan)
+    return True
+
+
+def complete_todo_after_final_answer(session_id: str) -> bool:
+    """
+    Close the active Todo after a normal final assistant answer has been produced.
+
+    ``auto_close_todo`` intentionally preserves plans that still have pending
+    steps so a genuine multi-turn plan can continue.  The chat API has stronger
+    context: when the turn ended with a visible final answer, no ask_user prompt,
+    and no agent error, leaving the active Todo registered makes history
+    hydration re-attach stale progress.  This finalizer is for that narrower
+    backend lifecycle point.
+
+    Returns:
+        True if an active Todo registration was closed, False if there was none.
+    """
+    if not has_active_todo(session_id):
+        return False
+
+    handler = get_todo_handler_for_session(session_id)
+    plan = handler.get_plan_for(session_id) if handler else None
+    if not handler or not plan:
+        unregister_active_todo(session_id)
+        return True
+
+    handler.finalize_plan(plan, session_id, action="final_answer")
+    logger.info(f"[Todo] Completed todo for session {session_id} after final answer")
 
     unregister_active_todo(session_id)
     _emit_todo_lifecycle_event(session_id, "todo_completed", plan)

--- a/tests/component/test_plan_handler.py
+++ b/tests/component/test_plan_handler.py
@@ -2,18 +2,75 @@
 
 import pytest
 
+from openakita.api.routes.chat import _complete_active_todo_after_final_answer
+from openakita.tools.handlers import todo_state
 from openakita.tools.handlers.plan import (
-    require_todo_for_session,
-    is_todo_required,
-    has_active_todo,
-    register_active_todo,
-    unregister_active_todo,
-    clear_session_todo_state,
+    PlanHandler,
     auto_close_todo,
     cancel_todo,
-    should_require_todo,
+    clear_session_todo_state,
+    complete_todo_after_final_answer,
     get_active_todo_prompt,
+    has_active_todo,
+    is_todo_required,
+    register_active_todo,
+    register_plan_handler,
+    require_todo_for_session,
+    should_require_todo,
+    unregister_active_todo,
 )
+
+
+class _DummyAgent:
+    def __init__(self, conversation_id: str):
+        self._current_conversation_id = conversation_id
+        self._current_session_id = conversation_id
+
+
+def _three_step_plan() -> dict:
+    return {
+        "id": "plan-final-answer",
+        "plan_type": "todo",
+        "task_summary": "Finish UI todo lifecycle",
+        "status": "in_progress",
+        "created_at": "2026-01-01T00:00:00",
+        "completed_at": None,
+        "logs": [],
+        "steps": [
+            {
+                "id": "s1",
+                "description": "Inspect",
+                "status": "completed",
+                "result": "ok",
+                "skills": [],
+            },
+            {
+                "id": "s2",
+                "description": "Patch",
+                "status": "completed",
+                "result": "ok",
+                "skills": [],
+            },
+            {
+                "id": "s3",
+                "description": "Verify",
+                "status": "pending",
+                "result": "",
+                "skills": [],
+            },
+        ],
+    }
+
+
+def _register_plan(monkeypatch: pytest.MonkeyPatch, tmp_path, sid: str) -> tuple[PlanHandler, dict]:
+    monkeypatch.setattr(PlanHandler, "_resolve_plan_dir", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(todo_state, "_emit_todo_lifecycle_event", lambda *args: None)
+    handler = PlanHandler(_DummyAgent(sid))
+    plan = _three_step_plan()
+    handler._todos_by_session[sid] = plan
+    register_active_todo(sid, plan["id"])
+    register_plan_handler(sid, handler)
+    return handler, plan
 
 
 class TestPlanSessionState:
@@ -51,6 +108,45 @@ class TestPlanSessionState:
         clear_session_todo_state(sid)
         result = auto_close_todo(sid)
         assert isinstance(result, bool)
+
+    def test_final_answer_completion_closes_pending_steps(self, monkeypatch, tmp_path):
+        sid = "test-plan-session-final-answer"
+        clear_session_todo_state(sid)
+        try:
+            _handler, plan = _register_plan(monkeypatch, tmp_path, sid)
+
+            result = complete_todo_after_final_answer(sid)
+
+            assert result is True
+            assert has_active_todo(sid) is False
+            assert plan["status"] == "completed"
+            assert [step["status"] for step in plan["steps"]] == [
+                "completed",
+                "completed",
+                "completed",
+            ]
+        finally:
+            clear_session_todo_state(sid)
+
+    def test_chat_final_answer_helper_records_completion_event(self, monkeypatch, tmp_path):
+        sid = "test-plan-session-chat-final-answer"
+        clear_session_todo_state(sid)
+        try:
+            _handler, plan = _register_plan(monkeypatch, tmp_path, sid)
+
+            snapshot, events = _complete_active_todo_after_final_answer(sid, plan, [])
+
+            assert has_active_todo(sid) is False
+            assert [event["type"] for event in events] == ["todo_completed"]
+            assert events[0]["planId"] == "plan-final-answer"
+            assert snapshot["status"] == "completed"
+            assert [step["status"] for step in snapshot["steps"]] == [
+                "completed",
+                "completed",
+                "completed",
+            ]
+        finally:
+            clear_session_todo_state(sid)
 
     def test_clear_state(self):
         sid = "test-plan-session-6"

--- a/tests/unit/test_message_parts.py
+++ b/tests/unit/test_message_parts.py
@@ -35,6 +35,12 @@ def _plan() -> dict:
     }
 
 
+def _plan_with_pending_step() -> dict:
+    plan = _plan()
+    plan["steps"].append({"id": "s3", "description": "verify", "status": "pending"})
+    return plan
+
+
 def test_serialize_plan_to_chat_todo_camelcases_and_keeps_steps():
     todo = serialize_plan_to_chat_todo(_plan())
     assert todo == {
@@ -159,6 +165,29 @@ def test_progress_event_journal_projects_latest_todo_state():
     assert todo["steps"][1]["result"] == "built"
 
 
+def test_progress_completion_terminalizes_pending_steps():
+    events = append_progress_event([], {"type": "todo_created", "plan": _plan_with_pending_step()})
+    events = append_progress_event(
+        events,
+        {
+            "type": "todo_step_updated",
+            "step_id": "s2",
+            "status": "completed",
+            "result": "built",
+        },
+    )
+    events = append_progress_event(events, {"type": "todo_completed"})
+
+    todo = project_progress_events_to_todo(events)
+
+    assert todo["status"] == "completed"
+    assert [step["status"] for step in todo["steps"]] == [
+        "completed",
+        "completed",
+        "completed",
+    ]
+
+
 def test_normalize_progress_events_preserves_lifecycle_plan_id():
     events = normalize_progress_events(
         [
@@ -179,9 +208,7 @@ def test_build_message_parts_inlines_progress_event_journal_on_plan_part():
         ]
     )
 
-    parts = build_message_parts(
-        {"role": "assistant", "content": "done", "progress_events": events}
-    )
+    parts = build_message_parts({"role": "assistant", "content": "done", "progress_events": events})
 
     plan = next(p for p in parts if p["kind"] == "plan")
     assert plan["todo"]["status"] == "completed"
@@ -197,7 +224,9 @@ def test_attach_todo_meta_persists_progress_event_journal():
     )
 
     meta = {}
-    _attach_todo_snapshot_meta(meta, conversation_id="conv1", todo_snapshot=None, progress_events=events)
+    _attach_todo_snapshot_meta(
+        meta, conversation_id="conv1", todo_snapshot=None, progress_events=events
+    )
 
     assert [e["type"] for e in meta["progress_events"]] == ["todo_created", "todo_completed"]
     assert meta["todo"]["status"] == "completed"
@@ -219,7 +248,7 @@ def test_extract_artifact_events_from_tool_and_delegation_results():
             "type": "tool_call_end",
             "tool": "delegate_to_agent",
             "result": (
-                'ok\n__ARTIFACT_RECEIPTS__\n'
+                "ok\n__ARTIFACT_RECEIPTS__\n"
                 '[{"status":"delivered","file_url":"/api/files/b","path":"b.txt","name":"b.txt"}]\n'
             ),
         }


### PR DESCRIPTION
## Summary
- Close active todo plans after normal final assistant answers so stale pending steps do not hydrate back into the floating todo list.
- Render todo progress only in the floating bar and keep message parts focused on text, tools, and reasoning, with a low-key skip action on the floating bar.
- Preserve final todo state in progress-event journals and add regression coverage for terminal projection.

## Tests
- `uv run --no-sync pytest tests/unit/test_message_parts.py tests/component/test_plan_handler.py`
- `uv run --no-sync ruff check src/openakita/api/routes/chat.py src/openakita/tools/handlers/todo_state.py src/openakita/tools/handlers/todo_handler.py tests/unit/test_message_parts.py tests/component/test_plan_handler.py`
- `uv run --no-sync ruff format --check src/openakita/api/routes/chat.py src/openakita/tools/handlers/todo_state.py src/openakita/tools/handlers/todo_handler.py tests/unit/test_message_parts.py tests/component/test_plan_handler.py`
- `npm run test:run -- src/views/chat/utils/__tests__/messageParts.test.ts src/views/chat/components/__tests__/FloatingPlanBar.test.tsx`
- `npx tsc -b`
- `npm run lint -- --quiet`
- `git diff --check`