### PR TITLE
Surface realtime sub-agent streams in desktop progress cards

### DIFF
--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -5568,6 +5568,62 @@ button.btnApplyRestart:hover {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
 }
+.sacStreamOutput {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line, rgba(255,255,255,0.06));
+}
+.sacStreamLabel {
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--fg, #e2e8f0);
+  opacity: 0.55;
+}
+.sacStreamText {
+  max-height: 92px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--fg, #e2e8f0);
+  opacity: 0.82;
+}
+.sacStreamList {
+  display: grid;
+  gap: 4px;
+  max-height: 148px;
+  overflow-y: auto;
+}
+.sacStreamItem {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 6px;
+  align-items: start;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--fg, #e2e8f0);
+  opacity: 0.72;
+}
+.sacStreamItem > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sacStreamKind {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+  color: var(--brand);
+  opacity: 0.72;
+}
+.sacStreamThinking {
+  opacity: 0.62;
+}
+.sacStreamError {
+  color: #f87171;
+}
 
 /* Light theme overrides for sub-agent cards */
 :root[data-theme="light"] .sacCard,
@@ -5612,6 +5668,14 @@ button.btnApplyRestart:hover {
 :root[data-theme="light"] .sacToolBlink,
 [data-theme="light"] .sacToolBlink {
   background: #2563eb;
+}
+:root[data-theme="light"] .sacStreamOutput,
+[data-theme="light"] .sacStreamOutput {
+  border-top-color: rgba(0,0,0,0.08);
+}
+:root[data-theme="light"] .sacStreamError,
+[data-theme="light"] .sacStreamError {
+  color: #dc2626;
 }
 
 /* ──────────────────────────────────────────────────

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -111,6 +111,369 @@ function _asFiniteCount(value: unknown): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
 }
 
+type SubAgentStreamPayload = {
+  conversation_id?: string;
+  session_id?: string;
+  chat_id?: string;
+  run_id?: string;
+  agent_id?: string;
+  profile_id?: string;
+  parent_agent_id?: string;
+  name?: string;
+  icon?: string;
+  reason?: string;
+  event?: StreamEvent & Record<string, unknown>;
+};
+
+const SUB_AGENT_STREAM_TEXT_CAP = 4000;
+
+function _subAgentTaskKey(task: Pick<SubAgentTask, "agent_id" | "run_id">): string {
+  return task.run_id || task.agent_id;
+}
+
+function _sameSubAgentTask(
+  a: Pick<SubAgentTask, "agent_id" | "run_id">,
+  b: Pick<SubAgentTask, "agent_id" | "run_id">,
+): boolean {
+  const ak = _subAgentTaskKey(a);
+  const bk = _subAgentTaskKey(b);
+  return !!ak && !!bk && ak === bk;
+}
+
+function _mergeSubAgentTask(existing: SubAgentTask | undefined, patch: SubAgentTask): SubAgentTask {
+  if (!existing) return patch;
+  return {
+    ...existing,
+    ...patch,
+    chain: patch.chain ?? existing.chain,
+    stream_text: patch.stream_text ?? existing.stream_text,
+    stream_preview: patch.stream_preview ?? existing.stream_preview,
+    stream_events: patch.stream_events ?? existing.stream_events,
+    last_stream_event_at: patch.last_stream_event_at ?? existing.last_stream_event_at,
+  };
+}
+
+function _mergeSubAgentTaskPatch(prev: SubAgentTask[], patch: SubAgentTask): SubAgentTask[] {
+  const idx = prev.findIndex((t) => _sameSubAgentTask(t, patch));
+  if (idx < 0) return [...prev, patch];
+  return prev.map((t, i) => i === idx ? _mergeSubAgentTask(t, patch) : t);
+}
+
+function _mergeSubAgentTaskList(existing: SubAgentTask[], incoming: SubAgentTask[]): SubAgentTask[] {
+  let merged = [...existing];
+  for (const task of incoming) {
+    merged = _mergeSubAgentTaskPatch(merged, task);
+  }
+  return merged;
+}
+
+function _subAgentToolCallsFromEntries(entries: ChainEntry[]): ChainToolCall[] {
+  const order: string[] = [];
+  const byId = new Map<string, ChainToolCall>();
+  for (const entry of entries) {
+    if (entry.kind === "tool_start") {
+      const key = entry.toolId || `${entry.tool}-${order.length}`;
+      if (!byId.has(key)) order.push(key);
+      byId.set(key, {
+        toolId: entry.toolId,
+        tool: entry.tool,
+        args: entry.args,
+        status: entry.status === "done" || entry.status === "error" ? entry.status : "running",
+        description: entry.description,
+      });
+    } else if (entry.kind === "tool_end") {
+      const key = entry.toolId || order[order.length - 1];
+      const prev = key ? byId.get(key) : undefined;
+      if (prev) {
+        prev.result = entry.result;
+        prev.status = entry.status;
+      }
+    }
+  }
+  return order.map((key) => byId.get(key)).filter((value): value is ChainToolCall => Boolean(value));
+}
+
+function _withSubAgentGroup(
+  groups: ChainGroup[],
+  iteration?: number,
+): { groups: ChainGroup[]; current: ChainGroup } {
+  if (typeof iteration === "number") {
+    const newGroup: ChainGroup = {
+      iteration,
+      entries: [],
+      toolCalls: [],
+      hasThinking: false,
+      collapsed: false,
+    };
+    return { groups: [...groups, newGroup], current: newGroup };
+  }
+  if (groups.length > 0) return { groups, current: groups[groups.length - 1] };
+  const initial: ChainGroup = {
+    iteration: 1,
+    entries: [],
+    toolCalls: [],
+    hasThinking: false,
+    collapsed: false,
+  };
+  return { groups: [initial], current: initial };
+}
+
+function _replaceLastSubAgentGroup(groups: ChainGroup[], group: ChainGroup): ChainGroup[] {
+  if (!groups.length) return [group];
+  return groups.map((item, index) => index === groups.length - 1 ? group : item);
+}
+
+function _appendSubAgentText(current: string | undefined, delta: string): string {
+  const next = `${current || ""}${delta}`;
+  return next.length > SUB_AGENT_STREAM_TEXT_CAP ? next.slice(-SUB_AGENT_STREAM_TEXT_CAP) : next;
+}
+
+function _safeConfigHintErrorCode(value: unknown): "missing_credential" | "auth_failed" | "rate_limited" | "network_unreachable" | "content_filter" | "unknown" {
+  return value === "missing_credential" ||
+    value === "auth_failed" ||
+    value === "rate_limited" ||
+    value === "network_unreachable" ||
+    value === "content_filter" ||
+    value === "unknown"
+    ? value
+    : "unknown";
+}
+
+function _applySubAgentStreamEvent(
+  task: SubAgentTask,
+  event: StreamEvent & Record<string, unknown>,
+): SubAgentTask {
+  const now = Date.now();
+  let next: SubAgentTask = {
+    ...task,
+    stream_events: (task.stream_events || 0) + 1,
+    last_stream_event_at: now,
+  };
+  let groups = (task.chain ?? []).map((group) => ({
+    ...group,
+    entries: [...group.entries],
+    toolCalls: [...group.toolCalls],
+  }));
+
+  const setCurrentGroup = (group: ChainGroup) => {
+    group.toolCalls = _subAgentToolCallsFromEntries(group.entries);
+    groups = _replaceLastSubAgentGroup(groups, group);
+    next = { ...next, chain: groups };
+  };
+
+  const appendProcessText = (content: string, icon?: string) => {
+    const text = content.trim();
+    if (!text) return;
+    const created = _withSubAgentGroup(groups);
+    groups = created.groups;
+    setCurrentGroup({
+      ...created.current,
+      entries: [
+        ...created.current.entries,
+        { kind: "text", content: text, ...(icon ? { icon } : {}) },
+      ],
+    });
+  };
+
+  switch (event.type) {
+    case "iteration_start": {
+      const created = _withSubAgentGroup(groups, Number(event.iteration || groups.length + 1));
+      groups = created.groups;
+      next = { ...next, iteration: Number(event.iteration || groups.length), chain: groups };
+      break;
+    }
+    case "thinking_start": {
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      next = { ...next, chain: groups };
+      break;
+    }
+    case "thinking_delta": {
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      const group = created.current;
+      const entries = [...group.entries];
+      const last = entries[entries.length - 1];
+      if (last?.kind === "thinking") {
+        entries[entries.length - 1] = { kind: "thinking", content: _appendSubAgentText(last.content, event.content || "") };
+      } else {
+        entries.push({ kind: "thinking", content: String(event.content || "") });
+      }
+      setCurrentGroup({ ...group, entries, hasThinking: true });
+      break;
+    }
+    case "thinking_end": {
+      if (groups.length > 0) {
+        const group = groups[groups.length - 1];
+        setCurrentGroup({
+          ...group,
+          durationMs: typeof event.duration_ms === "number" ? event.duration_ms : group.durationMs,
+          hasThinking: Boolean(event.has_thinking ?? group.hasThinking),
+        });
+      }
+      break;
+    }
+    case "chain_text": {
+      appendProcessText(String(event.content || ""), event.icon ? String(event.icon) : undefined);
+      break;
+    }
+    case "text_delta": {
+      const text = _appendSubAgentText(next.stream_text, event.content || "");
+      next = { ...next, stream_text: text, stream_preview: text.slice(-300) };
+      break;
+    }
+    case "text_replace": {
+      const text = String(event.content || "").slice(-SUB_AGENT_STREAM_TEXT_CAP);
+      next = { ...next, stream_text: text, stream_preview: text.slice(-300) };
+      break;
+    }
+    case "tool_call_start": {
+      const toolName = String(event.tool_name || event.tool || "");
+      const toolId = String(event.call_id || event.id || `${toolName}-${now}`);
+      const args = event.args && typeof event.args === "object" ? event.args as Record<string, unknown> : {};
+      const description = String(event.friendly_message || formatToolDescription(toolName, args));
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      setCurrentGroup({
+        ...created.current,
+        entries: [
+          ...created.current.entries,
+          { kind: "tool_start", toolId, tool: toolName, args, description, status: "running" },
+        ],
+      });
+      next = {
+        ...next,
+        current_tool_summary: description || toolName,
+        tools_executed: [...(next.tools_executed || []), toolName].slice(-20),
+        tools_total: Math.max((next.tools_total || 0) + 1, next.tools_total || 0),
+      };
+      break;
+    }
+    case "tool_call_end": {
+      const toolName = String(event.tool_name || event.tool || "");
+      const toolId = String(event.call_id || event.id || "");
+      const result = String(event.result_summary || event.result || "").slice(0, 500);
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      const status: "error" | "done" = event.is_error ? "error" : "done";
+      const entries = created.current.entries.map((entry) =>
+        entry.kind === "tool_start" && (!toolId || entry.toolId === toolId)
+          ? { ...entry, status }
+          : entry,
+      );
+      setCurrentGroup({
+        ...created.current,
+        entries: [
+          ...entries,
+          { kind: "tool_end", toolId, tool: toolName, result, status },
+        ],
+      });
+      next = { ...next, current_tool_summary: result || toolName };
+      break;
+    }
+    case "config_hint": {
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      setCurrentGroup({
+        ...created.current,
+        entries: [
+          ...created.current.entries,
+          {
+            kind: "config_hint",
+            toolId: String(event.tool_use_id || ""),
+            hint: {
+              scope: String(event.scope || ""),
+              error_code: _safeConfigHintErrorCode(event.error_code),
+              title: String(event.title || ""),
+              ...(event.message ? { message: String(event.message) } : {}),
+              ...(Array.isArray(event.actions) ? { actions: event.actions as Record<string, unknown>[] } : {}),
+            },
+          },
+        ],
+      });
+      break;
+    }
+    case "context_compressed": {
+      const created = _withSubAgentGroup(groups);
+      groups = created.groups;
+      setCurrentGroup({
+        ...created.current,
+        entries: [
+          ...created.current.entries,
+          {
+            kind: "compressed",
+            beforeTokens: Number(event.before_tokens || 0),
+            afterTokens: Number(event.after_tokens || 0),
+          },
+        ],
+      });
+      break;
+    }
+    case "source_used": {
+      const label = String(event.hostname || event.final_url || event.requested_url || "");
+      const suffix = event.from_cache ? " (cache)" : "";
+      appendProcessText(`来源 ${label}${suffix}`, "src");
+      break;
+    }
+    case "mcp_call": {
+      const target = `${String(event.server || "")}/${String(event.tool || "")}`.replace(/^\/|\/$/g, "");
+      const status = String(event.status || "");
+      const err = String(event.error || "");
+      appendProcessText(`MCP ${target}${status ? `: ${status}` : ""}${err ? ` - ${err}` : ""}`, "mcp");
+      break;
+    }
+    case "artifact": {
+      const label = String(event.name || event.path || event.file_url || "");
+      appendProcessText(`生成文件 ${label}`, "file");
+      break;
+    }
+    case "security_confirm": {
+      appendProcessText(`等待安全确认: ${String(event.tool || event.confirm_id || "")}`, "sec");
+      break;
+    }
+    case "budget_warning":
+      appendProcessText(String(event.message || event.level || "任务预算接近限制"), "bud");
+      break;
+    case "budget_exceeded":
+      appendProcessText(String(event.message || "任务预算已用尽"), "bud");
+      break;
+    case "task_checkpoint":
+      appendProcessText(String(event.summary || event.next_step_hint || "已保存任务检查点"), "chk");
+      break;
+    case "todo_created": {
+      const plan = _asRecord(event.plan);
+      appendProcessText(String(plan.title || plan.summary || "已创建待办计划"), "todo");
+      break;
+    }
+    case "todo_step_updated":
+      appendProcessText(String(event.result || event.status || "待办步骤已更新"), "todo");
+      break;
+    case "todo_completed":
+      appendProcessText("待办计划已完成", "todo");
+      break;
+    case "todo_cancelled":
+      appendProcessText("待办计划已取消", "todo");
+      break;
+    case "death_switch":
+      appendProcessText(String(event.reason || "自保护状态已变化"), "sec");
+      break;
+    case "ask_user":
+      appendProcessText(`等待用户输入: ${String(event.question || "")}`, "ask");
+      next = { ...next, current_tool_summary: String(event.question || "") };
+      break;
+    case "error":
+      appendProcessText(String(event.message || "子 Agent 出错"), "err");
+      next = { ...next, status: "error", current_tool_summary: String(event.message || "") };
+      break;
+    case "done":
+      next = { ...next, current_tool_summary: String(event.reason || "") || next.current_tool_summary };
+      break;
+    default:
+      break;
+  }
+  return next;
+}
+
 function _hasOwn(record: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
 }
@@ -723,6 +1086,10 @@ export function ChatView({
   const [lightbox, setLightbox] = useState<{ url: string; downloadUrl: string; name: string } | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null);
   const [securityConfirm, setSecurityConfirm] = useState<SecurityConfirmData | null>(null);
+  const securityConfirmRef = useRef<SecurityConfirmData | null>(null);
+  useEffect(() => {
+    securityConfirmRef.current = securityConfirm;
+  }, [securityConfirm]);
   // Backend-owned queued count from UIConfirmBus presentation state. The
   // frontend does not keep its own queue or decide RiskGate priority.
   const [securityQueueLen, setSecurityQueueLen] = useState(0);
@@ -2140,11 +2507,16 @@ export function ChatView({
       if (event !== "confirm_revoked") return;
       const convId = String(data.session_id || "");
       const activeConvId = activeConvIdRef.current || "";
-      if (convId && activeConvId && convId !== activeConvId) return;
       const confirmId = String(data.confirm_id || "");
+      const matchedCurrent = Boolean(
+        confirmId && securityConfirmRef.current?.toolId === confirmId,
+      );
       setSecurityConfirm((prev) => (
-        prev && prev.toolId === confirmId ? null : prev
+        prev && prev.toolId === confirmId
+          ? null
+          : prev
       ));
+      if (!matchedCurrent && convId && activeConvId && convId !== activeConvId) return;
       setSecurityQueueLen(_asFiniteCount(data.queued_count));
     });
   }, []);
@@ -2173,14 +2545,57 @@ export function ChatView({
         ? { ...patch, parent_agent_id: patch.parent_agent_id || inferredParent }
         : patch;
 
-      const idx = ctx.subAgentTasks.findIndex((t) => t.agent_id === enrichedPatch.agent_id);
-      if (idx >= 0) {
-        ctx.subAgentTasks = ctx.subAgentTasks.map((t, i) =>
-          i === idx ? { ...t, ...enrichedPatch } : t,
-        );
-      } else if (enrichedPatch.status === "starting" || enrichedPatch.status === "running") {
-        ctx.subAgentTasks = [...ctx.subAgentTasks, enrichedPatch];
+      if (enrichedPatch.status === "starting" || enrichedPatch.status === "running") {
+        ctx.subAgentTasks = _mergeSubAgentTaskPatch(ctx.subAgentTasks, enrichedPatch);
+      } else {
+        const idx = ctx.subAgentTasks.findIndex((t) => _sameSubAgentTask(t, enrichedPatch));
+        if (idx >= 0) {
+          ctx.subAgentTasks = _mergeSubAgentTaskPatch(ctx.subAgentTasks, enrichedPatch);
+        }
       }
+      if (activeConvIdRef.current === convId) {
+        setDisplaySubAgentTasks([...ctx.subAgentTasks]);
+      }
+    });
+  }, []);
+
+  // ── Sub-agent detailed real-time stream via WebSocket ──
+  useEffect(() => {
+    return onWsEvent((event, raw) => {
+      if (event !== "agents:sub_stream") return;
+      const payload = raw as SubAgentStreamPayload | null;
+      if (!payload?.agent_id || !payload.event) return;
+
+      const convId = activeConvIdRef.current;
+      if (!convId) return;
+      const chatId = String(payload.chat_id || payload.conversation_id || payload.session_id || "");
+      if (chatId && chatId !== convId) return;
+
+      const ctx = streamContexts.current.get(convId);
+      if (!ctx) return;
+
+      const baseTask: SubAgentTask = {
+        run_id: payload.run_id || payload.agent_id,
+        agent_id: payload.agent_id,
+        profile_id: payload.profile_id || payload.agent_id,
+        session_id: payload.session_id || chatId || convId,
+        chat_id: chatId || convId,
+        name: payload.name || payload.agent_id,
+        icon: payload.icon || "🤖",
+        status: "running",
+        iteration: 0,
+        tools_executed: [],
+        tools_total: 0,
+        elapsed_s: 0,
+        last_progress_s: 0,
+        started_at: Date.now() / 1000,
+        parent_agent_id: payload.parent_agent_id || undefined,
+        reason: payload.reason || undefined,
+      } as SubAgentTask;
+      const existing = ctx.subAgentTasks.find((t) => _sameSubAgentTask(t, baseTask));
+      const mergedBase = _mergeSubAgentTask(existing, baseTask);
+      const patched = _applySubAgentStreamEvent(mergedBase, payload.event);
+      ctx.subAgentTasks = _mergeSubAgentTaskPatch(ctx.subAgentTasks, patched);
       if (activeConvIdRef.current === convId) {
         setDisplaySubAgentTasks([...ctx.subAgentTasks]);
       }
@@ -3884,8 +4299,11 @@ export function ChatView({
                       .then((r) => r.json())
                       .then((rawData: SubAgentTask[]) => {
                         if (!Array.isArray(rawData)) return;
-                        const data = enrichTasksWithParents(rawData);
                         const c = streamContexts.current.get(thisConvId);
+                        const data = _mergeSubAgentTaskList(
+                          c?.subAgentTasks ?? [],
+                          enrichTasksWithParents(rawData),
+                        );
                         if (c) c.subAgentTasks = data;
                         if (activeConvIdRef.current === thisConvId) setDisplaySubAgentTasks(data);
                         logger.debug("Chat", "Sub-tasks poll result", {
@@ -3941,8 +4359,11 @@ export function ChatView({
                     .then((r) => r.json())
                     .then((rawData: SubAgentTask[]) => {
                       if (!Array.isArray(rawData)) return;
-                      const data = enrichTasksWithParents(rawData);
                       const c = streamContexts.current.get(thisConvId);
+                      const data = _mergeSubAgentTaskList(
+                        c?.subAgentTasks ?? [],
+                        enrichTasksWithParents(rawData),
+                      );
                       if (c) c.subAgentTasks = data;
                       if (activeConvIdRef.current === thisConvId) setDisplaySubAgentTasks(data);
                       const allDone = data.length > 0 && data.every(
@@ -4752,7 +5173,10 @@ export function ChatView({
               .then((r) => r.json())
               .then((rawData: SubAgentTask[]) => {
                 if (!Array.isArray(rawData)) return;
-                const data = enrichTasksWithParents(rawData);
+                const c = streamContexts.current.get(thisConvId);
+                const current = c?.subAgentTasks ?? [];
+                const data = _mergeSubAgentTaskList(current, enrichTasksWithParents(rawData));
+                if (c) c.subAgentTasks = data;
                 if (activeConvIdRef.current === thisConvId) setDisplaySubAgentTasks(data);
                 const allDone = data.length > 0 && data.every(
                   (t) => t.status === "completed" || t.status === "error" || t.status === "timeout" || t.status === "cancelled"

--- a/apps/setup-center/src/views/chat/components/SubAgentCards.tsx
+++ b/apps/setup-center/src/views/chat/components/SubAgentCards.tsx
@@ -44,15 +44,19 @@ type TaskNode = {
 function buildForest(tasks: SubAgentTask[]): TaskNode[] {
   if (!tasks.length) return [];
   const byId = new Map<string, TaskNode>();
+  const byAgentId = new Map<string, TaskNode>();
   for (const task of tasks) {
-    byId.set(task.agent_id, { task, children: [] });
+    const node: TaskNode = { task, children: [] };
+    byId.set(task.run_id || task.agent_id, node);
+    if (!byAgentId.has(task.agent_id)) byAgentId.set(task.agent_id, node);
   }
   const roots: TaskNode[] = [];
   for (const task of tasks) {
-    const node = byId.get(task.agent_id)!;
+    const node = byId.get(task.run_id || task.agent_id)!;
     const parentId = task.parent_agent_id;
-    if (parentId && byId.has(parentId) && parentId !== task.agent_id) {
-      byId.get(parentId)!.children.push(node);
+    const parent = parentId ? byId.get(parentId) || byAgentId.get(parentId) : null;
+    if (parent && parent !== node && parentId !== task.agent_id) {
+      parent.children.push(node);
     } else {
       roots.push(node);
     }
@@ -74,18 +78,19 @@ export function SubAgentCards({ tasks }: { tasks: SubAgentTask[] }) {
   useEffect(() => {
     const timers = fadeTimersRef.current;
     for (const task of tasks) {
+      const taskKey = task.run_id || task.agent_id;
       const isDone = task.status === "completed" || task.status === "error" || task.status === "cancelled" || task.status === "timeout";
-      if (isDone && !fadedIdsRef.current.has(task.agent_id) && !timers.has(task.agent_id)) {
-        timers.set(task.agent_id, setTimeout(() => {
-          setFadedIds((prev) => new Set(prev).add(task.agent_id));
-          timers.delete(task.agent_id);
+      if (isDone && !fadedIdsRef.current.has(taskKey) && !timers.has(taskKey)) {
+        timers.set(taskKey, setTimeout(() => {
+          setFadedIds((prev) => new Set(prev).add(taskKey));
+          timers.delete(taskKey);
         }, FADE_DELAY_MS));
-      } else if (!isDone && timers.has(task.agent_id)) {
-        clearTimeout(timers.get(task.agent_id));
-        timers.delete(task.agent_id);
+      } else if (!isDone && timers.has(taskKey)) {
+        clearTimeout(timers.get(taskKey));
+        timers.delete(taskKey);
         setFadedIds((prev) => {
           const next = new Set(prev);
-          next.delete(task.agent_id);
+          next.delete(taskKey);
           return next;
         });
       }
@@ -99,7 +104,7 @@ export function SubAgentCards({ tasks }: { tasks: SubAgentTask[] }) {
   }, []);
 
   const visibleTasks = useMemo(
-    () => tasks.filter((tk) => !fadedIds.has(tk.agent_id)),
+    () => tasks.filter((tk) => !fadedIds.has(tk.run_id || tk.agent_id)),
     [tasks, fadedIds],
   );
 
@@ -161,24 +166,85 @@ export function SubAgentCards({ tasks }: { tasks: SubAgentTask[] }) {
     return String(n);
   };
 
+  const renderChainEntries = (task: SubAgentTask) => {
+    const entries = (task.chain ?? []).flatMap((group) => group.entries).slice(-8);
+    if (!entries.length) return null;
+    return (
+      <div className="sacStreamList">
+        {entries.map((entry, idx) => {
+          if (entry.kind === "thinking") {
+            return (
+              <div key={`thinking-${idx}`} className="sacStreamItem sacStreamThinking">
+                <span className="sacStreamKind">{t("chat.thinking", "思考")}</span>
+                <span>{entry.content}</span>
+              </div>
+            );
+          }
+          if (entry.kind === "text") {
+            return (
+              <div key={`text-${idx}`} className="sacStreamItem">
+                <span className="sacStreamKind">{entry.icon || "·"}</span>
+                <span>{entry.content}</span>
+              </div>
+            );
+          }
+          if (entry.kind === "tool_start") {
+            return (
+              <div key={`tool-start-${idx}`} className="sacStreamItem">
+                <span className="sacStreamKind">run</span>
+                <span>{entry.description || entry.tool}</span>
+              </div>
+            );
+          }
+          if (entry.kind === "tool_end") {
+            return (
+              <div key={`tool-end-${idx}`} className={`sacStreamItem ${entry.status === "error" ? "sacStreamError" : ""}`}>
+                <span className="sacStreamKind">{entry.status === "error" ? "err" : "done"}</span>
+                <span>{entry.result}</span>
+              </div>
+            );
+          }
+          if (entry.kind === "compressed") {
+            return (
+              <div key={`compressed-${idx}`} className="sacStreamItem">
+                <span className="sacStreamKind">ctx</span>
+                <span>{entry.beforeTokens} → {entry.afterTokens} tokens</span>
+              </div>
+            );
+          }
+          if (entry.kind === "config_hint") {
+            return (
+              <div key={`hint-${idx}`} className="sacStreamItem sacStreamError">
+                <span className="sacStreamKind">hint</span>
+                <span>{entry.hint.title || entry.hint.message}</span>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  };
+
   const renderCard = (node: TaskNode, depth: number): JSX.Element => {
     const task = node.task;
-    const isExpanded = expandedId === task.agent_id;
+    const taskKey = task.run_id || task.agent_id;
+    const isExpanded = expandedId === taskKey;
     const childCount = node.children.length;
-    const collapsed = collapsedParents.has(task.agent_id);
+    const collapsed = collapsedParents.has(taskKey);
     const indent = Math.min(depth, MAX_DEPTH) * INDENT_PX;
     return (
-      <div key={task.agent_id} style={{ marginLeft: indent }}>
+      <div key={taskKey} style={{ marginLeft: indent }}>
         <div
           className={`sacCard ${task.status === "running" || task.status === "starting" ? "sacCardActive" : ""}`}
-          onClick={() => toggleExpand(task.agent_id)}
+          onClick={() => toggleExpand(taskKey)}
           style={{ cursor: "pointer" }}
         >
           <div className="sacCardTop">
             {childCount > 0 && (
               <button
                 className="sacPageBtn"
-                onClick={(e) => { e.stopPropagation(); toggleCollapse(task.agent_id); }}
+                onClick={(e) => { e.stopPropagation(); toggleCollapse(taskKey); }}
                 title={collapsed ? t("chat.expand", "展开") : t("chat.collapse", "折叠")}
                 style={{ padding: "0 6px", minWidth: 18, lineHeight: 1 }}
               >
@@ -245,6 +311,18 @@ export function SubAgentCards({ tasks }: { tasks: SubAgentTask[] }) {
               </div>
             )}
           </div>
+          {isExpanded && task.stream_text && (
+            <div className="sacStreamOutput">
+              <div className="sacStreamLabel">{t("chat.subAgentLiveOutput", "实时输出")}</div>
+              <div className="sacStreamText">{task.stream_text}</div>
+            </div>
+          )}
+          {isExpanded && (task.chain?.length ?? 0) > 0 && (
+            <div className="sacStreamOutput">
+              <div className="sacStreamLabel">{t("chat.subAgentLiveProcess", "实时过程")}</div>
+              {renderChainEntries(task)}
+            </div>
+          )}
         </div>
         {!collapsed && childCount > 0 && depth < MAX_DEPTH && (
           <div>

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -267,9 +267,11 @@ export type SubAgentEntry = {
 
 /** Sub-agent task progress card data */
 export type SubAgentTask = {
+  run_id?: string;
   agent_id: string;
   profile_id: string;
   session_id: string;
+  chat_id?: string;
   name: string;
   icon: string;
   status: "starting" | "running" | "completed" | "error" | "timeout" | "cancelled";
@@ -281,6 +283,12 @@ export type SubAgentTask = {
   started_at: number;
   tokens_used?: number;
   current_tool_summary?: string;
+  reason?: string;
+  stream_text?: string;
+  stream_preview?: string;
+  stream_events?: number;
+  chain?: ChainGroup[];
+  last_stream_event_at?: number;
   queue_count?: number;
   // P5.1: agent_id of the agent that delegated this task (root tasks omit it).
   // Inferred client-side from agent_handoff / delegate_to_agent / delegate_parallel

--- a/src/openakita/agents/orchestrator.py
+++ b/src/openakita/agents/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import inspect
 import json
 import logging
 import re
@@ -76,6 +77,41 @@ _VALID_TRANSITIONS: dict[SubAgentStatus, frozenset[SubAgentStatus]] = {
 MAX_DELEGATION_DEPTH = 5
 CHECK_INTERVAL = 3.0  # how often to poll progress (matches frontend polling)
 
+_SUB_STREAM_EVENT_TYPES = frozenset(
+    {
+        "iteration_start",
+        "thinking_start",
+        "thinking_delta",
+        "thinking_end",
+        "chain_text",
+        "text_delta",
+        "text_replace",
+        "tool_call_start",
+        "tool_call_end",
+        "config_hint",
+        "source_used",
+        "mcp_call",
+        "artifact",
+        "context_compressed",
+        "security_confirm",
+        "ask_user",
+        "death_switch",
+        "budget_warning",
+        "budget_exceeded",
+        "task_checkpoint",
+        "todo_created",
+        "todo_step_updated",
+        "todo_completed",
+        "todo_cancelled",
+        "done",
+        "error",
+    }
+)
+
+
+class _SubAgentStreamingUnavailable(TypeError):
+    """Raised when an agent does not expose the streaming chat contract."""
+
 # Defaults — overridden at runtime by settings when available.
 # 默认全部 0 = 不做"agent 自检自杀"，对齐 Claude Code 哲学；卡死由用户主动停止。
 _DEFAULT_IDLE_TIMEOUT = 0  # 0 = 禁用无进展超时检测
@@ -115,6 +151,97 @@ def _delegation_notice_title(exit_reason: str) -> str:
     if exit_reason in {"error", "timeout", "cancelled", "loop_terminated", "max_turns"}:
         return "任务结束通知"
     return "任务完成通知"
+
+
+async def _broadcast_sub_stream_event(meta: dict[str, Any], event: dict[str, Any]) -> None:
+    """Forward one child-agent stream event to desktop/web subscribers."""
+    if not isinstance(event, dict):
+        return
+    event_type = str(event.get("type") or "")
+    if event_type not in _SUB_STREAM_EVENT_TYPES:
+        return
+
+    payload = {
+        "conversation_id": meta.get("chat_id") or meta.get("session_id") or "",
+        "session_id": meta.get("session_id") or "",
+        "chat_id": meta.get("chat_id") or meta.get("session_id") or "",
+        "run_id": meta.get("run_id") or "",
+        "agent_id": meta.get("agent_id") or "",
+        "profile_id": meta.get("profile_id") or meta.get("agent_id") or "",
+        "parent_agent_id": meta.get("parent_agent_id") or "",
+        "name": meta.get("name") or "",
+        "icon": meta.get("icon") or "",
+        "reason": meta.get("reason") or "",
+        "event_type": event_type,
+        "event": dict(event),
+        "ts": time.time(),
+    }
+
+    try:
+        from openakita.api.routes.websocket import broadcast_event
+
+        await broadcast_event("agents:sub_stream", payload)
+        if event_type == "security_confirm":
+            promoted_confirm = dict(event)
+            promoted_confirm["conversation_id"] = payload["chat_id"] or payload["session_id"]
+            if event.get("conversation_id") and event.get("conversation_id") != promoted_confirm[
+                "conversation_id"
+            ]:
+                promoted_confirm["backend_conversation_id"] = event.get("conversation_id")
+            await broadcast_event(
+                "security_confirm_promoted",
+                {
+                    "confirm_id": promoted_confirm.get("confirm_id")
+                    or promoted_confirm.get("id")
+                    or "",
+                    "session_id": promoted_confirm.get("conversation_id") or payload["chat_id"],
+                    "backend_session_id": event.get("conversation_id") or payload["session_id"],
+                    "confirm": promoted_confirm,
+                },
+            )
+    except Exception:
+        logger.debug("[Orchestrator] failed to broadcast sub-agent stream event", exc_info=True)
+
+
+async def _call_agent_streaming(
+    agent: Any,
+    session: Any,
+    message: str,
+    *,
+    gateway: Any,
+    mode: str,
+    stream_meta: dict[str, Any],
+) -> str:
+    """Consume a sub-agent stream, forwarding events while preserving final text."""
+    stream_method = getattr(agent, "chat_with_session_stream", None)
+    if not inspect.isasyncgenfunction(stream_method):
+        raise _SubAgentStreamingUnavailable(
+            "agent.chat_with_session_stream is not an async generator function"
+        )
+
+    reply_text = ""
+    session_messages = session.context.get_messages()
+    async for event in stream_method(
+        message=message,
+        session_messages=session_messages,
+        session_id=session.id,
+        session=session,
+        gateway=gateway,
+        mode=mode,
+    ):
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "done" and event.get("content"):
+            reply_text = event.get("content", "") or reply_text
+        elif event_type == "text_delta":
+            reply_text += event.get("content", "")
+        elif event_type == "text_replace":
+            reply_text = event.get("content", "") or ""
+        elif event_type == "ask_user" and not reply_text:
+            reply_text = event.get("question", "") or ""
+        await _broadcast_sub_stream_event(stream_meta, event)
+    return reply_text
 
 
 @dataclass
@@ -506,6 +633,7 @@ class AgentOrchestrator:
                 depth=depth,
                 isolated_browser=isolated_browser,
                 pre_state_key=pre_state_key,
+                parent_agent_id=from_agent or "",
             )
             elapsed_ms = (time.monotonic() - start) * 1000
             health.successful += 1
@@ -632,6 +760,7 @@ class AgentOrchestrator:
         depth: int = 0,
         isolated_browser: Any = None,
         pre_state_key: str | None = None,
+        parent_agent_id: str = "",
     ) -> str:
         """Run an agent with progress-aware timeout instead of a hard wall-clock limit.
 
@@ -684,20 +813,11 @@ class AgentOrchestrator:
             agent.pw_tools = PlaywrightTools(isolated_browser)
             agent.bu_runner = BrowserUseRunner(isolated_browser)
 
-        gw = self._gateway if pass_gateway else None
-
-        task = asyncio.create_task(
-            self._call_agent(agent, session, message, gateway=gw, is_sub_agent=(depth > 0))
-        )
-
-        start = time.monotonic()
-        last_fingerprint: tuple[int, str, int] = (-1, "", 0)
-        last_progress_time = start
-
         state_key = pre_state_key or f"{session.id}:{agent_profile_id}:{uuid.uuid4().hex[:8]}"
         existing_state = self._sub_agent_states.get(state_key, {})
         self._sub_agent_states[state_key] = {
             **existing_state,
+            "run_id": state_key,
             "agent_id": agent_profile_id,
             "profile_id": profile.id,
             "session_id": session.id,
@@ -711,7 +831,41 @@ class AgentOrchestrator:
             "started_at": time.time(),
             "name": existing_state.get("name") or profile.get_display_name(),
             "icon": existing_state.get("icon") or profile.icon or "🤖",
+            "parent_agent_id": existing_state.get("parent_agent_id")
+            or existing_state.get("from_agent")
+            or parent_agent_id,
+            "from_agent": existing_state.get("from_agent") or parent_agent_id,
+            "reason": existing_state.get("reason", ""),
         }
+        stream_meta = {
+            "run_id": state_key,
+            "agent_id": agent_profile_id,
+            "profile_id": profile.id,
+            "session_id": session.id,
+            "chat_id": getattr(session, "chat_id", session.id),
+            "name": self._sub_agent_states[state_key]["name"],
+            "icon": self._sub_agent_states[state_key]["icon"],
+            "parent_agent_id": self._sub_agent_states[state_key].get("parent_agent_id", ""),
+            "reason": self._sub_agent_states[state_key].get("reason", ""),
+        }
+        self._broadcast_sub_state_change(state_key, "starting", self._sub_agent_states[state_key])
+
+        gw = self._gateway if pass_gateway else None
+
+        task = asyncio.create_task(
+            self._call_agent(
+                agent,
+                session,
+                message,
+                gateway=gw,
+                is_sub_agent=(depth > 0),
+                stream_meta=stream_meta if depth > 0 else None,
+            )
+        )
+
+        start = time.monotonic()
+        last_fingerprint: tuple[int, str, int] = (-1, "", 0)
+        last_progress_time = start
 
         try:
             while not task.done():
@@ -885,13 +1039,17 @@ class AgentOrchestrator:
                 return
 
             payload: dict[str, Any] = {
+                "run_id": state_entry.get("run_id", key),
                 "session_id": state_entry.get("session_id", ""),
                 "chat_id": state_entry.get("chat_id", ""),
                 "agent_id": state_entry.get("agent_id", ""),
                 "profile_id": state_entry.get("profile_id", ""),
+                "parent_agent_id": state_entry.get("parent_agent_id", "")
+                or state_entry.get("from_agent", ""),
                 "name": state_entry.get("name", ""),
                 "icon": state_entry.get("icon", ""),
                 "status": status,
+                "reason": state_entry.get("reason", ""),
                 "iteration": state_entry.get("iteration", 0),
                 "tools_executed": state_entry.get("tools_executed", []),
                 "tools_total": state_entry.get("tools_total", 0),
@@ -1010,6 +1168,7 @@ class AgentOrchestrator:
         *,
         gateway: Any = None,
         is_sub_agent: bool = True,
+        stream_meta: dict[str, Any] | None = None,
     ) -> str:
         """Thin wrapper around agent.chat_with_session for use as a task target.
 
@@ -1058,15 +1217,36 @@ class AgentOrchestrator:
             _start = time.time()
             exit_reason = "completed"
             try:
-                session_messages = session.context.get_messages()
-                result = await agent.chat_with_session(
-                    message=message,
-                    session_messages=session_messages,
-                    session_id=session.id,
-                    session=session,
-                    gateway=gateway,
-                    mode=_mode,
-                )
+                if is_sub_agent and stream_meta:
+                    try:
+                        result = await _call_agent_streaming(
+                            agent,
+                            session,
+                            message,
+                            gateway=gateway,
+                            mode=_mode,
+                            stream_meta=stream_meta,
+                        )
+                    except _SubAgentStreamingUnavailable:
+                        session_messages = session.context.get_messages()
+                        result = await agent.chat_with_session(
+                            message=message,
+                            session_messages=session_messages,
+                            session_id=session.id,
+                            session=session,
+                            gateway=gateway,
+                            mode=_mode,
+                        )
+                else:
+                    session_messages = session.context.get_messages()
+                    result = await agent.chat_with_session(
+                        message=message,
+                        session_messages=session_messages,
+                        session_id=session.id,
+                        session=session,
+                        gateway=gateway,
+                        mode=_mode,
+                    )
                 # Persist sub-agent work record into parent session
                 try:
                     _persist_sub_agent_record(agent, session, message, result, _start)
@@ -1312,6 +1492,7 @@ class AgentOrchestrator:
                 profile_name = p.get_display_name()
                 profile_icon = p.icon or "🤖"
         self._sub_agent_states[state_key] = {
+            "run_id": state_key,
             "agent_id": to_agent,
             "profile_id": to_agent,
             "session_id": session.id,
@@ -1324,8 +1505,10 @@ class AgentOrchestrator:
             "tools_total": 0,
             "elapsed_s": 0,
             "from_agent": from_agent,
+            "parent_agent_id": from_agent,
             "reason": reason or "",
         }
+        self._broadcast_sub_state_change(state_key, "starting", self._sub_agent_states[state_key])
 
         # Emit handoff event for SSE stream (session.context.handoff_events)
         if session and hasattr(session, "context") and hasattr(session.context, "handoff_events"):

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -1039,6 +1039,99 @@ class TestAgentOrchestrator:
         assert "工具调用: 0 次" in result
 
     @pytest.mark.asyncio
+    async def test_sub_agent_stream_events_are_broadcast_to_websocket(
+        self, orchestrator, mock_pool, monkeypatch
+    ):
+        session = _make_session(session_id="sess-stream")
+        captured: list[tuple[str, dict]] = []
+
+        async def fake_broadcast(event_name: str, payload: dict):
+            captured.append((event_name, payload))
+
+        async def fake_stream(**kwargs):
+            assert kwargs["session_id"] == "sess-stream"
+            yield {"type": "iteration_start", "iteration": 1}
+            yield {"type": "chain_text", "content": "正在分析子任务"}
+            yield {
+                "type": "tool_call_start",
+                "tool_name": "search_docs",
+                "call_id": "call-1",
+                "args": {"query": "openakita"},
+            }
+            yield {
+                "type": "security_confirm",
+                "source": "policy_v2",
+                "tool": "run_shell",
+                "args": {"command": "echo ok"},
+                "id": "confirm-1",
+                "confirm_id": "confirm-1",
+                "conversation_id": "sess-stream",
+                "reason": "test",
+                "risk_level": "medium",
+                "needs_sandbox": False,
+                "timeout_seconds": 60,
+                "default_on_timeout": "deny",
+                "approval_class": "execute",
+                "policy_version": 2,
+                "channel": "desktop",
+                "delegate_chain": ["default", "helper"],
+                "root_user_id": "user-1",
+                "decision_chain": [],
+                "display": {},
+                "options": ["allow_once", "deny"],
+                "risk_intent": {},
+                "presentation_state": "active",
+                "queued_count": 0,
+                "queue_position": None,
+                "active_confirm_id": "confirm-1",
+                "pending_count": 1,
+            }
+            yield {"type": "text_delta", "content": "hello "}
+            yield {"type": "text_delta", "content": "world"}
+            yield {"type": "done"}
+
+        monkeypatch.setattr("openakita.api.routes.websocket.broadcast_event", fake_broadcast)
+        mock_agent = mock_pool.get_or_create.return_value
+        mock_agent.chat_with_session_stream = fake_stream
+
+        result = await orchestrator._dispatch(
+            session,
+            "sub task",
+            "helper",
+            depth=1,
+            from_agent="default",
+        )
+        await asyncio.sleep(0)
+
+        assert "hello world" in result
+        mock_agent.chat_with_session.assert_not_awaited()
+
+        stream_events = [payload for name, payload in captured if name == "agents:sub_stream"]
+        assert [payload["event_type"] for payload in stream_events] == [
+            "iteration_start",
+            "chain_text",
+            "tool_call_start",
+            "security_confirm",
+            "text_delta",
+            "text_delta",
+            "done",
+        ]
+        assert {payload["run_id"] for payload in stream_events}
+        assert {payload["agent_id"] for payload in stream_events} == {"helper"}
+        assert {payload["parent_agent_id"] for payload in stream_events} == {"default"}
+        assert stream_events[1]["event"]["content"] == "正在分析子任务"
+
+        promoted_events = [
+            payload for name, payload in captured if name == "security_confirm_promoted"
+        ]
+        assert len(promoted_events) == 1
+        promoted = promoted_events[0]
+        assert promoted["session_id"] == "chat-1"
+        assert promoted["backend_session_id"] == "sess-stream"
+        assert promoted["confirm"]["conversation_id"] == "chat-1"
+        assert promoted["confirm"]["backend_conversation_id"] == "sess-stream"
+
+    @pytest.mark.asyncio
     async def test_handle_message_resets_delegation_chain(self, orchestrator):
         session = _make_session()
         session.context.delegation_chain = [{"old": "data"}]


### PR DESCRIPTION
## Summary
- Surface real-time sub-agent stream events in the desktop sub-agent progress cards.
- Promote sub-agent security confirmations with the user-visible conversation id so approval modals appear reliably.
- Closes #686

## Tests
- uv run --no-sync pytest tests/unit/test_multi_agent.py -k "sub_agent_stream_events_are_broadcast_to_websocket or sub_agent_dispatch_keeps_structured_tool_response or delegate_registers_sub_agent_state" -q
- uv run --no-sync ruff check src/openakita/agents/orchestrator.py tests/unit/test_multi_agent.py
- git diff --check
- npm run build