### PR TITLE
Add per-agent capability controls for tools, MCP servers, and skills

### DIFF
--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -1898,6 +1898,66 @@
     "skillsModeInclusive": "Only selected skills",
     "skillsModeExclusive": "Exclude selected skills",
     "skillSearchPlaceholder": "Search skills…",
+    "systemAbilities": "Built-in abilities",
+    "externalServices": "External services",
+    "skillExtensions": "Skills",
+    "modeAll": "All available",
+    "modeInclusive": "Only selected",
+    "modeExclusive": "Exclude selected",
+    "systemSearchPlaceholder": "Search built-in abilities…",
+    "serviceSearchPlaceholder": "Search external services…",
+    "noSystemAbilities": "No built-in abilities are available",
+    "noExternalServices": "No external services are configured",
+    "noSkills": "No skills available",
+    "noCapabilityMatches": "No matches",
+    "serviceDefaultDescription": "External service available to agents",
+    "serviceReady": "Ready",
+    "serviceNotConnected": "Not connected",
+    "serviceDisabled": "Disabled",
+    "availableActions": "{{count}} abilities",
+    "skillDisabled": "Disabled",
+    "toolCategory": {
+      "research": {
+        "label": "Web research",
+        "description": "Find public information, news, and web pages"
+      },
+      "planning": {
+        "label": "Planning",
+        "description": "Break down work and track step progress"
+      },
+      "filesystem": {
+        "label": "Files and commands",
+        "description": "Read and edit files, and run commands when needed"
+      },
+      "memory": {
+        "label": "Memory",
+        "description": "Read and save long-term information for tasks"
+      },
+      "browser": {
+        "label": "Browser",
+        "description": "Open pages, click, type, capture screenshots, and read page content"
+      },
+      "desktop": {
+        "label": "Desktop control",
+        "description": "Inspect and operate local application windows"
+      },
+      "communication": {
+        "label": "Messages and files",
+        "description": "Read current chat context and deliver generated files"
+      },
+      "scheduled": {
+        "label": "Reminders and scheduled tasks",
+        "description": "Create, update, and trigger reminders or automated tasks"
+      },
+      "code": {
+        "label": "Code assistance",
+        "description": "Read diagnostics, find code references, and use language feedback"
+      },
+      "profile": {
+        "label": "User preferences",
+        "description": "Read or update user preferences and proactive help settings"
+      }
+    },
     "category": "Category",
     "categoryAll": "All",
     "categoryGeneral": "General",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -1898,6 +1898,66 @@
     "skillsModeInclusive": "仅使用勾选的技能",
     "skillsModeExclusive": "排除勾选的技能",
     "skillSearchPlaceholder": "搜索技能…",
+    "systemAbilities": "内置能力",
+    "externalServices": "外部服务",
+    "skillExtensions": "技能",
+    "modeAll": "全部可用",
+    "modeInclusive": "仅所选",
+    "modeExclusive": "排除所选",
+    "systemSearchPlaceholder": "搜索内置能力…",
+    "serviceSearchPlaceholder": "搜索外部服务…",
+    "noSystemAbilities": "暂无可配置的内置能力",
+    "noExternalServices": "暂无已配置的外部服务",
+    "noSkills": "暂无可用技能",
+    "noCapabilityMatches": "没有匹配项",
+    "serviceDefaultDescription": "可供 Agent 使用的外部服务",
+    "serviceReady": "可用",
+    "serviceNotConnected": "未连接",
+    "serviceDisabled": "已停用",
+    "availableActions": "{{count}} 项能力",
+    "skillDisabled": "已停用",
+    "toolCategory": {
+      "research": {
+        "label": "网络搜索",
+        "description": "查找公开信息、新闻和网页内容"
+      },
+      "planning": {
+        "label": "计划跟踪",
+        "description": "拆分任务、跟踪步骤进度"
+      },
+      "filesystem": {
+        "label": "文件和命令",
+        "description": "读取、编辑文件，并在需要时运行命令"
+      },
+      "memory": {
+        "label": "记忆",
+        "description": "读取和保存与任务相关的长期信息"
+      },
+      "browser": {
+        "label": "浏览器",
+        "description": "打开网页、点击、输入、截图和读取页面内容"
+      },
+      "desktop": {
+        "label": "桌面操作",
+        "description": "查看和操作本机窗口界面"
+      },
+      "communication": {
+        "label": "消息和文件",
+        "description": "读取当前会话资料并交付生成的文件"
+      },
+      "scheduled": {
+        "label": "提醒和定时任务",
+        "description": "创建、更新和触发提醒或自动任务"
+      },
+      "code": {
+        "label": "代码辅助",
+        "description": "读取诊断信息、查找代码引用和语言服务反馈"
+      },
+      "profile": {
+        "label": "用户偏好",
+        "description": "读取或更新用户偏好和主动协助设置"
+      }
+    },
     "category": "分类",
     "categoryAll": "全部",
     "categoryGeneral": "通用基础",

