### PR TITLE
Enable chat-driven organization changes to refresh the organization editor

### DIFF
--- a/apps/setup-center/src/streamEvents.ts
+++ b/apps/setup-center/src/streamEvents.ts
@@ -30,6 +30,7 @@ export const StreamEventType = {
   CONFIG_HINT: "config_hint",
   SOURCE_USED: "source_used",
   MCP_CALL: "mcp_call",
+  ORG_STRUCTURE_CHANGED: "org_structure_changed",
 
   // ── Context management ──
   CONTEXT_COMPRESSED: "context_compressed",

--- a/apps/setup-center/src/utils/__tests__/orgStructureEvents.test.ts
+++ b/apps/setup-center/src/utils/__tests__/orgStructureEvents.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ORG_STRUCTURE_CHANGED_EVENT,
+  dispatchOrgStructureChanged,
+  normalizeOrgStructureChange,
+} from "../orgStructureEvents";
+
+describe("orgStructureEvents", () => {
+  it("normalizes backend snake_case payloads", () => {
+    expect(normalizeOrgStructureChange({
+      action: "created",
+      org_id: "org_123",
+      org_name: "测试组织",
+      node_count: 3,
+      edge_count: 2,
+      tool_use_id: "call_1",
+    })).toEqual({
+      action: "created",
+      orgId: "org_123",
+      orgName: "测试组织",
+      templateId: undefined,
+      nodeCount: 3,
+      edgeCount: 2,
+      status: undefined,
+      toolUseId: "call_1",
+    });
+  });
+
+  it("dispatches a browser event only when org id is present", () => {
+    const listener = vi.fn();
+    window.addEventListener(ORG_STRUCTURE_CHANGED_EVENT, listener);
+    try {
+      expect(dispatchOrgStructureChanged({ action: "updated" })).toBe(false);
+      expect(dispatchOrgStructureChanged({ action: "updated", org_id: "org_abc" })).toBe(true);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].detail).toMatchObject({
+        action: "updated",
+        orgId: "org_abc",
+      });
+    } finally {
+      window.removeEventListener(ORG_STRUCTURE_CHANGED_EVENT, listener);
+    }
+  });
+});

