### PR TITLE
Improve desktop chat attachment handling for large local files

### DIFF
--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -5431,6 +5431,7 @@ fn main() {
             http_proxy_request,
             backend_fetch,
             backend_fetch_cancel,
+            get_local_file_info,
             read_file_base64,
             download_file,
             copy_file_to_downloads,
@@ -8947,15 +8948,94 @@ async fn backend_fetch(
     }))
 }
 
-/// Read a file from disk and return its contents as a base64 data-URL.
-/// Used by the frontend to handle Tauri file-drop events (which provide paths, not File objects).
+const READ_FILE_BASE64_MAX_BYTES: u64 = 50 * 1024 * 1024;
+const READ_FILE_BASE64_CHUNK_SIZE: usize = 256 * 1024;
+
+#[derive(Serialize)]
+struct LocalFileInfo {
+    size: u64,
+    is_file: bool,
+    is_directory: bool,
+}
+
+#[derive(Serialize, Clone)]
+struct LocalFileReadProgress {
+    id: String,
+    loaded: u64,
+    total: u64,
+}
+
+/// Return local file metadata without reading the file contents.
+/// Used by drag/drop handling to reject or route large files before they can
+/// exhaust WebView memory.
 #[tauri::command]
-async fn read_file_base64(path: String) -> Result<String, String> {
+fn get_local_file_info(path: String) -> Result<LocalFileInfo, String> {
     let p = std::path::Path::new(&path);
-    if !p.exists() {
-        return Err(format!("File not found: {}", path));
+    let meta = std::fs::metadata(p).map_err(|e| format!("Failed to stat {}: {}", path, e))?;
+    Ok(LocalFileInfo {
+        size: meta.len(),
+        is_file: meta.is_file(),
+        is_directory: meta.is_dir(),
+    })
+}
+
+/// Read a file from disk and return its contents as a base64 data-URL.
+/// Used by the frontend to handle small Tauri media file-drop events.
+#[tauri::command]
+async fn read_file_base64(
+    app: tauri::AppHandle,
+    path: String,
+    progress_id: Option<String>,
+) -> Result<String, String> {
+    let p = std::path::Path::new(&path);
+    let meta = std::fs::metadata(p).map_err(|e| format!("Failed to stat {}: {}", path, e))?;
+    if !meta.is_file() {
+        return Err(format!("Not a file: {}", path));
     }
-    let data = std::fs::read(p).map_err(|e| format!("Failed to read {}: {}", path, e))?;
+    if meta.len() > READ_FILE_BASE64_MAX_BYTES {
+        return Err(format!(
+            "File too large for base64 preview: {:.1} MB (max 50 MB)",
+            meta.len() as f64 / 1024.0 / 1024.0
+        ));
+    }
+    let total = meta.len();
+    let mut file = std::fs::File::open(p).map_err(|e| format!("Failed to open {}: {}", path, e))?;
+    let mut data = Vec::with_capacity(total as usize);
+    let mut loaded = 0_u64;
+    let mut buf = vec![0_u8; READ_FILE_BASE64_CHUNK_SIZE];
+
+    if let Some(id) = progress_id.as_ref() {
+        let _ = app.emit(
+            "local_file_read_progress",
+            LocalFileReadProgress {
+                id: id.clone(),
+                loaded,
+                total,
+            },
+        );
+    }
+
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("Failed to read {}: {}", path, e))?;
+        if n == 0 {
+            break;
+        }
+        data.extend_from_slice(&buf[..n]);
+        loaded += n as u64;
+        if let Some(id) = progress_id.as_ref() {
+            let _ = app.emit(
+                "local_file_read_progress",
+                LocalFileReadProgress {
+                    id: id.clone(),
+                    loaded,
+                    total,
+                },
+            );
+            tokio::task::yield_now().await;
+        }
+    }
     let mime = match p
         .extension()
         .and_then(|e| e.to_str())

--- a/apps/setup-center/src/platform/index.ts
+++ b/apps/setup-center/src/platform/index.ts
@@ -150,11 +150,56 @@ export async function openFileWithDefault(path: string): Promise<void> {
 }
 
 /** Read a local file as a base64 data-URL. Only available in Tauri. */
-export async function readFileBase64(path: string): Promise<string> {
+export async function readFileBase64(
+  path: string,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<string> {
   if (!IS_TAURI)
     throw new Error("readFileBase64 is only available in Tauri");
   const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
-  return tauriInvoke<string>("read_file_base64", { path });
+  if (!onProgress) {
+    return tauriInvoke<string>("read_file_base64", { path });
+  }
+
+  const progressId = `file-read-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const { listen: tauriListen } = await import("@tauri-apps/api/event");
+  const unlisten = await tauriListen<{
+    id: string;
+    loaded: number;
+    total: number;
+  }>("local_file_read_progress", (event) => {
+    const payload = event.payload;
+    if (payload?.id !== progressId) return;
+    onProgress(payload.loaded, payload.total);
+  });
+  try {
+    return await tauriInvoke<string>("read_file_base64", { path, progressId });
+  } finally {
+    unlisten();
+  }
+}
+
+export type LocalFileInfo = {
+  size: number;
+  isFile: boolean;
+  isDirectory: boolean;
+};
+
+/** Read local file metadata without loading the file contents. Tauri only. */
+export async function getLocalFileInfo(path: string): Promise<LocalFileInfo> {
+  if (!IS_TAURI)
+    throw new Error("getLocalFileInfo is only available in Tauri");
+  const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+  const info = await tauriInvoke<{
+    size: number;
+    is_file: boolean;
+    is_directory: boolean;
+  }>("get_local_file_info", { path });
+  return {
+    size: info.size,
+    isFile: info.is_file,
+    isDirectory: info.is_directory,
+  };
 }
 
 /** Write text content to a local file. Only available in Tauri. */

--- a/apps/setup-center/src/types.ts
+++ b/apps/setup-center/src/types.ts
@@ -473,6 +473,7 @@ export type ChatAttachment = {
   size?: number;
   mimeType?: string;
   uploadStatus?: "uploading" | "uploaded" | "failed";
+  uploadProgress?: number;
   uploadError?: string;
   /** Transient upload tracking ID — not persisted to backend */
   _uploadId?: string;

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -14,7 +14,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { toast } from "sonner";
 import { setThemePref } from "../theme";
 import type { Theme } from "../theme";
-import { downloadFile, showInFolder, readFileBase64, onDragDrop, IS_TAURI, IS_WEB, IS_MOBILE_BROWSER, onWsEvent, logger } from "../platform";
+import { downloadFile, showInFolder, readFileBase64, getLocalFileInfo, onDragDrop, IS_TAURI, IS_WEB, IS_MOBILE_BROWSER, onWsEvent, logger } from "../platform";
 import { safeFetch } from "../providers";
 import type {
   ChatMessage,
@@ -500,6 +500,23 @@ type HistoryPageState = {
   hasMoreBefore: boolean;
   loadingOlder: boolean;
 };
+
+const DESKTOP_DRAG_FILE_MAX_SIZE = 50 * 1024 * 1024;
+const DESKTOP_DRAG_VIDEO_MAX_SIZE = 7 * 1024 * 1024;
+
+function formatAttachmentSize(bytes: number | null | undefined): string {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (n >= 1024 * 1024 * 1024) return `${(n / 1024 / 1024 / 1024).toFixed(2)}GB`;
+  if (n >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${Math.round(n)}B`;
+}
+
+function isAttachmentStillPreparing(att: ChatAttachment): boolean {
+  if (att.uploadStatus === "uploading") return true;
+  return !att.url && !att.localPath;
+}
 
 // ─── 主组件 ───
 
@@ -2838,16 +2855,14 @@ export function ChatView({
     // When omitted we fall back to the composer's pending attachments.
     const attachmentsToSend = attachmentsOverride ?? pendingAttachments;
     if (!text && attachmentsToSend.length === 0 && !isResumeTransport) return;
-    const pendingUploads = attachmentsToSend.filter((a) =>
-      a.type !== "image" && a.type !== "video" && (!a.url || a.uploadStatus === "uploading")
-    );
+    const pendingUploads = attachmentsToSend.filter(isAttachmentStillPreparing);
     if (pendingUploads.length > 0) {
-      notifyError(t("chat.uploadStillRunning", "附件还在上传，请稍等一下"));
+      notifyError(t("chat.uploadStillRunning", "附件还在处理，请稍等一下"));
       return;
     }
     const failedUploads = attachmentsToSend.filter((a) => a.uploadStatus === "failed");
     if (failedUploads.length > 0) {
-      notifyError(t("chat.uploadFailedRetry", "有附件上传失败，请重新选择或稍后重试"));
+      notifyError(t("chat.uploadFailedRetry", "有附件处理失败，请重新选择或稍后重试"));
       return;
     }
     if (orgCommandPendingRef.current) return;
@@ -2908,7 +2923,7 @@ export function ChatView({
       id: genId(),
       role: "user",
       content: displayContent || text,
-      attachments: attachmentsToSend.length > 0 ? attachmentsToSend.map(({ _uploadId, ...rest }) => rest) : undefined,
+      attachments: attachmentsToSend.length > 0 ? attachmentsToSend.map(({ _uploadId, uploadProgress, ...rest }) => rest) : undefined,
       timestamp: Date.now(),
     };
 
@@ -5231,15 +5246,13 @@ export function ChatView({
     // Mirror sendMessage's upload guards: only fully-uploaded attachments may
     // enter the queue, otherwise the drain would reject them and drop the
     // message. Keeping them in the composer lets the user retry/wait.
-    const pendingUploads = attachments.filter((a) =>
-      a.type !== "image" && a.type !== "video" && (!a.url || a.uploadStatus === "uploading")
-    );
+    const pendingUploads = attachments.filter(isAttachmentStillPreparing);
     if (pendingUploads.length > 0) {
-      notifyError(t("chat.uploadStillRunning", "附件还在上传，请稍等一下"));
+      notifyError(t("chat.uploadStillRunning", "附件还在处理，请稍等一下"));
       return;
     }
     if (attachments.some((a) => a.uploadStatus === "failed")) {
-      notifyError(t("chat.uploadFailedRetry", "有附件上传失败，请重新选择或稍后重试"));
+      notifyError(t("chat.uploadFailedRetry", "有附件处理失败，请重新选择或稍后重试"));
       return;
     }
     setMessageQueue(prev => [...prev, {
@@ -5247,7 +5260,7 @@ export function ChatView({
       text,
       timestamp: Date.now(),
       convId: activeConvId,
-      attachments: attachments.length > 0 ? attachments.map(({ _uploadId, ...rest }) => rest) : undefined,
+      attachments: attachments.length > 0 ? attachments.map(({ _uploadId, uploadProgress, ...rest }) => rest) : undefined,
       mode: chatMode,
     }]);
     setInputValue("");
@@ -5410,26 +5423,50 @@ export function ChatView({
         name: file.name,
         size: file.size,
         mimeType: file.type,
-        uploadStatus: file.type.startsWith("image/") || file.type.startsWith("video/") ? "uploaded" : "uploading",
+        uploadStatus: "uploading",
+        uploadProgress: 0,
         _uploadId: uploadId,
       };
       if (att.type === "video" && file.size > 7 * 1024 * 1024) {
-        notifyError(`视频文件过大 (${(file.size / 1024 / 1024).toFixed(1)}MB)，桌面端最大支持 7MB（base64 编码后需 < 10MB）`);
+        notifyError(`视频文件过大 (${formatAttachmentSize(file.size)})，请压缩或截短后再添加。`);
         continue;
       }
       if (att.type === "image" || att.type === "video") {
+        setPendingAttachments((prev) => [...prev, att]);
         const reader = new FileReader();
+        reader.onprogress = (event) => {
+          if (!event.lengthComputable || event.total <= 0) return;
+          const progress = Math.max(0, Math.min(0.98, event.loaded / event.total));
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId ? { ...a, uploadProgress: progress } : a
+          ));
+        };
         reader.onload = () => {
-          att.previewUrl = att.type === "image" ? reader.result as string : undefined;
-          att.url = reader.result as string;
-          setPendingAttachments((prev) => [...prev, att]);
+          const dataUrl = reader.result as string;
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId
+              ? {
+                ...a,
+                previewUrl: a.type === "image" ? dataUrl : undefined,
+                url: dataUrl,
+                uploadStatus: "uploaded",
+                uploadProgress: undefined,
+                uploadError: undefined,
+              }
+              : a
+          ));
         };
         reader.onerror = () => {
           notifyError(`文件读取失败: ${file.name}`);
+          setPendingAttachments((prev) =>
+            prev.map((a) => a._uploadId === uploadId
+              ? { ...a, uploadStatus: "failed", uploadProgress: undefined, uploadError: "文件读取失败" }
+              : a)
+          );
         };
         reader.readAsDataURL(file);
       } else {
-        setPendingAttachments((prev) => [...prev, att]);
+        setPendingAttachments((prev) => [...prev, { ...att, uploadProgress: undefined }]);
         uploadFile(file, file.name)
           .then((uploaded) => {
             setPendingAttachments((prev) =>
@@ -5481,16 +5518,47 @@ export function ChatView({
         e.preventDefault();
         const file = item.getAsFile();
         if (!file) continue;
+        const uploadId = genId();
+        const name = `粘贴图片-${Date.now()}.png`;
+        setPendingAttachments((prev) => [...prev, {
+          type: "image",
+          name,
+          size: file.size,
+          mimeType: file.type,
+          uploadStatus: "uploading",
+          uploadProgress: 0,
+          _uploadId: uploadId,
+        }]);
         const reader = new FileReader();
+        reader.onprogress = (event) => {
+          if (!event.lengthComputable || event.total <= 0) return;
+          const progress = Math.max(0, Math.min(0.98, event.loaded / event.total));
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId ? { ...a, uploadProgress: progress } : a
+          ));
+        };
         reader.onload = () => {
-          setPendingAttachments((prev) => [...prev, {
-            type: "image",
-            name: `粘贴图片-${Date.now()}.png`,
-            previewUrl: reader.result as string,
-            url: reader.result as string,
-            size: file.size,
-            mimeType: file.type,
-          }]);
+          const dataUrl = reader.result as string;
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId
+              ? {
+                ...a,
+                previewUrl: dataUrl,
+                url: dataUrl,
+                uploadStatus: "uploaded",
+                uploadProgress: undefined,
+                uploadError: undefined,
+              }
+              : a
+          ));
+        };
+        reader.onerror = () => {
+          notifyError(`文件读取失败: ${name}`);
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId
+              ? { ...a, uploadStatus: "failed", uploadProgress: undefined, uploadError: "文件读取失败" }
+              : a
+          ));
         };
         reader.readAsDataURL(file);
       }
@@ -5513,109 +5581,109 @@ export function ChatView({
       aac: "audio/aac", flac: "audio/flac", ogg: "audio/ogg", opus: "audio/opus",
       pdf: "application/pdf", txt: "text/plain", md: "text/plain",
       json: "application/json", csv: "text/csv",
+      zip: "application/zip", rar: "application/vnd.rar", "7z": "application/x-7z-compressed",
+      tar: "application/x-tar", gz: "application/gzip",
     };
 
-    const FILE_MAX_SIZE = 50 * 1024 * 1024;
+    const imageExts = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
+    const videoExts = new Set(["mp4", "webm", "avi", "mov", "mkv"]);
+    const audioExts = new Set(["mp3", "wav", "m4a", "aac", "flac", "ogg", "opus", "weba", "wma", "amr"]);
 
-    const dataUrlToBlob = (dataUrl: string, mimeType: string): Blob | null => {
+    const handleDroppedPath = async (filePath: string) => {
+      const name = filePath.split(/[\\/]/).pop() || "file";
+      const ext = (name.split(".").pop() || "").toLowerCase();
+      const isImage = imageExts.has(ext);
+      const isVideo = videoExts.has(ext);
+      const isAudio = audioExts.has(ext);
+      const isPdf = ext === "pdf";
+      const mimeType = mimeMap[ext] || "application/octet-stream";
+
+      let info: { size: number; isFile: boolean; isDirectory: boolean };
       try {
-        const commaIdx = dataUrl.indexOf(",");
-        const b64 = commaIdx >= 0 ? dataUrl.slice(commaIdx + 1) : dataUrl;
-        const bin = atob(b64);
-        const bytes = new Uint8Array(bin.length);
-        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-        return new Blob([bytes], { type: mimeType });
-      } catch {
-        return null;
+        info = await getLocalFileInfo(filePath);
+      } catch (err) {
+        if (!cancelled) notifyError(`无法读取文件信息: ${name}`);
+        logger.error("Chat", "DragDrop getLocalFileInfo failed", { name, error: String(err) });
+        return;
       }
+      if (cancelled) return;
+      if (!info.isFile) {
+        notifyError(info.isDirectory ? `暂不支持拖拽文件夹: ${name}` : `不是可上传的文件: ${name}`);
+        return;
+      }
+
+      if (isImage || isVideo) {
+        if (info.size > DESKTOP_DRAG_FILE_MAX_SIZE) {
+          notifyError(`${isImage ? "图片" : "视频"}文件过大 (${formatAttachmentSize(info.size)})，请压缩后再添加。`);
+          return;
+        }
+        if (isVideo && info.size > DESKTOP_DRAG_VIDEO_MAX_SIZE) {
+          notifyError(`视频文件过大 (${formatAttachmentSize(info.size)})，请压缩或截短后再添加。`);
+          return;
+        }
+
+        const uploadId = genId();
+        setPendingAttachments((prev) => [...prev, {
+          type: isImage ? "image" : "video",
+          name,
+          localPath: filePath,
+          size: info.size,
+          mimeType,
+          uploadStatus: "uploading",
+          uploadProgress: 0,
+          _uploadId: uploadId,
+        }]);
+        try {
+          const dataUrl = await readFileBase64(filePath, (loaded, total) => {
+            if (total <= 0) return;
+            const progress = Math.max(0, Math.min(0.98, loaded / total));
+            setPendingAttachments((prev) => prev.map((a) =>
+              a._uploadId === uploadId ? { ...a, uploadProgress: progress } : a
+            ));
+          });
+          if (cancelled) return;
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId
+              ? {
+                ...a,
+                previewUrl: isImage ? dataUrl : undefined,
+                url: dataUrl,
+                uploadStatus: "uploaded",
+                uploadProgress: undefined,
+                uploadError: undefined,
+              }
+              : a
+          ));
+        } catch (err) {
+          if (!cancelled) notifyError(`文件读取失败: ${name}`);
+          logger.error("Chat", "DragDrop read_file_base64 failed", { name, error: String(err) });
+          setPendingAttachments((prev) => prev.map((a) =>
+            a._uploadId === uploadId
+              ? { ...a, uploadStatus: "failed", uploadProgress: undefined, uploadError: "文件读取失败" }
+              : a
+          ));
+        }
+        return;
+      }
+
+      const att: ChatAttachment = {
+        type: isAudio ? "voice" : isPdf ? "document" : "file",
+        name,
+        localPath: filePath,
+        size: info.size,
+        mimeType,
+        uploadStatus: "uploaded",
+      };
+      setPendingAttachments((prev) => [...prev, att]);
+      logger.info("Chat.Upload", "DragDrop staged local file attachment", {
+        name,
+        size: info.size,
+        localOnly: true,
+      });
     };
 
     const handleDroppedPaths = (paths: string[]) => {
-      for (const filePath of paths) {
-        const name = filePath.split(/[\\/]/).pop() || "file";
-        const ext = (name.split(".").pop() || "").toLowerCase();
-        const isImage = ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"].includes(ext);
-        const isVideo = ["mp4", "webm", "avi", "mov", "mkv"].includes(ext);
-        const isAudio = ["mp3", "wav", "m4a", "aac", "flac", "ogg", "opus", "weba", "wma", "amr"].includes(ext);
-        const mimeType = mimeMap[ext] || "application/octet-stream";
-        readFileBase64(filePath)
-          .then((dataUrl) => {
-            if (cancelled) return;
-            const commaIdx = dataUrl.indexOf(",");
-            const base64Len = commaIdx >= 0 ? dataUrl.length - commaIdx - 1 : dataUrl.length;
-            const estimatedSize = base64Len * 3 / 4;
-            if (estimatedSize > FILE_MAX_SIZE) {
-              notifyError(`文件过大 (${(estimatedSize / 1024 / 1024).toFixed(1)}MB)，最大支持 50MB`);
-              return;
-            }
-            if (isVideo) {
-              const VIDEO_MAX_SIZE = 7 * 1024 * 1024;
-              if (estimatedSize > VIDEO_MAX_SIZE) {
-                notifyError(`视频文件过大 (${(estimatedSize / 1024 / 1024).toFixed(1)}MB)，最大支持 7MB（base64 编码后需 < 10MB）`);
-                return;
-              }
-            }
-
-            // 图片 / 视频：保留 dataUrl，后端 multimodal 路径会直接消费（不会拼进文本 prompt）
-            if (isImage || isVideo) {
-              setPendingAttachments((prev) => [...prev, {
-                type: isImage ? "image" : "video",
-                name,
-                previewUrl: isImage ? dataUrl : undefined,
-                url: dataUrl,
-                size: estimatedSize,
-                mimeType,
-              }]);
-              return;
-            }
-
-            // 文档 / 其他文件：必须上传到后端拿短 URL，否则 base64 dataUrl 会被
-            // 拼进 LLM prompt 文本 → token 爆炸 + 被中间环节截断（→ "..."）
-            // → 模型反复说"找不到文件 / 内容被截断"。与 handleFileSelect 路径保持一致。
-            const blob = dataUrlToBlob(dataUrl, mimeType);
-            if (!blob) {
-              notifyError(`文件解码失败: ${name}`);
-              logger.error("Chat.Upload", "DragDrop dataUrl decode failed", { name });
-              return;
-            }
-            const uploadId = genId();
-            const isPdf = ext === "pdf" || mimeType === "application/pdf";
-            const att: ChatAttachment = {
-              type: isAudio ? "voice" : isPdf ? "document" : "file",
-              name,
-              size: estimatedSize,
-              mimeType,
-              uploadStatus: "uploading",
-              _uploadId: uploadId,
-            };
-            setPendingAttachments((prev) => [...prev, att]);
-            uploadFile(blob, name)
-              .then((uploaded) => {
-                if (cancelled) return;
-                setPendingAttachments((prev) => prev.map((a) =>
-                  a._uploadId === uploadId
-                    ? {
-                      ...a,
-                      url: `${apiBaseRef.current}${uploaded.url}`,
-                      localPath: uploaded.localPath,
-                      uploadId: uploaded.uploadId,
-                      size: uploaded.size ?? a.size,
-                      mimeType: uploaded.mimeType ?? a.mimeType,
-                      uploadStatus: "uploaded",
-                      uploadError: undefined,
-                    }
-                    : a,
-                ));
-              })
-              .catch((err) => {
-                notifyError(`文件上传失败: ${name}`);
-                logger.error("Chat.Upload", "DragDrop uploadFile failed", { name, error: String(err) });
-                setPendingAttachments((prev) => prev.map((a) =>
-                  a._uploadId === uploadId ? { ...a, uploadStatus: "failed", uploadError: String(err) } : a));
-              });
-          })
-          .catch((err) => logger.error("Chat", "DragDrop read_file_base64 failed", { name, error: String(err) }));
-      }
+      for (const filePath of paths) void handleDroppedPath(filePath);
     };
 
     onDragDrop({

--- a/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
+++ b/apps/setup-center/src/views/chat/components/AttachmentPreview.tsx
@@ -26,6 +26,15 @@ function resolvePreviewUrls(att: ChatAttachment, apiBaseUrl?: string): { display
   return { displayUrl: "", downloadUrl: "" };
 }
 
+function formatAttachmentSize(bytes: number | null | undefined): string {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (n >= 1024 * 1024 * 1024) return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+  if (n >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${Math.round(n)} B`;
+}
+
 export function AttachmentPreview({
   att,
   onRemove,
@@ -37,7 +46,11 @@ export function AttachmentPreview({
   apiBaseUrl?: string;
   onImagePreview?: (displayUrl: string, downloadUrl: string, name: string) => void;
 }) {
-  const { displayUrl: previewUrl, downloadUrl } = att.type === "image"
+  const isUploading = att.uploadStatus === "uploading";
+  const rawProgress = Number(att.uploadProgress);
+  const hasProgress = Number.isFinite(rawProgress);
+  const progressValue = hasProgress ? Math.max(0, Math.min(100, Math.round(rawProgress * 100))) : undefined;
+  const { displayUrl: previewUrl, downloadUrl } = att.type === "image" && !isUploading
     ? resolvePreviewUrls(att, apiBaseUrl)
     : { displayUrl: "", downloadUrl: "" };
   if (att.type === "image" && previewUrl) {
@@ -74,11 +87,11 @@ export function AttachmentPreview({
     );
   }
   const icon = att.type === "voice" ? <IconMic size={14} /> : att.type === "video" ? <IconPlay size={14} /> : att.type === "image" ? <IconImage size={14} /> : <IconPaperclip size={14} />;
-  const sizeStr = att.size ? `${(att.size / 1024).toFixed(1)} KB` : "";
-  const statusText = att.uploadStatus === "uploading" ? "上传中" : att.uploadStatus === "failed" ? "上传失败" : "";
+  const sizeStr = formatAttachmentSize(att.size);
+  const statusText = isUploading ? "处理中" : att.uploadStatus === "failed" ? "处理失败" : "";
   const statusColor = att.uploadStatus === "failed" ? "var(--danger)" : "var(--muted)";
   return (
-    <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 28px 6px 10px", borderRadius: 10, border: "1px solid var(--line)", fontSize: 12 }}>
+    <div style={{ position: "relative", display: "inline-flex", flexDirection: "column", gap: 4, padding: "6px 28px 6px 10px", borderRadius: 10, border: "1px solid var(--line)", fontSize: 12, minWidth: isUploading ? 180 : undefined }}>
       {onRemove && (
         <button
           onClick={(e) => { e.stopPropagation(); onRemove(); }}
@@ -93,10 +106,20 @@ export function AttachmentPreview({
           <IconX size={11} />
         </button>
       )}
-      <span style={{ display: "inline-flex", alignItems: "center" }}>{icon}</span>
-      <span style={{ fontWeight: 600 }}>{att.name}</span>
-      {sizeStr && <span style={{ opacity: 0.5 }}>{sizeStr}</span>}
-      {statusText && <span style={{ color: statusColor, fontSize: 11 }}>{statusText}</span>}
+      <div style={{ display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", flexShrink: 0 }}>{icon}</span>
+        <span style={{ fontWeight: 600, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{att.name}</span>
+        {sizeStr && <span style={{ opacity: 0.5, flexShrink: 0 }}>{sizeStr}</span>}
+        {statusText && <span style={{ color: statusColor, fontSize: 11, flexShrink: 0 }}>{statusText}</span>}
+      </div>
+      {isUploading && (
+        <progress
+          aria-label="附件处理进度"
+          max={100}
+          value={progressValue}
+          style={{ width: "100%", height: 4, display: "block", accentColor: "var(--brand)" }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/setup-center/src/views/chat/components/__tests__/AttachmentPreview.test.tsx
+++ b/apps/setup-center/src/views/chat/components/__tests__/AttachmentPreview.test.tsx
@@ -39,4 +39,39 @@ describe("AttachmentPreview image lightbox trigger", () => {
     expect(onRemove).toHaveBeenCalledTimes(1);
     expect(onImagePreview).not.toHaveBeenCalled();
   });
+
+  it("formats large attachment sizes in GB", () => {
+    render(
+      <AttachmentPreview
+        att={{
+          type: "file",
+          name: "large.zip",
+          size: 3.14 * 1024 * 1024 * 1024,
+          mimeType: "application/zip",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("3.14 GB")).toBeInTheDocument();
+  });
+
+  it("shows a progress bar while an attachment is uploading", () => {
+    render(
+      <AttachmentPreview
+        att={{
+          type: "image",
+          name: "large.png",
+          size: 16 * 1024 * 1024,
+          mimeType: "image/png",
+          uploadStatus: "uploading",
+          uploadProgress: 0.42,
+        }}
+      />,
+    );
+
+    const progress = screen.getByLabelText("附件处理进度");
+    expect(progress).toBeInTheDocument();
+    expect(progress).toHaveAttribute("value", "42");
+    expect(screen.getByText("处理中")).toBeInTheDocument();
+  });
 });

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -4118,11 +4118,14 @@ class Agent:
                 att_name = getattr(att, "name", None) or "file"
                 att_url = getattr(att, "url", None) or ""
                 att_mime = getattr(att, "mime_type", None) or att_type
+                att_local_path = getattr(att, "local_path", None) or ""
                 self.memory_manager.record_attachment(
                     filename=att_name,
                     mime_type=att_mime,
+                    local_path=att_local_path,
                     url=att_url,
                     direction="inbound",
+                    file_size=getattr(att, "size", 0) or 0,
                 )
 
     @staticmethod
@@ -5630,7 +5633,7 @@ class Agent:
                         _degraded_notices.append(
                             f"[用户发送了视频 {att_name}，当前模型不支持视频输入]"
                         )
-                elif att_url:
+                elif att_url or att_local_path:
                     content_blocks.append(
                         {
                             "type": "text",

--- a/tests/runtime/test_desktop_attachments.py
+++ b/tests/runtime/test_desktop_attachments.py
@@ -52,13 +52,8 @@ def test_local_upload_re_matches_local_urls_only() -> None:
 def test_maybe_inline_local_image_skips_remote_urls() -> None:
     """Non-local URLs short-circuit to None without IO."""
     assert attachments.maybe_inline_local_image("", "image/png") is None
-    assert attachments.maybe_inline_local_image(
-        "https://example.com/foo.png", "image/png"
-    ) is None
-    assert (
-        attachments.maybe_inline_local_image("data:image/png;base64,AAAA", "image/png")
-        is None
-    )
+    assert attachments.maybe_inline_local_image("https://example.com/foo.png", "image/png") is None
+    assert attachments.maybe_inline_local_image("data:image/png;base64,AAAA", "image/png") is None
 
 
 def test_maybe_inline_local_image_returns_data_url(tmp_path) -> None:
@@ -71,9 +66,7 @@ def test_maybe_inline_local_image_returns_data_url(tmp_path) -> None:
         "openakita.api.routes.upload.get_upload_dir",
         return_value=upload_dir,
     ):
-        out = attachments.maybe_inline_local_image(
-            "/api/uploads/tiny.png", "image/png"
-        )
+        out = attachments.maybe_inline_local_image("/api/uploads/tiny.png", "image/png")
     assert out is not None
     assert out.startswith("data:image/png;base64,")
     body = out.split(",", 1)[1]
@@ -90,9 +83,7 @@ def test_maybe_inline_local_image_skips_oversized(tmp_path) -> None:
         "openakita.api.routes.upload.get_upload_dir",
         return_value=upload_dir,
     ):
-        out = attachments.maybe_inline_local_image(
-            "/api/uploads/big.png", "image/png"
-        )
+        out = attachments.maybe_inline_local_image("/api/uploads/big.png", "image/png")
     assert out is None
 
 
@@ -122,6 +113,24 @@ def test_format_desktop_attachment_reference_audio_default() -> None:
     )
     assert "音频" in text  # audio label in Chinese
     assert "memo.mp3" in text
+
+
+def test_format_desktop_attachment_reference_local_path_without_url() -> None:
+    """A desktop drop can reference a large local file without an upload URL."""
+    text = attachments.format_desktop_attachment_reference(
+        att_type="file",
+        att_name="archive.zip",
+        att_mime="application/zip",
+        att_url="",
+        att_local_path="D:/tmp/archive.zip",
+        att_size=3_371_549_327,
+    )
+
+    assert "archive.zip" in text
+    assert "D:/tmp/archive.zip" in text
+    assert "URL: 无" in text
+    assert "3371549327 bytes" in text
+    assert "直接使用文件/音频处理工具打开该本地路径" in text
 
 
 def test_save_data_uri_attachment_rejects_non_data_uri() -> None:
@@ -181,4 +190,5 @@ def test_module_exports_are_stable() -> None:
         "save_data_uri_attachment",
     }
     from openakita.runtime.desktop import __all__ as pkg_all
+
     assert set(pkg_all) == expected


### PR DESCRIPTION
## Summary
- Avoid reading large desktop-dropped files into the WebView by staging non-media files as local attachments.
- Show real progress while local media files are read and use processing-focused attachment copy.

## Tests
- `npx tsc -b --pretty false`
- `npm run test:run -- src/views/chat/components/__tests__/AttachmentPreview.test.tsx`
- `npm run lint -- --quiet src/views/ChatView.tsx src/views/chat/components/AttachmentPreview.tsx src/views/chat/components/__tests__/AttachmentPreview.test.tsx src/types.ts src/platform/index.ts`
- `cargo check`
- `uv run --no-sync pytest tests/runtime/test_desktop_attachments.py tests/unit/test_desktop_attachment_reference.py tests/unit/test_session_history_attachments.py`
- `git diff --check`