--- a/apps/setup-center/src/views/AgentManagerView.tsx
+++ b/apps/setup-center/src/views/AgentManagerView.tsx
@@ -24,6 +24,10 @@ type AgentProfile = {
   type: string;
   skills: string[];
   skills_mode: string;
+  tools: string[];
+  tools_mode: string;
+  mcp_servers: string[];
+  mcp_mode: string;
   custom_prompt: string;
   preferred_endpoint?: string | null;
   endpoint_policy?: "prefer" | "require";
@@ -44,6 +48,20 @@ type SkillItem = {
   name_i18n?: Record<string, string> | null;
 };
 
+type ToolCategoryItem = {
+  id: string;
+  tools: string[];
+};
+
+type McpServerItem = {
+  name: string;
+  description?: string;
+  connected?: boolean;
+  enabled?: boolean;
+  tool_count?: number;
+  catalog_tool_count?: number;
+};
+
 type ModelInfo = {
   name: string;
   provider: string;
@@ -61,6 +79,10 @@ const EMPTY_PROFILE: AgentProfile = {
   type: "custom",
   skills: [],
   skills_mode: "all",
+  tools: [],
+  tools_mode: "all",
+  mcp_servers: [],
+  mcp_mode: "all",
   custom_prompt: "",
   preferred_endpoint: null,
   endpoint_policy: "prefer",
@@ -183,6 +205,8 @@ export function AgentManagerView({
   const [saving, setSaving] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [availableSkills, setAvailableSkills] = useState<SkillItem[]>([]);
+  const [availableToolCategories, setAvailableToolCategories] = useState<ToolCategoryItem[]>([]);
+  const [availableMcpServers, setAvailableMcpServers] = useState<McpServerItem[]>([]);
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
   const [iconCat, setIconCat] = useState("common");
@@ -194,6 +218,8 @@ export function AgentManagerView({
   const [newCatLabel, setNewCatLabel] = useState("");
   const [newCatColor, setNewCatColor] = useState("#6b7280");
   const [batchSelected, setBatchSelected] = useState<Set<string>>(new Set());
+  const [toolSearch, setToolSearch] = useState("");
+  const [mcpSearch, setMcpSearch] = useState("");
   const [skillSearch, setSkillSearch] = useState("");
   const importInputRef = useRef<HTMLInputElement>(null);
 
@@ -290,6 +316,40 @@ export function AgentManagerView({
       );
     } catch {
       /* skills endpoint may not be available */
+    }
+  }, [apiBaseUrl]);
+
+  const fetchToolCategories = useCallback(async () => {
+    try {
+      const res = await safeFetch(`${apiBaseUrl}/api/agents/tool-categories`);
+      const data = await res.json();
+      setAvailableToolCategories(
+        (data.categories || []).map((cat: any) => ({
+          id: String(cat.id || cat.name || ""),
+          tools: Array.isArray(cat.tools) ? cat.tools.map((name: unknown) => String(name)) : [],
+        })).filter((cat: ToolCategoryItem) => cat.id),
+      );
+    } catch {
+      /* tool categories endpoint may not be available */
+    }
+  }, [apiBaseUrl]);
+
+  const fetchMcpServers = useCallback(async () => {
+    try {
+      const res = await safeFetch(`${apiBaseUrl}/api/mcp/servers`);
+      const data = await res.json();
+      setAvailableMcpServers(
+        (data.servers || []).map((server: any) => ({
+          name: String(server.name || ""),
+          description: server.description || "",
+          connected: !!server.connected,
+          enabled: server.enabled !== false,
+          tool_count: Number(server.tool_count || 0),
+          catalog_tool_count: Number(server.catalog_tool_count || 0),
+        })).filter((server: McpServerItem) => server.name),
+      );
+    } catch {
+      /* MCP endpoint may not be available */
     }
   }, [apiBaseUrl]);
 
@@ -408,26 +468,51 @@ export function AgentManagerView({
     if (visible) {
       fetchProfiles();
       fetchSkills();
+      fetchToolCategories();
+      fetchMcpServers();
       fetchCategories();
       fetchModels();
     }
-  }, [visible, fetchProfiles, fetchSkills, fetchCategories, fetchModels]);
+  }, [
+    visible,
+    fetchProfiles,
+    fetchSkills,
+    fetchToolCategories,
+    fetchMcpServers,
+    fetchCategories,
+    fetchModels,
+  ]);
 
   const openCreateEditor = () => {
     setEditingProfile({ ...EMPTY_PROFILE });
     setIsCreating(true);
     setEditorOpen(true);
     setEmojiPickerOpen(false);
+    setToolSearch("");
+    setMcpSearch("");
+    setSkillSearch("");
     setIdentityContent("");
     setIdentitySource("global");
     setMemoryStats(null);
   };
 
   const openEditEditor = (profile: AgentProfile) => {
-    setEditingProfile({ ...profile });
+    setEditingProfile({
+      ...EMPTY_PROFILE,
+      ...profile,
+      tools: profile.tools || [],
+      tools_mode: profile.tools_mode || "all",
+      mcp_servers: profile.mcp_servers || [],
+      mcp_mode: profile.mcp_mode || "all",
+      skills: profile.skills || [],
+      skills_mode: profile.skills_mode || "all",
+    });
     setIsCreating(false);
     setEditorOpen(true);
     setEmojiPickerOpen(false);
+    setToolSearch("");
+    setMcpSearch("");
+    setSkillSearch("");
     if (profile.identity_mode === "custom") {
       loadIdentityFile(profile.id, identityTab);
     }
@@ -439,6 +524,8 @@ export function AgentManagerView({
   const closeEditor = () => {
     setEditorOpen(false);
     setEmojiPickerOpen(false);
+    setToolSearch("");
+    setMcpSearch("");
     setSkillSearch("");
   };
 
@@ -471,6 +558,10 @@ export function AgentManagerView({
         description: editingProfile.description,
         icon: editingProfile.icon,
         color: editingProfile.color,
+        tools: editingProfile.tools,
+        tools_mode: editingProfile.tools_mode,
+        mcp_servers: editingProfile.mcp_servers,
+        mcp_mode: editingProfile.mcp_mode,
         skills: editingProfile.skills,
         skills_mode: editingProfile.skills_mode,
         custom_prompt: editingProfile.custom_prompt,
@@ -522,6 +613,24 @@ export function AgentManagerView({
     });
   };
 
+  const toggleToolCategory = (categoryId: string) => {
+    setEditingProfile((prev) => {
+      const tools = prev.tools.includes(categoryId)
+        ? prev.tools.filter((name) => name !== categoryId)
+        : [...prev.tools, categoryId];
+      return { ...prev, tools };
+    });
+  };
+
+  const toggleMcpServer = (serverName: string) => {
+    setEditingProfile((prev) => {
+      const mcp_servers = prev.mcp_servers.includes(serverName)
+        ? prev.mcp_servers.filter((name) => name !== serverName)
+        : [...prev.mcp_servers, serverName];
+      return { ...prev, mcp_servers };
+    });
+  };
+
   const handleVisibility = async (profileId: string, hidden: boolean) => {
     try {
       await safeFetch(`${apiBaseUrl}/api/agents/profiles/${profileId}/visibility`, {
@@ -564,6 +673,12 @@ export function AgentManagerView({
   const getI18nName = (agent: AgentProfile) => agent.name_i18n?.[langKey] || agent.name;
   const getI18nDesc = (agent: AgentProfile) => agent.description_i18n?.[langKey] || agent.description;
 
+  const getToolCategoryLabel = (categoryId: string): string =>
+    t(`agentManager.toolCategory.${categoryId}.label`, { defaultValue: categoryId });
+
+  const getToolCategoryDescription = (categoryId: string): string =>
+    t(`agentManager.toolCategory.${categoryId}.description`, { defaultValue: "" });
+
   const getCategoryColor = (catId: string): string => {
     const found = categories.find((c) => c.id === catId);
     return found?.color || "var(--primary, #3b82f6)";
@@ -593,6 +708,29 @@ export function AgentManagerView({
   const filteredProfiles = activeCategory
     ? visibleProfiles.filter((p) => p.category === activeCategory)
     : visibleProfiles;
+  const toolQuery = toolSearch.trim().toLowerCase();
+  const filteredToolCategories = availableToolCategories.filter((category) => {
+    if (!toolQuery) return true;
+    return (
+      category.id.toLowerCase().includes(toolQuery) ||
+      getToolCategoryLabel(category.id).toLowerCase().includes(toolQuery) ||
+      getToolCategoryDescription(category.id).toLowerCase().includes(toolQuery)
+    );
+  });
+  const mcpQuery = mcpSearch.trim().toLowerCase();
+  const filteredMcpServers = availableMcpServers.filter((server) => {
+    if (!mcpQuery) return true;
+    return (
+      server.name.toLowerCase().includes(mcpQuery) ||
+      (server.description || "").toLowerCase().includes(mcpQuery)
+    );
+  });
+  const skillQuery = skillSearch.trim().toLowerCase();
+  const filteredSkills = availableSkills.filter((skill) => {
+    if (!skillQuery) return true;
+    const displayName = skill.name_i18n?.[langKey] || skill.name;
+    return displayName.toLowerCase().includes(skillQuery) || skill.name.toLowerCase().includes(skillQuery);
+  });
 
   return (
     <div style={{ padding: 20, position: "relative", overflow: "auto", height: "100%" }}>
@@ -1185,63 +1323,210 @@ export function AgentManagerView({
               </div>
             </div>
 
-            {/* Skills Mode */}
             <div className="space-y-1.5">
-              <Label className="text-xs opacity-70">{t("agentManager.skills")}</Label>
+              <Label className="text-xs opacity-70">{t("agentManager.systemAbilities")}</Label>
+              <Select
+                value={editingProfile.tools_mode}
+                onValueChange={(v) => { setEditingProfile((p) => ({ ...p, tools_mode: v })); setToolSearch(""); }}
+              >
+                <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("agentManager.modeAll")}</SelectItem>
+                  <SelectItem value="inclusive">{t("agentManager.modeInclusive")}</SelectItem>
+                  <SelectItem value="exclusive">{t("agentManager.modeExclusive")}</SelectItem>
+                </SelectContent>
+              </Select>
+              {editingProfile.tools_mode !== "all" && (
+                <>
+                  {availableToolCategories.length > 4 && (
+                    <Input
+                      placeholder={t("agentManager.systemSearchPlaceholder")}
+                      value={toolSearch}
+                      onChange={(e) => setToolSearch(e.target.value)}
+                      className="h-8 text-xs"
+                    />
+                  )}
+                  <div className="max-h-[220px] overflow-y-auto rounded-md border p-1">
+                    {availableToolCategories.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noSystemAbilities")}
+                      </div>
+                    ) : filteredToolCategories.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noCapabilityMatches")}
+                      </div>
+                    ) : (
+                      filteredToolCategories.map((category) => {
+                        const checked = editingProfile.tools.includes(category.id);
+                        return (
+                          <label
+                            key={category.id}
+                            className={`flex cursor-pointer items-start gap-2.5 rounded-md px-2.5 py-2 text-[13px] transition-colors ${
+                              checked ? "bg-primary/8" : "hover:bg-accent/50"
+                            }`}
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={() => toggleToolCategory(category.id)}
+                              className="mt-0.5"
+                            />
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate font-medium">{getToolCategoryLabel(category.id)}</span>
+                              <span className="block truncate text-[11px] text-muted-foreground">
+                                {getToolCategoryDescription(category.id)}
+                              </span>
+                            </span>
+                          </label>
+                        );
+                      })
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-xs opacity-70">{t("agentManager.externalServices")}</Label>
+              <Select
+                value={editingProfile.mcp_mode}
+                onValueChange={(v) => { setEditingProfile((p) => ({ ...p, mcp_mode: v })); setMcpSearch(""); }}
+              >
+                <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("agentManager.modeAll")}</SelectItem>
+                  <SelectItem value="inclusive">{t("agentManager.modeInclusive")}</SelectItem>
+                  <SelectItem value="exclusive">{t("agentManager.modeExclusive")}</SelectItem>
+                </SelectContent>
+              </Select>
+              {editingProfile.mcp_mode !== "all" && (
+                <>
+                  {availableMcpServers.length > 4 && (
+                    <Input
+                      placeholder={t("agentManager.serviceSearchPlaceholder")}
+                      value={mcpSearch}
+                      onChange={(e) => setMcpSearch(e.target.value)}
+                      className="h-8 text-xs"
+                    />
+                  )}
+                  <div className="max-h-[220px] overflow-y-auto rounded-md border p-1">
+                    {availableMcpServers.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noExternalServices")}
+                      </div>
+                    ) : filteredMcpServers.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noCapabilityMatches")}
+                      </div>
+                    ) : (
+                      filteredMcpServers.map((server) => {
+                        const checked = editingProfile.mcp_servers.includes(server.name);
+                        const actionCount = server.tool_count || server.catalog_tool_count || 0;
+                        return (
+                          <label
+                            key={server.name}
+                            className={`flex cursor-pointer items-start gap-2.5 rounded-md px-2.5 py-2 text-[13px] transition-colors ${
+                              checked ? "bg-primary/8" : "hover:bg-accent/50"
+                            }`}
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={() => toggleMcpServer(server.name)}
+                              className="mt-0.5"
+                            />
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate font-medium">{server.name}</span>
+                              <span className="block truncate text-[11px] text-muted-foreground">
+                                {server.description || t("agentManager.serviceDefaultDescription")}
+                              </span>
+                            </span>
+                            <span className="flex shrink-0 flex-col items-end gap-1">
+                              <Badge
+                                variant={server.enabled === false || !server.connected ? "outline" : "default"}
+                                className="text-[10px] font-normal"
+                              >
+                                {server.enabled === false
+                                  ? t("agentManager.serviceDisabled")
+                                  : server.connected
+                                    ? t("agentManager.serviceReady")
+                                    : t("agentManager.serviceNotConnected")}
+                              </Badge>
+                              {actionCount > 0 && (
+                                <span className="text-[10px] text-muted-foreground">
+                                  {t("agentManager.availableActions", { count: actionCount })}
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                        );
+                      })
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-xs opacity-70">{t("agentManager.skillExtensions")}</Label>
               <Select
                 value={editingProfile.skills_mode}
                 onValueChange={(v) => { setEditingProfile((p) => ({ ...p, skills_mode: v })); setSkillSearch(""); }}
               >
                 <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">{t("agentManager.skillsModeAll")}</SelectItem>
-                  <SelectItem value="inclusive">{t("agentManager.skillsModeInclusive")}</SelectItem>
-                  <SelectItem value="exclusive">{t("agentManager.skillsModeExclusive")}</SelectItem>
+                  <SelectItem value="all">{t("agentManager.modeAll")}</SelectItem>
+                  <SelectItem value="inclusive">{t("agentManager.modeInclusive")}</SelectItem>
+                  <SelectItem value="exclusive">{t("agentManager.modeExclusive")}</SelectItem>
                 </SelectContent>
               </Select>
+              {editingProfile.skills_mode !== "all" && (
+                <>
+                  {availableSkills.length > 4 && (
+                    <Input
+                      placeholder={t("agentManager.skillSearchPlaceholder")}
+                      value={skillSearch}
+                      onChange={(e) => setSkillSearch(e.target.value)}
+                      className="h-8 text-xs"
+                    />
+                  )}
+                  <div className="max-h-[220px] overflow-y-auto rounded-md border p-1">
+                    {availableSkills.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noSkills")}
+                      </div>
+                    ) : filteredSkills.length === 0 ? (
+                      <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                        {t("agentManager.noCapabilityMatches")}
+                      </div>
+                    ) : (
+                      filteredSkills.map((skill) => {
+                        const checked = editingProfile.skills.includes(skill.skillId);
+                        return (
+                          <label
+                            key={skill.skillId}
+                            className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] transition-colors ${
+                              checked ? "bg-primary/8" : "hover:bg-accent/50"
+                            }`}
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={() => toggleSkill(skill.skillId)}
+                            />
+                            <span className="min-w-0 flex-1 truncate">
+                              {skill.name_i18n?.[langKey] || skill.name}
+                            </span>
+                            {!skill.enabled && (
+                              <Badge variant="outline" className="shrink-0 text-[10px] font-normal">
+                                {t("agentManager.skillDisabled")}
+                              </Badge>
+                            )}
+                          </label>
+                        );
+                      })
+                    )}
+                  </div>
+                </>
+              )}
             </div>
-
-            {/* Skills multi-select */}
-            {editingProfile.skills_mode !== "all" && availableSkills.length > 0 && (
-              <div className="rounded-lg border">
-                <div className="p-1.5 border-b">
-                  <Input
-                    placeholder={t("agentManager.skillSearchPlaceholder")}
-                    value={skillSearch}
-                    onChange={(e) => setSkillSearch(e.target.value)}
-                    className="h-7 text-xs"
-                  />
-                </div>
-                <div className="max-h-[200px] overflow-y-auto p-1">
-                  {availableSkills
-                    .filter((skill) => {
-                      if (!skillSearch.trim()) return true;
-                      const q = skillSearch.trim().toLowerCase();
-                      const displayName = skill.name_i18n?.[i18n.language?.startsWith("zh") ? "zh" : i18n.language || "zh"] || skill.name;
-                      return displayName.toLowerCase().includes(q) || skill.name.toLowerCase().includes(q);
-                    })
-                    .map((skill) => {
-                      const checked = editingProfile.skills.includes(skill.skillId);
-                      return (
-                        <label
-                          key={skill.skillId}
-                          className={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md cursor-pointer text-[13px] transition-colors ${
-                            checked ? "bg-primary/8" : "hover:bg-accent/50"
-                          }`}
-                        >
-                          <Checkbox
-                            checked={checked}
-                            onCheckedChange={() => toggleSkill(skill.skillId)}
-                          />
-                          <span className="flex-1 min-w-0 truncate">
-                            {skill.name_i18n?.[i18n.language?.startsWith("zh") ? "zh" : i18n.language || "zh"] || skill.name}
-                          </span>
-                        </label>
-                      );
-                    })}
-                </div>
-              </div>
-            )}
 
             {/* Preferred Endpoint */}
             <div className="space-y-1.5">

--- a/src/openakita/agents/factory.py
+++ b/src/openakita/agents/factory.py
@@ -23,30 +23,32 @@ logger = logging.getLogger(__name__)
 _IDLE_TIMEOUT_SECONDS = 30 * 60  # 30 分钟空闲回收
 _REAP_INTERVAL_SECONDS = 60  # 每分钟检查一次
 
-# INCLUSIVE 模式下始终保留的基础系统工具。
-# 所有子 Agent（含用户手动创建的）都需要这些工具才能正常工作。
-# 只有浏览器、桌面控制、MCP、定时任务等专用工具需在 profile.skills 显式列出。
+# INCLUSIVE 模式下始终保留的基础控制工具。业务能力（文件、网络、记忆、
+# 浏览器等）必须由 profile.tools 精确放行。
 ESSENTIAL_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        "run_shell",
-        "read_file",
-        "write_file",
-        "list_directory",
-        "web_search",
-        "deliver_artifacts",
-        "get_chat_history",
-        "search_memory",
-        "add_memory",
-        "create_todo",
-        "update_todo_step",
-        "get_todo_status",
-        "complete_todo",
-        "list_skills",
-        "get_skill_info",
         "get_tool_info",
         "set_task_timeout",
-        "get_image_file",
-        "get_voice_file",
+    }
+)
+
+MCP_GATEWAY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "call_mcp_tool",
+        "list_mcp_servers",
+        "get_mcp_instructions",
+        "connect_mcp_server",
+        "disconnect_mcp_server",
+    }
+)
+
+SKILL_GATEWAY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "list_skills",
+        "get_skill_info",
+        "get_skill_reference",
+        "run_skill_script",
+        "execute_skill",
     }
 )
 
@@ -214,8 +216,10 @@ class AgentFactory:
         # Rebuild the initial system prompt so it reflects the filtered catalogs.
         # INCLUSIVE 模式无论 skills 是否为空都需要重建（空列表 = 隐藏全部非必要技能）。
         needs_rebuild = (
-            (profile.tools_mode != "all" and profile.tools)
-            or (profile.mcp_mode != "all" and profile.mcp_servers)
+            profile.tools_mode == "inclusive"
+            or (profile.tools_mode == "exclusive" and profile.tools)
+            or profile.mcp_mode == "inclusive"
+            or (profile.mcp_mode == "exclusive" and profile.mcp_servers)
             or profile.skills_mode == SkillsMode.INCLUSIVE
             or (profile.skills_mode == SkillsMode.EXCLUSIVE and profile.skills)
         )
@@ -360,26 +364,26 @@ class AgentFactory:
         """按 profile.tools + tools_mode 过滤 Agent 的工具列表。
 
         tools 字段支持类目名（如 "research"）和具体工具名的混合。
-        INCLUSIVE 模式下 ESSENTIAL_TOOL_NAMES 始终保留。
+        INCLUSIVE 模式下只保留基础控制工具，以及由 MCP/Skill 区块独立放行
+        所需的入口工具。
         """
-        if profile.tools_mode == "all" or not profile.tools:
+        if profile.tools_mode == "all":
+            return
+        if profile.tools_mode == "exclusive" and not profile.tools:
             return
 
         from ..orgs.tool_categories import expand_tool_categories
 
         specified = expand_tool_categories(profile.tools)
+        always_allowed = AgentFactory._always_allowed_tool_names(profile)
 
         if profile.tools_mode == "inclusive":
             agent._tools = [
-                t
-                for t in agent._tools
-                if t["name"] in specified or t["name"] in ESSENTIAL_TOOL_NAMES
+                t for t in agent._tools if t["name"] in specified or t["name"] in always_allowed
             ]
         elif profile.tools_mode == "exclusive":
             agent._tools = [
-                t
-                for t in agent._tools
-                if t["name"] not in specified or t["name"] in ESSENTIAL_TOOL_NAMES
+                t for t in agent._tools if t["name"] not in specified or t["name"] in always_allowed
             ]
 
         agent._tools.sort(key=lambda t: t["name"])
@@ -398,7 +402,9 @@ class AgentFactory:
         创建一个 filtered clone 替换 agent.mcp_catalog，
         使 call_mcp_tool handler 只能访问 clone 中的 server。
         """
-        if profile.mcp_mode == "all" or not profile.mcp_servers:
+        if profile.mcp_mode == "all":
+            return
+        if profile.mcp_mode == "exclusive" and not profile.mcp_servers:
             return
 
         catalog = getattr(agent, "mcp_catalog", None)
@@ -412,6 +418,15 @@ class AgentFactory:
             f"servers={profile.mcp_servers}, "
             f"remaining={filtered.server_count} servers"
         )
+
+    @staticmethod
+    def _always_allowed_tool_names(profile: AgentProfile) -> frozenset[str]:
+        allowed = set(ESSENTIAL_TOOL_NAMES)
+        if profile.mcp_mode != "inclusive" or profile.mcp_servers:
+            allowed.update(MCP_GATEWAY_TOOL_NAMES)
+        if profile.skills_mode != SkillsMode.INCLUSIVE or profile.skills:
+            allowed.update(SKILL_GATEWAY_TOOL_NAMES)
+        return frozenset(allowed)
 
     @staticmethod
     def _apply_identity_override(agent: Agent, profile: AgentProfile) -> None:

--- a/src/openakita/agents/profile.py
+++ b/src/openakita/agents/profile.py
@@ -58,6 +58,7 @@ _SKILLS_MODE_ALIASES: dict[str, str] = {
 }
 _IDENTITY_MODES = frozenset({"shared", "custom"})
 _MEMORY_MODES = frozenset({"shared", "isolated"})
+_LIST_MODES = frozenset({"all", "inclusive", "exclusive"})
 
 
 def _normalize_choice(value: Any, *, allowed: frozenset[str], default: str, field_name: str) -> str:
@@ -208,6 +209,24 @@ class AgentProfile:
     def __post_init__(self):
         self.type = safe_agent_type(self.type)
         self.skills_mode = safe_skills_mode(self.skills_mode)
+        self.tools_mode = _normalize_choice(
+            self.tools_mode,
+            allowed=_LIST_MODES,
+            default="all",
+            field_name="tools_mode",
+        )
+        self.mcp_mode = _normalize_choice(
+            self.mcp_mode,
+            allowed=_LIST_MODES,
+            default="all",
+            field_name="mcp_mode",
+        )
+        self.plugins_mode = _normalize_choice(
+            self.plugins_mode,
+            allowed=_LIST_MODES,
+            default="all",
+            field_name="plugins_mode",
+        )
         if self.endpoint_policy not in {"prefer", "require"}:
             self.endpoint_policy = "prefer"
         self.identity_mode = _normalize_choice(

--- a/src/openakita/api/routes/agents.py
+++ b/src/openakita/api/routes/agents.py
@@ -31,6 +31,16 @@ VALID_BOT_TYPES = frozenset(
         "wechat",
     }
 )
+VALID_PROFILE_LIST_MODES = frozenset({"all", "inclusive", "exclusive"})
+
+
+def _validate_profile_list_mode(field_name: str, value: str | None) -> None:
+    if value is None or value in VALID_PROFILE_LIST_MODES:
+        return
+    raise HTTPException(
+        status_code=400,
+        detail=f"{field_name} must be one of: {', '.join(sorted(VALID_PROFILE_LIST_MODES))}",
+    )
 
 
 def _invalidate_bot_agent_sessions(bot_cfg: dict) -> None:
@@ -433,6 +443,14 @@ async def delete_category(category_id: str):
     return {"status": "ok"}
 
 
+@router.get("/api/agents/tool-categories")
+async def list_agent_tool_categories():
+    """Return built-in capability categories available to Agent profiles."""
+    from openakita.orgs.tool_categories import list_agent_system_tool_categories
+
+    return {"categories": list_agent_system_tool_categories()}
+
+
 # ─── Agent profile routes ───────────────────────────────────────────────
 
 
@@ -479,25 +497,15 @@ async def create_agent_profile(body: ProfileCreateRequest):
     """Create a new custom agent profile."""
     from openakita.agents.profile import AgentProfile, AgentType, SkillsMode, get_profile_store
 
-    valid_modes = {"all", "inclusive", "exclusive"}
-    if body.skills_mode not in valid_modes:
-        raise HTTPException(
-            status_code=400, detail=f"skills_mode must be one of: {', '.join(valid_modes)}"
-        )
+    _validate_profile_list_mode("skills_mode", body.skills_mode)
 
     store = get_profile_store()
 
     if store.exists(body.id):
         raise HTTPException(status_code=400, detail=f"Profile '{body.id}' already exists")
 
-    valid_mode_values = {"all", "inclusive", "exclusive"}
     for field_name in ("tools_mode", "mcp_mode", "plugins_mode"):
-        val = getattr(body, field_name)
-        if val not in valid_mode_values:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{field_name} must be one of: {', '.join(valid_mode_values)}",
-            )
+        _validate_profile_list_mode(field_name, getattr(body, field_name))
 
     profile = AgentProfile(
         id=body.id,
@@ -538,12 +546,8 @@ async def update_agent_profile(profile_id: str, body: ProfileUpdateRequest, requ
     """Update a custom agent profile (system profiles have restricted updates)."""
     from openakita.agents.profile import get_profile_store
 
-    if body.skills_mode is not None:
-        valid_modes = {"all", "inclusive", "exclusive"}
-        if body.skills_mode not in valid_modes:
-            raise HTTPException(
-                status_code=400, detail=f"skills_mode must be one of: {', '.join(valid_modes)}"
-            )
+    for field_name in ("skills_mode", "tools_mode", "mcp_mode", "plugins_mode"):
+        _validate_profile_list_mode(field_name, getattr(body, field_name))
 
     store = get_profile_store()
     update_data = body.model_dump(exclude_unset=True)

--- a/src/openakita/orgs/_runtime_tool_categories.py
+++ b/src/openakita/orgs/_runtime_tool_categories.py
@@ -4,15 +4,8 @@
 # ADR-0011 6-subsystem layout). Body restored verbatim from 90a7d77f~1.
 #
 # A 5-LOC public re-export at src/openakita/orgs/tool_categories.py preserves
-# the original import path; the 4 known callers
-#   - src/openakita/agents/factory.py:370 (expand_tool_categories)
-#   - src/openakita/tools/handlers/org_setup.py:129 (TOOL_CATEGORIES)
-#   - src/openakita/tools/handlers/org_setup.py:440 (get_avatar_for_role / get_preset_for_role)
-#   - src/openakita/tools/handlers/org_setup.py:731 (get_avatar_for_role / get_preset_for_role)
-# stay unchanged. Symbols exported: TOOL_CATEGORIES, ROLE_TOOL_PRESETS,
-# ALL_CATEGORY_NAMES, expand_tool_categories, get_preset_for_role,
-# list_categories, AVATAR_PRESETS, AVATAR_MAP, get_avatar_for_role,
-# list_avatar_presets.
+# the original import path for runtime filtering, org setup resources, and the
+# Agent capability editor.
 
 """
 外部工具类目定义、岗位角色工具预设、节点头像预设。
@@ -26,39 +19,123 @@ from __future__ import annotations
 TOOL_CATEGORIES: dict[str, list[str]] = {
     "research": ["web_search", "news_search", "web_fetch"],
     "planning": [
-        "create_plan", "update_plan_step",
-        "get_plan_status", "complete_plan",
+        "create_todo",
+        "update_todo_step",
+        "get_todo_status",
+        "complete_todo",
+        "create_plan_file",
     ],
-    "filesystem": ["run_shell", "write_file", "read_file", "list_directory"],
-    "memory": ["add_memory", "search_memory", "get_memory_stats"],
-    "mcp": ["call_mcp_tool", "list_mcp_servers", "get_mcp_instructions"],
+    "filesystem": [
+        "run_shell",
+        "run_powershell",
+        "write_file",
+        "read_file",
+        "edit_file",
+        "list_directory",
+        "glob",
+        "grep",
+        "move_file",
+        "delete_file",
+    ],
+    "memory": [
+        "add_memory",
+        "search_memory",
+        "get_memory_stats",
+        "list_recent_tasks",
+        "search_conversation_traces",
+    ],
     "browser": [
-        "browser_task", "browser_open", "browser_navigate",
+        "browser_open",
+        "browser_navigate",
+        "browser_get_content",
         "browser_screenshot",
+        "browser_click",
+        "browser_type",
+        "browser_scroll",
+        "browser_wait",
+        "browser_execute_js",
+        "browser_list_tabs",
+        "browser_switch_tab",
+        "browser_new_tab",
+        "browser_close",
     ],
-    "communication": ["deliver_artifacts", "get_chat_history"],
+    "desktop": [
+        "desktop_screenshot",
+        "desktop_click",
+        "desktop_type",
+        "desktop_hotkey",
+        "desktop_scroll",
+        "desktop_window",
+        "desktop_wait",
+        "desktop_inspect",
+        "desktop_find_element",
+    ],
+    "communication": [
+        "deliver_artifacts",
+        "get_chat_history",
+        "get_image_file",
+        "get_voice_file",
+        "send_sticker",
+    ],
+    "scheduled": [
+        "schedule_task",
+        "list_scheduled_tasks",
+        "cancel_scheduled_task",
+        "update_scheduled_task",
+        "trigger_scheduled_task",
+    ],
+    "code": ["read_lints", "lsp", "semantic_search"],
+    "profile": [
+        "get_user_profile",
+        "update_user_profile",
+        "skip_profile_question",
+        "switch_persona",
+        "toggle_proactive",
+    ],
+    # These categories are kept for existing profiles and org templates. The
+    # Agent editor presents MCP servers and Skills as separate sections.
+    "mcp": [
+        "call_mcp_tool",
+        "list_mcp_servers",
+        "get_mcp_instructions",
+        "connect_mcp_server",
+        "disconnect_mcp_server",
+    ],
     "skills": ["run_skill_script", "list_skills", "get_skill_info", "get_skill_reference"],
 }
 
+AGENT_SYSTEM_TOOL_CATEGORY_IDS: tuple[str, ...] = (
+    "research",
+    "planning",
+    "filesystem",
+    "memory",
+    "browser",
+    "desktop",
+    "communication",
+    "scheduled",
+    "code",
+    "profile",
+)
+
 ROLE_TOOL_PRESETS: dict[str, list[str]] = {
-    "ceo":        ["research", "planning", "memory"],
-    "cto":        ["research", "planning", "filesystem", "memory"],
-    "cpo":        ["research", "planning", "memory"],
-    "cmo":        ["research", "planning", "memory"],
-    "cfo":        ["research", "memory"],
-    "developer":  ["filesystem", "memory"],
-    "engineer":   ["filesystem", "memory"],
+    "ceo": ["research", "planning", "memory"],
+    "cto": ["research", "planning", "filesystem", "memory"],
+    "cpo": ["research", "planning", "memory"],
+    "cmo": ["research", "planning", "memory"],
+    "cfo": ["research", "memory"],
+    "developer": ["filesystem", "memory"],
+    "engineer": ["filesystem", "memory"],
     "researcher": ["research", "memory"],
-    "writer":     ["research", "filesystem", "memory"],
-    "analyst":    ["research", "memory"],
-    "designer":   ["browser", "filesystem"],
-    "devops":     ["filesystem", "memory"],
-    "pm":         ["research", "planning", "memory"],
-    "hr":         ["research", "memory"],
-    "legal":      ["research", "memory"],
-    "seo":        ["research", "memory"],
-    "content":    ["research", "filesystem", "memory"],
-    "default":    ["research", "memory"],
+    "writer": ["research", "filesystem", "memory"],
+    "analyst": ["research", "memory"],
+    "designer": ["browser", "filesystem"],
+    "devops": ["filesystem", "memory"],
+    "pm": ["research", "planning", "memory"],
+    "hr": ["research", "memory"],
+    "legal": ["research", "memory"],
+    "seo": ["research", "memory"],
+    "content": ["research", "filesystem", "memory"],
+    "default": ["research", "memory"],
 }
 
 ALL_CATEGORY_NAMES: frozenset[str] = frozenset(TOOL_CATEGORIES.keys())
@@ -116,9 +193,15 @@ def get_preset_for_role(role_hint: str) -> list[str]:
 
 def list_categories() -> list[dict[str, str | list[str]]]:
     """Return category info for frontend display."""
+    return [{"name": name, "tools": tools} for name, tools in TOOL_CATEGORIES.items()]
+
+
+def list_agent_system_tool_categories() -> list[dict[str, str | list[str]]]:
+    """Return built-in tool categories shown in the Agent capability editor."""
     return [
-        {"name": name, "tools": tools}
-        for name, tools in TOOL_CATEGORIES.items()
+        {"id": name, "tools": TOOL_CATEGORIES[name]}
+        for name in AGENT_SYSTEM_TOOL_CATEGORY_IDS
+        if name in TOOL_CATEGORIES
     ]
 
 
@@ -127,49 +210,49 @@ def list_categories() -> list[dict[str, str | list[str]]]:
 # ---------------------------------------------------------------------------
 
 AVATAR_PRESETS: list[dict[str, str]] = [
-    {"id": "ceo",         "bg": "#1a365d", "label": "CEO / 总裁"},
-    {"id": "cto",         "bg": "#2b6cb0", "label": "CTO / 技术总监"},
-    {"id": "cfo",         "bg": "#2f855a", "label": "CFO / 财务总监"},
-    {"id": "cmo",         "bg": "#dd6b20", "label": "CMO / 市场总监"},
-    {"id": "cpo",         "bg": "#6b46c1", "label": "CPO / 产品总监"},
-    {"id": "architect",   "bg": "#2c5282", "label": "架构师"},
-    {"id": "dev-m",       "bg": "#3182ce", "label": "开发工程师 (男)"},
-    {"id": "dev-f",       "bg": "#00838f", "label": "开发工程师 (女)"},
-    {"id": "devops",      "bg": "#4a5568", "label": "DevOps 工程师"},
-    {"id": "designer-m",  "bg": "#d53f8c", "label": "设计师 (男)"},
-    {"id": "designer-f",  "bg": "#b83280", "label": "设计师 (女)"},
-    {"id": "pm",          "bg": "#805ad5", "label": "产品 / 项目经理"},
-    {"id": "analyst",     "bg": "#3182ce", "label": "数据分析师"},
-    {"id": "marketer",    "bg": "#e53e3e", "label": "市场营销"},
-    {"id": "writer",      "bg": "#744210", "label": "文案 / 写手"},
-    {"id": "hr",          "bg": "#c05621", "label": "人力资源"},
-    {"id": "legal",       "bg": "#718096", "label": "法务顾问"},
-    {"id": "support",     "bg": "#319795", "label": "客服支持"},
-    {"id": "researcher",  "bg": "#276749", "label": "研究员"},
-    {"id": "media",       "bg": "#e53e3e", "label": "社媒运营"},
+    {"id": "ceo", "bg": "#1a365d", "label": "CEO / 总裁"},
+    {"id": "cto", "bg": "#2b6cb0", "label": "CTO / 技术总监"},
+    {"id": "cfo", "bg": "#2f855a", "label": "CFO / 财务总监"},
+    {"id": "cmo", "bg": "#dd6b20", "label": "CMO / 市场总监"},
+    {"id": "cpo", "bg": "#6b46c1", "label": "CPO / 产品总监"},
+    {"id": "architect", "bg": "#2c5282", "label": "架构师"},
+    {"id": "dev-m", "bg": "#3182ce", "label": "开发工程师 (男)"},
+    {"id": "dev-f", "bg": "#00838f", "label": "开发工程师 (女)"},
+    {"id": "devops", "bg": "#4a5568", "label": "DevOps 工程师"},
+    {"id": "designer-m", "bg": "#d53f8c", "label": "设计师 (男)"},
+    {"id": "designer-f", "bg": "#b83280", "label": "设计师 (女)"},
+    {"id": "pm", "bg": "#805ad5", "label": "产品 / 项目经理"},
+    {"id": "analyst", "bg": "#3182ce", "label": "数据分析师"},
+    {"id": "marketer", "bg": "#e53e3e", "label": "市场营销"},
+    {"id": "writer", "bg": "#744210", "label": "文案 / 写手"},
+    {"id": "hr", "bg": "#c05621", "label": "人力资源"},
+    {"id": "legal", "bg": "#718096", "label": "法务顾问"},
+    {"id": "support", "bg": "#319795", "label": "客服支持"},
+    {"id": "researcher", "bg": "#276749", "label": "研究员"},
+    {"id": "media", "bg": "#e53e3e", "label": "社媒运营"},
 ]
 
 AVATAR_MAP: dict[str, dict[str, str]] = {a["id"]: a for a in AVATAR_PRESETS}
 
 _ROLE_AVATAR_KEYWORDS: dict[str, list[str]] = {
-    "ceo":        ["ceo", "首席执行", "总裁", "总经理"],
-    "cto":        ["cto", "技术总监"],
-    "cfo":        ["cfo", "财务总监", "财务"],
-    "cmo":        ["cmo", "市场总监"],
-    "cpo":        ["cpo", "产品总监"],
-    "architect":  ["架构"],
-    "dev-m":      ["工程师", "developer", "dev", "开发", "全栈"],
-    "devops":     ["devops", "运维"],
+    "ceo": ["ceo", "首席执行", "总裁", "总经理"],
+    "cto": ["cto", "技术总监"],
+    "cfo": ["cfo", "财务总监", "财务"],
+    "cmo": ["cmo", "市场总监"],
+    "cpo": ["cpo", "产品总监"],
+    "architect": ["架构"],
+    "dev-m": ["工程师", "developer", "dev", "开发", "全栈"],
+    "devops": ["devops", "运维"],
     "designer-m": ["设计", "designer", "ui"],
-    "pm":         ["产品经理", "项目经理", "pm"],
-    "analyst":    ["分析", "analyst", "数据"],
-    "marketer":   ["营销", "推广", "market"],
-    "writer":     ["文案", "写手", "编辑", "内容", "content", "seo"],
-    "hr":         ["hr", "人力", "人事", "招聘"],
-    "legal":      ["法务", "法律", "legal"],
-    "support":    ["客服", "support", "客户"],
+    "pm": ["产品经理", "项目经理", "pm"],
+    "analyst": ["分析", "analyst", "数据"],
+    "marketer": ["营销", "推广", "market"],
+    "writer": ["文案", "写手", "编辑", "内容", "content", "seo"],
+    "hr": ["hr", "人力", "人事", "招聘"],
+    "legal": ["法务", "法律", "legal"],
+    "support": ["客服", "support", "客户"],
     "researcher": ["研究", "research"],
-    "media":      ["社媒", "运营", "social"],
+    "media": ["社媒", "运营", "social"],
 }
 
 

--- a/tests/unit/test_agent_factory_skill_filter.py
+++ b/tests/unit/test_agent_factory_skill_filter.py
@@ -39,6 +39,10 @@ class _FakeCatalog:
         self.generated += 1
 
 
+def _tool(name: str) -> dict:
+    return {"name": name, "description": name, "input_schema": {"type": "object"}}
+
+
 def test_inclusive_hides_non_selected_from_catalog():
     """INCLUSIVE mode: non-selected skills are catalog_hidden, not unregistered."""
     registry = _FakeRegistry(
@@ -166,3 +170,88 @@ def test_exclusive_unregisters_blacklisted_skills():
     assert len(registry._skills) == 2
     assert catalog.invalidated == 1
     assert catalog.generated == 1
+
+
+def test_tool_inclusive_empty_keeps_only_independent_basics_when_extensions_empty():
+    agent = SimpleNamespace(
+        _tools=[
+            _tool("run_shell"),
+            _tool("web_search"),
+            _tool("call_mcp_tool"),
+            _tool("list_skills"),
+            _tool("get_tool_info"),
+        ]
+    )
+    profile = AgentProfile(
+        id="locked",
+        name="Locked",
+        tools=[],
+        tools_mode="inclusive",
+        mcp_servers=[],
+        mcp_mode="inclusive",
+        skills=[],
+        skills_mode=SkillsMode.INCLUSIVE,
+    )
+
+    AgentFactory._apply_tool_filter(agent, profile)
+
+    assert [tool["name"] for tool in agent._tools] == ["get_tool_info"]
+
+
+def test_tool_inclusive_preserves_mcp_gateway_when_mcp_servers_are_selected():
+    agent = SimpleNamespace(
+        _tools=[
+            _tool("run_shell"),
+            _tool("call_mcp_tool"),
+            _tool("list_mcp_servers"),
+            _tool("get_mcp_instructions"),
+            _tool("web_search"),
+            _tool("get_tool_info"),
+        ]
+    )
+    profile = AgentProfile(
+        id="mcp-worker",
+        name="MCP Worker",
+        tools=["filesystem"],
+        tools_mode="inclusive",
+        mcp_servers=["database"],
+        mcp_mode="inclusive",
+        skills=[],
+        skills_mode=SkillsMode.INCLUSIVE,
+    )
+
+    AgentFactory._apply_tool_filter(agent, profile)
+
+    assert [tool["name"] for tool in agent._tools] == [
+        "call_mcp_tool",
+        "get_mcp_instructions",
+        "get_tool_info",
+        "list_mcp_servers",
+        "run_shell",
+    ]
+
+
+class _FakeMcpCatalog:
+    def __init__(self, server_count: int = 2) -> None:
+        self.server_count = server_count
+        self.clone_calls: list[tuple[list[str], str]] = []
+
+    def clone_filtered(self, server_ids: list[str], *, mode: str = "inclusive"):
+        self.clone_calls.append((list(server_ids), mode))
+        return _FakeMcpCatalog(server_count=len(server_ids) if mode == "inclusive" else 1)
+
+
+def test_mcp_inclusive_empty_filters_catalog_to_no_servers():
+    catalog = _FakeMcpCatalog()
+    agent = SimpleNamespace(mcp_catalog=catalog)
+    profile = AgentProfile(
+        id="no-mcp",
+        name="No MCP",
+        mcp_servers=[],
+        mcp_mode="inclusive",
+    )
+
+    AgentFactory._apply_mcp_filter(agent, profile)
+
+    assert catalog.clone_calls == [([], "inclusive")]
+    assert agent.mcp_catalog.server_count == 0

--- a/tests/unit/test_agent_profile_capability_api.py
+++ b/tests/unit/test_agent_profile_capability_api.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openakita.api.routes.agents import router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_agent_tool_categories_expose_user_configurable_system_groups():
+    client = _client()
+
+    response = client.get("/api/agents/tool-categories")
+
+    assert response.status_code == 200
+    categories = response.json()["categories"]
+    ids = [category["id"] for category in categories]
+    assert "research" in ids
+    assert "filesystem" in ids
+    assert "mcp" not in ids
+    assert "skills" not in ids
+    research = next(category for category in categories if category["id"] == "research")
+    assert "web_search" in research["tools"]
+
+
+def test_create_agent_profile_rejects_invalid_tool_mode_before_store_access():
+    client = _client()
+
+    response = client.post(
+        "/api/agents/profiles",
+        json={
+            "id": "bad-tools-mode",
+            "name": "Bad Tools Mode",
+            "tools_mode": "selected",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "tools_mode must be one of" in response.json()["detail"]
+
+
+def test_update_agent_profile_rejects_invalid_mcp_mode_before_store_access():
+    client = _client()
+
+    response = client.put(
+        "/api/agents/profiles/default",
+        json={"mcp_mode": "selected"},
+    )
+
+    assert response.status_code == 400
+    assert "mcp_mode must be one of" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Add Agent editor controls for built-in abilities, external services, and skills with independent all, only selected, and exclude selected modes.
- Expose user-configurable built-in tool categories and validate capability list modes in the profile API.
- Apply tool, MCP server, and skill filters when creating agents, including empty inclusive lists.

## Tests
- `uv run --no-sync pytest tests/unit/test_agent_factory_skill_filter.py tests/unit/test_agent_profile_capability_api.py`
- `uv run --no-sync ruff check src/openakita/agents/factory.py src/openakita/agents/profile.py src/openakita/api/routes/agents.py src/openakita/orgs/_runtime_tool_categories.py tests/unit/test_agent_factory_skill_filter.py tests/unit/test_agent_profile_capability_api.py`
- `npm run build:web`

Fixes #599