--- a/apps/setup-center/src/utils/orgStructureEvents.ts
+++ b/apps/setup-center/src/utils/orgStructureEvents.ts
@@ -1,0 +1,52 @@
+export const ORG_STRUCTURE_CHANGED_EVENT = "openakita:org-structure-changed";
+
+export type OrgStructureChangeAction = "created" | "updated" | "deleted";
+
+export interface OrgStructureChangeDetail {
+  action: OrgStructureChangeAction;
+  orgId: string;
+  orgName?: string;
+  templateId?: string;
+  nodeCount?: number;
+  edgeCount?: number;
+  status?: string;
+  toolUseId?: string;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function normalizeOrgStructureChange(value: unknown): OrgStructureChangeDetail | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const orgId = stringValue(raw.org_id) || stringValue(raw.orgId);
+  if (!orgId) return null;
+
+  const rawAction = stringValue(raw.action) || "updated";
+  const action: OrgStructureChangeAction =
+    rawAction === "created" || rawAction === "deleted" ? rawAction : "updated";
+
+  return {
+    action,
+    orgId,
+    orgName: stringValue(raw.org_name) || stringValue(raw.orgName),
+    templateId: stringValue(raw.template_id) || stringValue(raw.templateId),
+    nodeCount: numberValue(raw.node_count ?? raw.nodeCount),
+    edgeCount: numberValue(raw.edge_count ?? raw.edgeCount),
+    status: stringValue(raw.status),
+    toolUseId: stringValue(raw.tool_use_id) || stringValue(raw.toolUseId),
+  };
+}
+
+export function dispatchOrgStructureChanged(value: unknown): boolean {
+  const detail = normalizeOrgStructureChange(value);
+  if (!detail) return false;
+  window.dispatchEvent(new CustomEvent<OrgStructureChangeDetail>(ORG_STRUCTURE_CHANGED_EVENT, { detail }));
+  return true;
+}

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -46,6 +46,7 @@ import type {
 import { genId, timeAgo } from "../utils";
 import { SseStateMachine, type SseFrame } from "../utils/sseStateMachine";
 import { notifyError, notifyInfo } from "../utils/notify";
+import { dispatchOrgStructureChanged } from "../utils/orgStructureEvents";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import {
   IconSend, IconPaperclip, IconMic, IconStopCircle,
@@ -4310,6 +4311,30 @@ export function ChatView({
                   error: event.error,
                 }];
                 break;
+              case "org_structure_changed": {
+                dispatchOrgStructureChanged(event);
+                const changedOrgId = String(event.org_id || "");
+                safeFetch(`${apiBase}/api/v2/orgs`)
+                  .then((r) => r.json())
+                  .then((data) => {
+                    if (!Array.isArray(data)) return;
+                    setOrgList(data.map((o: any) => ({
+                      id: o.id,
+                      name: o.name,
+                      icon: o.icon || "",
+                      status: o.status,
+                    })));
+                  })
+                  .catch(() => {});
+                if (changedOrgId) {
+                  if (event.action === "deleted") {
+                    setSelectedOrgId((prev) => prev === changedOrgId ? null : prev);
+                  } else {
+                    setSelectedOrgId(changedOrgId);
+                  }
+                }
+                break;
+              }
               case "agent_handoff": {
                 // P5.1: capture delegation parentage so SubAgentCards can render
                 // a tree.  We only record when the from_agent is non-empty,

--- a/apps/setup-center/src/views/OrgEditorView.tsx
+++ b/apps/setup-center/src/views/OrgEditorView.tsx
@@ -70,6 +70,11 @@ import { OrgDashboard } from "../components/OrgDashboard";
 import { OrgProjectBoard } from "../components/OrgProjectBoard";
 import { ZoomIn, ZoomOut, Maximize, X as XIcon, Copy as IconCopy } from "lucide-react";
 import { copyToClipboard } from "../utils/clipboard";
+import {
+  ORG_STRUCTURE_CHANGED_EVENT,
+  normalizeOrgStructureChange,
+  type OrgStructureChangeDetail,
+} from "../utils/orgStructureEvents";
 import { Button } from "../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
 import { Checkbox } from "../components/ui/checkbox";
@@ -924,6 +929,54 @@ export function OrgEditorView({
       fetchAgentProfiles();
     }
   }, [visible, fetchOrgList, fetchMcpServers, fetchAvailableSkills, fetchAgentProfiles]);
+
+  useEffect(() => {
+    const onOrgStructureChanged = (event: Event) => {
+      const detail = normalizeOrgStructureChange(
+        (event as CustomEvent<OrgStructureChangeDetail>).detail,
+      );
+      if (!detail) return;
+
+      void (async () => {
+        await fetchOrgList();
+        if (detail.action === "deleted") {
+          if (selectedOrgId === detail.orgId) {
+            if (saveTimerRef.current) { clearTimeout(saveTimerRef.current); saveTimerRef.current = null; }
+            setActiveDrawer(null);
+            setSelectedOrgId(null);
+            setCurrentOrg(null);
+            setNodes([]);
+            setEdges([]);
+          }
+          if (visible) showToast(t("org.editor.chatDeletedOrg", "聊天已删除组织"), "ok");
+          return;
+        }
+
+        setSelectedOrgId(detail.orgId);
+        if (visible) {
+          await fetchOrg(detail.orgId);
+          const name = detail.orgName || detail.orgId;
+          showToast(
+            detail.action === "created"
+              ? t("org.editor.chatCreatedOrg", "聊天已创建组织：{{name}}", { name })
+              : t("org.editor.chatUpdatedOrg", "聊天已更新组织：{{name}}", { name }),
+            "ok",
+          );
+        }
+      })();
+    };
+    window.addEventListener(ORG_STRUCTURE_CHANGED_EVENT, onOrgStructureChanged);
+    return () => window.removeEventListener(ORG_STRUCTURE_CHANGED_EVENT, onOrgStructureChanged);
+  }, [
+    fetchOrgList,
+    fetchOrg,
+    selectedOrgId,
+    setNodes,
+    setEdges,
+    showToast,
+    t,
+    visible,
+  ]);
 
   useEffect(() => {
     if (selectedOrgId && visible) {

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -159,6 +159,7 @@ export type StreamEvent =
     }
   | { type: "source_used"; tool_name?: string; tool_use_id?: string; requested_url: string; final_url: string; hostname?: string; redirected?: boolean; from_cache?: boolean; status?: string; hint?: string; protocol_version?: number }
   | { type: "mcp_call"; tool_use_id?: string; server: string; tool: string; status?: "ok" | "error" | string; auto_connected?: boolean; reconnected?: boolean; error?: string; protocol_version?: number }
+  | { type: "org_structure_changed"; action?: "created" | "updated" | "deleted" | string; org_id: string; org_name?: string; template_id?: string; node_count?: number; edge_count?: number; status?: string; tool_use_id?: string; protocol_version?: number }
   | { type: "todo_created"; plan: ChatTodo; restored?: boolean }
   | { type: "todo_step_updated"; planId?: string; plan_id?: string; stepId?: string; step_id?: string; stepIdx?: number; status: string; result?: string | null; protocol_version?: number }
   | { type: "todo_completed"; planId?: string; plan_id?: string }

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -667,6 +667,41 @@ def _extract_mcp_call(event: dict) -> dict | None:
     return payload
 
 
+def _extract_org_structure_change(event: dict) -> dict | None:
+    """Extract org create/update/delete metadata from setup_organization results."""
+    if event.get("type") != "tool_call_end":
+        return None
+    if (event.get("tool_name") or event.get("tool", "")) != "setup_organization":
+        return None
+    result = str(event.get("result", ""))
+    marker = "[OPENAKITA_ORG]"
+    if marker not in result:
+        return None
+    try:
+        line = result[result.index(marker) + len(marker) :].strip().splitlines()[0].strip()
+        payload = json.loads(line)
+    except (json.JSONDecodeError, TypeError, ValueError, IndexError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    payload.setdefault("tool_use_id", event.get("call_id") or event.get("id", ""))
+    payload.setdefault("action", "updated")
+    payload.setdefault("org_id", "")
+    payload.setdefault("org_name", "")
+    return payload
+
+
+def _strip_org_structure_marker(event: dict) -> dict:
+    """Hide the OpenAkita org marker from frontend tool-result rendering."""
+    result = event.get("result")
+    if not isinstance(result, str) or "[OPENAKITA_ORG]" not in result:
+        return event
+    next_event = dict(event)
+    lines = [line for line in result.splitlines() if not line.strip().startswith("[OPENAKITA_ORG]")]
+    next_event["result"] = "\n".join(lines).rstrip()
+    return next_event
+
+
 def _artifact_data_from_receipt(receipt: dict) -> dict | None:
     """Convert one delivery receipt into the chat artifact shape."""
     if not isinstance(receipt, dict):
@@ -1527,6 +1562,9 @@ async def _stream_chat(
 
             await _refresh_busy_lease()
             event_type = event.get("type", "")
+            _org_structure_change = _extract_org_structure_change(event)
+            if _org_structure_change:
+                event = _strip_org_structure_marker(event)
 
             # Observe every raw event (before coalescing / disconnect gating) so
             # the persisted timeline is complete regardless of wire state.
@@ -1609,6 +1647,10 @@ async def _stream_chat(
 
             if _mcp_call:
                 yield _sse("mcp_call", _mcp_call)
+                _last_emit_ts = time.time()
+
+            if _org_structure_change:
+                yield _sse("org_structure_changed", _org_structure_change)
                 _last_emit_ts = time.time()
 
             for art_data in _new_artifacts:

--- a/src/openakita/events.py
+++ b/src/openakita/events.py
@@ -38,6 +38,7 @@ class StreamEventType(StrEnum):
     CONFIG_HINT = "config_hint"
     SOURCE_USED = "source_used"
     MCP_CALL = "mcp_call"
+    ORG_STRUCTURE_CHANGED = "org_structure_changed"
 
     # ── Context management ──
     CONTEXT_COMPRESSED = "context_compressed"
@@ -111,6 +112,12 @@ def normalize_stream_event(event: dict | None) -> dict:
         payload.setdefault("auto_connected", False)
         payload.setdefault("reconnected", False)
         payload.setdefault("error", "")
+
+    if event_type == StreamEventType.ORG_STRUCTURE_CHANGED.value:
+        payload.setdefault("tool_use_id", payload.get("id", payload.get("call_id", "")))
+        payload.setdefault("action", "updated")
+        payload.setdefault("org_id", "")
+        payload.setdefault("org_name", "")
 
     if event_type == StreamEventType.SECURITY_CONFIRM.value:
         payload.setdefault("tool_name", payload.get("tool", ""))

--- a/src/openakita/orgs/store.py
+++ b/src/openakita/orgs/store.py
@@ -75,6 +75,7 @@ __all__ = [
     "JsonOrgStore",
     "OrgNotFound",
     "get_default_store",
+    "get_default_org_manager",
     "reset_default_store",
     "set_default_org_manager",
 ]
@@ -120,6 +121,12 @@ def set_default_org_manager(manager: OrgManager | None) -> None:
         _DEFAULT_MANAGER = manager
         if _DEFAULT_STORE is not None and isinstance(_DEFAULT_STORE, JsonOrgStore):
             _DEFAULT_STORE._set_manager(manager)
+
+
+def get_default_org_manager() -> OrgManager | None:
+    """Return the process-wide :class:`OrgManager` override, if one is wired."""
+    with _DEFAULT_MANAGER_LOCK:
+        return _DEFAULT_MANAGER
 
 
 def _build_default_manager() -> OrgManager:

--- a/src/openakita/tools/handlers/org_setup.py
+++ b/src/openakita/tools/handlers/org_setup.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...core.policy_v2 import ApprovalClass
@@ -36,6 +37,14 @@ _VALID_ACTIONS = (
     "update_org",
     "delete_org",
 )
+
+_ORG_EVENT_MARKER = "[OPENAKITA_ORG]"
+
+
+def _with_org_event_marker(result: str, payload: dict[str, Any]) -> str:
+    """Append a machine-readable org-change marker for the chat SSE layer."""
+    marker = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return f"{result}\n\n{_ORG_EVENT_MARKER} {marker}"
 
 
 class OrgSetupHandler:
@@ -352,13 +361,21 @@ class OrgSetupHandler:
         try:
             org = manager.create(org_data)
             edge_summary = self._format_edge_summary(org.edges)
-            return (
+            return _with_org_event_marker(
                 f"✅ 组织「{org.name}」创建成功！\n"
                 f"- ID: {org.id}\n"
                 f"- 节点数: {len(org.nodes)}\n"
                 f"- 连线: {edge_summary}\n"
                 f"- 状态: dormant（需在前端启动）\n\n"
-                f"用户可在组织编排页面查看和微调架构。"
+                f"用户可在组织编排页面查看和微调架构。",
+                {
+                    "action": "created",
+                    "org_id": org.id,
+                    "org_name": org.name,
+                    "node_count": len(org.nodes),
+                    "edge_count": len(org.edges),
+                    "status": org.status.value if hasattr(org.status, "value") else org.status,
+                },
             )
         except Exception as e:
             logger.error(f"[OrgSetup] Failed to create org: {e}", exc_info=True)
@@ -381,12 +398,21 @@ class OrgSetupHandler:
 
         try:
             org = manager.create_from_template(template_id, overrides)
-            return (
+            return _with_org_event_marker(
                 f"✅ 从模板「{template_id}」创建组织成功！\n"
                 f"- 名称: {org.name}\n"
                 f"- ID: {org.id}\n"
                 f"- 节点数: {len(org.nodes)}\n"
-                f"- 状态: dormant（需在前端启动）"
+                f"- 状态: dormant（需在前端启动）",
+                {
+                    "action": "created",
+                    "org_id": org.id,
+                    "org_name": org.name,
+                    "template_id": template_id,
+                    "node_count": len(org.nodes),
+                    "edge_count": len(org.edges),
+                    "status": org.status.value if hasattr(org.status, "value") else org.status,
+                },
             )
         except FileNotFoundError:
             return f"❌ 模板 '{template_id}' 不存在。请先调用 get_resources 查看可用模板。"
@@ -655,10 +681,18 @@ class OrgSetupHandler:
 
             summary = "\n".join(f"  {i + 1}. {c}" for i, c in enumerate(changes))
             edge_summary = self._format_edge_summary(org.edges)
-            return (
+            return _with_org_event_marker(
                 f"✅ 组织「{org.name}」修改成功！\n\n"
                 f"变更摘要：\n{summary}\n\n"
-                f"当前节点数: {len(org.nodes)} | 连线: {edge_summary}"
+                f"当前节点数: {len(org.nodes)} | 连线: {edge_summary}",
+                {
+                    "action": "updated",
+                    "org_id": org.id,
+                    "org_name": org.name,
+                    "node_count": len(org.nodes),
+                    "edge_count": len(org.edges),
+                    "status": org.status.value if hasattr(org.status, "value") else org.status,
+                },
             )
         except Exception as e:
             logger.error(f"[OrgSetup] Failed to update org: {e}", exc_info=True)
@@ -679,7 +713,13 @@ class OrgSetupHandler:
         if rt is not None:
             try:
                 await rt.delete_org(org_id)
-                return f"✅ 组织({org_id}) 已永久删除。"
+                return _with_org_event_marker(
+                    f"✅ 组织({org_id}) 已永久删除。",
+                    {
+                        "action": "deleted",
+                        "org_id": org_id,
+                    },
+                )
             except ValueError:
                 return f"❌ 组织 '{org_id}' 不存在"
             except Exception as e:
@@ -697,7 +737,14 @@ class OrgSetupHandler:
         org_name = org.name
         try:
             manager.delete(org_id)
-            return f"✅ 组织「{org_name}」({org_id}) 已永久删除。"
+            return _with_org_event_marker(
+                f"✅ 组织「{org_name}」({org_id}) 已永久删除。",
+                {
+                    "action": "deleted",
+                    "org_id": org_id,
+                    "org_name": org_name,
+                },
+            )
         except Exception as e:
             logger.error(f"[OrgSetup] Failed to delete org: {e}", exc_info=True)
             return f"❌ 删除失败: {e}"
@@ -711,9 +758,18 @@ class OrgSetupHandler:
         from ...config import settings
 
         try:
+            from ...orgs.store import get_default_org_manager
+
+            base_dir = Path(settings.data_dir)
+            default_manager = get_default_org_manager()
+            if default_manager is not None:
+                default_data_dir = getattr(default_manager, "_data_dir", None)
+                if default_data_dir is not None and Path(default_data_dir) == base_dir:
+                    return default_manager
+
             from ...orgs.manager import OrgManager
 
-            return OrgManager(settings.data_dir)
+            return OrgManager(base_dir)
         except Exception as e:
             logger.error(f"[OrgSetup] Cannot get OrgManager: {e}")
             return None

--- a/tests/unit/test_chat_org_structure_event.py
+++ b/tests/unit/test_chat_org_structure_event.py
@@ -1,0 +1,42 @@
+"""Regression coverage for chat-to-org-editor refresh events."""
+
+from __future__ import annotations
+
+from openakita.api.routes.chat import (
+    _extract_org_structure_change,
+    _strip_org_structure_marker,
+)
+
+
+def test_extract_org_structure_change_from_setup_organization_marker():
+    event = {
+        "type": "tool_call_end",
+        "tool": "setup_organization",
+        "id": "call_1",
+        "result": (
+            "✅ 组织「测试组织」创建成功！\n\n"
+            '[OPENAKITA_ORG] {"action":"created","org_id":"org_123","org_name":"测试组织"}'
+        ),
+    }
+
+    payload = _extract_org_structure_change(event)
+
+    assert payload == {
+        "action": "created",
+        "org_id": "org_123",
+        "org_name": "测试组织",
+        "tool_use_id": "call_1",
+    }
+
+
+def test_strip_org_structure_marker_keeps_user_facing_result_clean():
+    event = {
+        "type": "tool_call_end",
+        "tool": "setup_organization",
+        "result": "完成\n\n[OPENAKITA_ORG] {\"action\":\"updated\",\"org_id\":\"org_123\"}",
+    }
+
+    stripped = _strip_org_structure_marker(event)
+
+    assert stripped["result"] == "完成"
+    assert event["result"].endswith('{"action":"updated","org_id":"org_123"}')

--- a/tests/unit/test_org_setup_tool.py
+++ b/tests/unit/test_org_setup_tool.py
@@ -258,6 +258,12 @@ class TestCreate:
         assert "✅" in result
         assert "测试组织" in result
         assert "节点数: 2" in result
+        assert "[OPENAKITA_ORG]" in result
+        marker = result.split("[OPENAKITA_ORG]", 1)[1].strip().splitlines()[0]
+        payload = json.loads(marker)
+        assert payload["action"] == "created"
+        assert payload["org_id"].startswith("org_")
+        assert payload["org_name"] == "测试组织"
         assert "连线:" in result
 
     @pytest.mark.asyncio
@@ -447,6 +453,42 @@ class TestListOrgs:
             ms.data_dir = tmp_data_dir
             result = handler._list_orgs()
         assert "没有任何组织" in result
+
+    def test_ignores_default_manager_for_different_data_dir(self, handler, tmp_path):
+        from openakita.orgs.manager import OrgManager
+        from openakita.orgs.store import set_default_org_manager
+
+        stale_manager = OrgManager(tmp_path / "stale")
+        stale_manager.create({"name": "stale org"})
+
+        try:
+            set_default_org_manager(stale_manager)
+            with patch("openakita.config.settings") as ms:
+                ms.data_dir = tmp_path / "current"
+                result = handler._list_orgs()
+        finally:
+            set_default_org_manager(None)
+
+        assert "没有任何组织" in result
+        assert "stale org" not in result
+
+    def test_reuses_default_manager_for_same_data_dir(self, handler, tmp_path):
+        from openakita.orgs.manager import OrgManager
+        from openakita.orgs.store import set_default_org_manager
+
+        shared_manager = OrgManager(tmp_path / "shared")
+        org = shared_manager.create({"name": "shared org"})
+
+        try:
+            set_default_org_manager(shared_manager)
+            with patch("openakita.config.settings") as ms:
+                ms.data_dir = tmp_path / "shared"
+                result = handler._list_orgs()
+        finally:
+            set_default_org_manager(None)
+
+        assert "shared org" in result
+        assert org.id in result
 
     def test_list_returns_existing(self, handler, tmp_data_dir, created_org):
         org_id, data_dir = created_org


### PR DESCRIPTION
## Summary
- Emit structured organization-change metadata from `setup_organization` and translate it into `org_structure_changed` SSE events.
- Refresh chat and organization editor state so chat-created or updated organizations appear and are selected without parsing localized tool text.

## Tests
- `uv run --no-sync pytest tests/unit/test_chat_org_structure_event.py tests/unit/test_org_setup_tool.py -q`
- `uv run --no-sync ruff check src/openakita/api/routes/chat.py src/openakita/events.py src/openakita/tools/handlers/org_setup.py src/openakita/orgs/store.py tests/unit/test_chat_org_structure_event.py tests/unit/test_org_setup_tool.py`
- `npx vitest run --pool=vmThreads --maxWorkers=1 src/utils/__tests__/orgStructureEvents.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/views/ChatView.tsx src/views/OrgEditorView.tsx src/utils/orgStructureEvents.ts src/utils/__tests__/orgStructureEvents.test.ts --max-warnings=9999` (warnings only; no errors)
- Closes #687