### PR TITLE
Fix Agent Manager state consistency

### DIFF
--- a/apps/setup-center/src/views/AgentManagerView.tsx
+++ b/apps/setup-center/src/views/AgentManagerView.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback, useRef, type ChangeEvent } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { IconBot, IconRefresh, IconPlus, IconEdit, IconTrash, IconDownload, IconUpload, IconImage } from "../icons";
 import { safeFetch } from "../providers";
-import { logger, saveFileDialog, IS_TAURI } from "../platform";
+import { logger, onWsEvent, saveFileDialog, IS_TAURI } from "../platform";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -100,6 +100,11 @@ type CategoryInfo = {
   color: string;
   builtin: boolean;
   agent_count: number;
+};
+
+type AgentManagerStateResponse = {
+  profiles?: AgentProfile[];
+  categories?: CategoryInfo[];
 };
 
 const SVG_ICONS = AGENT_SVG_ICONS;
@@ -249,26 +254,20 @@ export function AgentManagerView({
     } catch {}
   }, [apiBaseUrl]);
 
-  const fetchCategories = useCallback(async () => {
+  const fetchManagerState = useCallback(async (opts?: { showLoading?: boolean }) => {
+    const showLoading = opts?.showLoading !== false;
+    if (showLoading) setLoading(true);
     try {
-      const res = await safeFetch(`${apiBaseUrl}/api/agents/categories`);
+      const res = await safeFetch(`${apiBaseUrl}/api/agents/manager-state?include_hidden=true`);
       const data = await res.json();
-      setCategories(data.categories || []);
+      const state = data as AgentManagerStateResponse;
+      setProfiles(state.profiles || []);
+      setCategories(state.categories || []);
     } catch (e) {
-      logger.warn("AgentManager", "Failed to fetch categories", { error: String(e) });
+      logger.warn("AgentManager", "Failed to fetch manager state", { error: String(e) });
+    } finally {
+      if (showLoading) setLoading(false);
     }
-  }, [apiBaseUrl]);
-
-  const fetchProfiles = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await safeFetch(`${apiBaseUrl}/api/agents/profiles?include_hidden=true`);
-      const data = await res.json();
-      setProfiles(data.profiles || []);
-    } catch (e) {
-      logger.warn("AgentManager", "Failed to fetch profiles", { error: String(e) });
-    }
-    setLoading(false);
   }, [apiBaseUrl]);
 
   const fetchSkills = useCallback(async () => {
@@ -384,10 +383,10 @@ export function AgentManagerView({
       });
       const data = await res.json();
       showToast(data.message || `Agent「${data.profile?.name || ""}」导入成功`);
-      fetchProfiles();
+      fetchManagerState();
     } catch (err) { showToast(String(err), "err"); }
     if (importInputRef.current) importInputRef.current.value = "";
-  }, [apiBaseUrl, showToast, fetchProfiles]);
+  }, [apiBaseUrl, showToast, fetchManagerState]);
 
   const toggleBatchSelect = useCallback((id: string) => {
     setBatchSelected((prev) => {
@@ -435,22 +434,47 @@ export function AgentManagerView({
 
   useEffect(() => {
     if (visible) {
-      fetchProfiles();
+      fetchManagerState();
       fetchSkills();
       fetchToolCategories();
       fetchMcpServers();
-      fetchCategories();
       fetchModels();
     }
   }, [
     visible,
-    fetchProfiles,
+    fetchManagerState,
     fetchSkills,
     fetchToolCategories,
     fetchMcpServers,
-    fetchCategories,
     fetchModels,
   ]);
+
+  useEffect(() => {
+    if (!visible) return;
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefresh = () => {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => {
+        refreshTimer = null;
+        fetchManagerState({ showLoading: false });
+      }, 50);
+    };
+    const unsubscribe = onWsEvent((event) => {
+      if (event === "agents:profiles_changed" || event === "agents:categories_changed") {
+        scheduleRefresh();
+      }
+    });
+    return () => {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      unsubscribe();
+    };
+  }, [visible, fetchManagerState]);
+
+  useEffect(() => {
+    if (activeCategory && !categories.some((cat) => cat.id === activeCategory)) {
+      setActiveCategory("");
+    }
+  }, [activeCategory, categories]);
 
   const openCreateEditor = () => {
     setEditingProfile({ ...EMPTY_PROFILE });
@@ -584,7 +608,7 @@ export function AgentManagerView({
       });
 
       closeEditor();
-      fetchProfiles();
+      fetchManagerState();
       showToast(t("agentManager.saveSuccess"), "ok");
     } catch (e) {
       showToast(String(e) || t("agentManager.saveFailed"), "err");
@@ -596,7 +620,7 @@ export function AgentManagerView({
     try {
       await safeFetch(`${apiBaseUrl}/api/agents/profiles/${profileId}`, { method: "DELETE" });
       setConfirmDeleteId(null);
-      fetchProfiles();
+      fetchManagerState();
       showToast(t("agentManager.deleteSuccess"), "ok");
     } catch (e) {
       showToast(String(e) || t("agentManager.deleteFailed"), "err");
@@ -637,7 +661,7 @@ export function AgentManagerView({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ hidden }),
       });
-      fetchProfiles();
+      fetchManagerState();
       showToast(t(hidden ? "agentManager.hideSuccess" : "agentManager.restoreSuccess"), "ok");
     } catch (e) {
       showToast(String(e), "err");
@@ -649,7 +673,7 @@ export function AgentManagerView({
       await safeFetch(`${apiBaseUrl}/api/agents/profiles/${profileId}/reset`, {
         method: "POST",
       });
-      fetchProfiles();
+      fetchManagerState();
       showToast(t("agentManager.resetSuccess"), "ok");
     } catch (e) {
       showToast(String(e), "err");
@@ -698,12 +722,20 @@ export function AgentManagerView({
       setAddingCategory(false);
       setNewCatLabel("");
       setNewCatColor("#6b7280");
-      fetchCategories();
+      fetchManagerState();
     } catch (err) { showToast(String(err), "err"); }
   };
 
-  const visibleProfiles = profiles.filter((p) => !p.hidden);
-  const hiddenProfiles = profiles.filter((p) => p.hidden);
+  const visibleProfiles = useMemo(() => profiles.filter((p) => !p.hidden), [profiles]);
+  const hiddenProfiles = useMemo(() => profiles.filter((p) => p.hidden), [profiles]);
+  const categoryProfileCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const profile of visibleProfiles) {
+      if (!profile.category) continue;
+      counts.set(profile.category, (counts.get(profile.category) || 0) + 1);
+    }
+    return counts;
+  }, [visibleProfiles]);
   const filteredProfiles = activeCategory
     ? visibleProfiles.filter((p) => p.category === activeCategory)
     : visibleProfiles;
@@ -739,7 +771,7 @@ export function AgentManagerView({
         <div style={{ flex: 1, minWidth: 24 }} />
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <button
-            onClick={fetchProfiles}
+            onClick={() => fetchManagerState()}
             disabled={loading}
             style={{
               display: "flex", alignItems: "center", gap: 4,
@@ -827,7 +859,7 @@ export function AgentManagerView({
             }}
           >
             {cat.label}
-            <Badge variant="secondary" className={cn("ml-1 px-1.5 py-0 text-[11px] min-w-[1.25rem] justify-center rounded-full", activeCategory === cat.id ? "bg-white/25 text-primary-foreground" : "bg-foreground/10 text-foreground/60")}>{cat.agent_count ?? 0}</Badge>
+            <Badge variant="secondary" className={cn("ml-1 px-1.5 py-0 text-[11px] min-w-[1.25rem] justify-center rounded-full", activeCategory === cat.id ? "bg-white/25 text-primary-foreground" : "bg-foreground/10 text-foreground/60")}>{categoryProfileCounts.get(cat.id) || 0}</Badge>
             {!cat.builtin && (
               <span
                 onClick={async (e) => {
@@ -836,7 +868,7 @@ export function AgentManagerView({
                     await safeFetch(`${apiBaseUrl}/api/agents/categories/${cat.id}`, { method: "DELETE" });
                     showToast(`已删除分类「${cat.label}」`);
                     if (activeCategory === cat.id) setActiveCategory("");
-                    fetchCategories();
+                    fetchManagerState();
                   } catch (err) { showToast(String(err), "err"); }
                 }}
                 title="删除此分类"

--- a/src/openakita/agents/profile.py
+++ b/src/openakita/agents/profile.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -798,10 +799,13 @@ class ProfileStore:
     def _persist_categories(self) -> None:
         atomic_json_write(self._categories_file, self._custom_categories)
 
-    def list_categories(self) -> list[dict[str, Any]]:
+    def list_categories(self, profiles: Iterable[AgentProfile] | None = None) -> list[dict[str, Any]]:
         """返回所有分类（内置 + 自定义），每项含 agent_count。"""
-        with self._lock:
-            all_profiles = list(self._cache.values())
+        if profiles is None:
+            with self._lock:
+                all_profiles = list(self._cache.values())
+        else:
+            all_profiles = list(profiles)
 
         cat_counts: dict[str, int] = {}
         for p in all_profiles:

--- a/src/openakita/api/agent_events.py
+++ b/src/openakita/api/agent_events.py
@@ -1,0 +1,49 @@
+"""Shared Agent management WebSocket event helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fire_agent_event(event: str, payload: dict[str, Any]) -> None:
+    try:
+        from openakita.api.routes.websocket import fire_event
+
+        fire_event(event, payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[AgentEvents] Failed to emit %s: %s", event, exc)
+
+
+def emit_agent_profiles_changed(
+    action: str,
+    *,
+    profile_id: str | None = None,
+    profile_ids: Sequence[str] | None = None,
+) -> None:
+    payload: dict[str, Any] = {"action": action}
+    if profile_id:
+        payload["profile_id"] = profile_id
+    if profile_ids:
+        payload["profile_ids"] = list(profile_ids)
+    _fire_agent_event("agents:profiles_changed", payload)
+
+
+def emit_agent_categories_changed(
+    action: str,
+    *,
+    category_id: str | None = None,
+    profile_id: str | None = None,
+    profile_ids: Sequence[str] | None = None,
+) -> None:
+    payload: dict[str, Any] = {"action": action}
+    if category_id:
+        payload["category_id"] = category_id
+    if profile_id:
+        payload["profile_id"] = profile_id
+    if profile_ids:
+        payload["profile_ids"] = list(profile_ids)
+    _fire_agent_event("agents:categories_changed", payload)

--- a/src/openakita/api/routes/agents.py
+++ b/src/openakita/api/routes/agents.py
@@ -11,6 +11,10 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
 
 from openakita.agents.identity_files import PROFILE_IDENTITY_FILENAMES
+from openakita.api.agent_events import (
+    emit_agent_categories_changed,
+    emit_agent_profiles_changed,
+)
 from openakita.memory.json_utils import coerce_text
 
 logger = logging.getLogger(__name__)
@@ -118,6 +122,58 @@ def _detect_agent_icon_extension(data: bytes) -> str | None:
     if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
         return ".webp"
     return None
+
+
+def _list_agent_profiles_for_manager(store, *, include_hidden: bool) -> list:
+    """Return the authoritative Agent profile list used by manager views.
+
+    This is the same SYSTEM_PRESETS + stored-profile merge policy that backs
+    ``/api/agents/profiles``. Category counts are derived from this exact list
+    so the Agent Manager never combines profiles and counts from different
+    projections.
+    """
+    from openakita.agents.presets import SYSTEM_PRESETS
+
+    stored_profiles = store.list_all(include_hidden=True)
+    stored_map = {p.id: p for p in stored_profiles}
+
+    preset_order = [p.id for p in SYSTEM_PRESETS]
+    seen_ids: set[str] = set()
+    profiles = []
+
+    for pid in preset_order:
+        seen_ids.add(pid)
+        p = stored_map.get(pid)
+        if p is None:
+            preset = next((x for x in SYSTEM_PRESETS if x.id == pid), None)
+            if preset is None:
+                continue
+            p = preset
+        if not include_hidden and p.hidden:
+            continue
+        profiles.append(p)
+
+    for p in stored_profiles:
+        if p.id not in seen_ids:
+            if not include_hidden and p.hidden:
+                continue
+            profiles.append(p)
+
+    return profiles
+
+
+def _build_agent_manager_state(store=None, *, include_hidden: bool = True) -> dict:
+    """Build the single backend read model for Agent Manager clients."""
+    if store is None:
+        from openakita.agents.profile import get_profile_store
+
+        store = get_profile_store()
+    profiles = _list_agent_profiles_for_manager(store, include_hidden=include_hidden)
+    return {
+        "profiles": [p.to_dict() for p in profiles],
+        "categories": store.list_categories(profiles),
+        "multi_agent_enabled": True,
+    }
 
 
 # ─── Pydantic models ─────────────────────────────────────────────────────
@@ -425,7 +481,19 @@ async def list_categories():
     from openakita.agents.profile import get_profile_store
 
     store = get_profile_store()
-    return {"categories": store.list_categories()}
+    state = _build_agent_manager_state(store, include_hidden=True)
+    return {"categories": state["categories"]}
+
+
+@router.get("/api/agents/manager-state")
+async def get_agent_manager_state(include_hidden: bool = True):
+    """Return the authoritative Agent Manager read model.
+
+    The response intentionally combines profiles and category counts from the
+    same merged profile projection so desktop, web, and multi-window clients do
+    not compose stale or mismatched state from separate endpoints.
+    """
+    return _build_agent_manager_state(include_hidden=include_hidden)
 
 
 @router.post("/api/agents/categories")
@@ -440,6 +508,7 @@ async def create_category(body: CategoryCreateRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
     logger.info(f"[Agents API] Created category: {body.id}")
+    emit_agent_categories_changed("created", category_id=body.id)
     return {"status": "ok", "category": cat}
 
 
@@ -460,6 +529,7 @@ async def delete_category(category_id: str):
         raise HTTPException(status_code=404, detail=f"分类 '{category_id}' 不存在")
 
     logger.info(f"[Agents API] Deleted category: {category_id}")
+    emit_agent_categories_changed("deleted", category_id=category_id)
     return {"status": "ok"}
 
 
@@ -511,35 +581,11 @@ async def list_agent_profiles(include_hidden: bool = False):
     Query params:
         include_hidden: if True, also return hidden profiles (default False).
     """
-    from openakita.agents.presets import SYSTEM_PRESETS
     from openakita.agents.profile import get_profile_store
 
     store = get_profile_store()
-    stored_map = {p.id: p for p in store.list_all(include_hidden=True)}
-
-    preset_order = [p.id for p in SYSTEM_PRESETS]
-    seen_ids: set[str] = set()
-    profiles = []
-
-    for pid in preset_order:
-        seen_ids.add(pid)
-        p = stored_map.get(pid)
-        if p is None:
-            preset = next((x for x in SYSTEM_PRESETS if x.id == pid), None)
-            if preset is None:
-                continue
-            p = preset
-        if not include_hidden and p.hidden:
-            continue
-        profiles.append(p.to_dict())
-
-    for p in store.list_all(include_hidden=True):
-        if p.id not in seen_ids:
-            if not include_hidden and p.hidden:
-                continue
-            profiles.append(p.to_dict())
-
-    return {"profiles": profiles, "multi_agent_enabled": True}
+    state = _build_agent_manager_state(store, include_hidden=include_hidden)
+    return {"profiles": state["profiles"], "multi_agent_enabled": True}
 
 
 @router.post("/api/agents/profiles")
@@ -588,6 +634,8 @@ async def create_agent_profile(body: ProfileCreateRequest):
 
     store.save(profile)
     logger.info(f"[Agents API] Created profile: {body.id}")
+    emit_agent_profiles_changed("created", profile_id=body.id)
+    emit_agent_categories_changed("profile_created", profile_id=body.id)
     return {"status": "ok", "profile": profile.to_dict()}
 
 
@@ -611,6 +659,8 @@ async def update_agent_profile(profile_id: str, body: ProfileUpdateRequest, requ
 
     _invalidate_profile_agents(request, profile_id)
     logger.info(f"[Agents API] Updated profile: {profile_id}")
+    emit_agent_profiles_changed("updated", profile_id=profile_id)
+    emit_agent_categories_changed("profile_updated", profile_id=profile_id)
     return {"status": "ok", "profile": updated.to_dict()}
 
 
@@ -630,6 +680,8 @@ async def delete_agent_profile(profile_id: str):
         raise HTTPException(status_code=404, detail=f"Profile '{profile_id}' not found")
 
     logger.info(f"[Agents API] Deleted profile: {profile_id}")
+    emit_agent_profiles_changed("deleted", profile_id=profile_id)
+    emit_agent_categories_changed("profile_deleted", profile_id=profile_id)
     return {"status": "ok"}
 
 
@@ -662,6 +714,8 @@ async def reset_agent_profile(profile_id: str, request: Request):
     _invalidate_profile_agents(request, profile_id)
     logger.info(f"[Agents API] Reset profile to defaults: {profile_id}")
     result = store.get(profile_id)
+    emit_agent_profiles_changed("reset", profile_id=profile_id)
+    emit_agent_categories_changed("profile_reset", profile_id=profile_id)
     return {"status": "ok", "profile": result.to_dict() if result else {}}
 
 
@@ -677,6 +731,8 @@ async def update_profile_visibility(profile_id: str, body: ProfileVisibilityRequ
         raise HTTPException(status_code=404, detail=f"Profile '{profile_id}' not found")
 
     logger.info(f"[Agents API] Visibility updated: {profile_id} hidden={body.hidden}")
+    emit_agent_profiles_changed("visibility_updated", profile_id=profile_id)
+    emit_agent_categories_changed("profile_visibility_updated", profile_id=profile_id)
     return {"status": "ok", "profile": updated.to_dict()}
 
 

--- a/src/openakita/api/routes/hub.py
+++ b/src/openakita/api/routes/hub.py
@@ -26,6 +26,10 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from openakita.agents.identity_files import PROFILE_IDENTITY_FILENAMES
+from openakita.api.agent_events import (
+    emit_agent_categories_changed,
+    emit_agent_profiles_changed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -425,6 +429,10 @@ async def import_agent(
             imported.append(profile.to_dict())
 
         _reload_skills(request)
+        imported_ids = [str(p.get("id", "")) for p in imported if p.get("id")]
+        if imported_ids:
+            emit_agent_profiles_changed("imported", profile_ids=imported_ids)
+            emit_agent_categories_changed("profiles_imported", profile_ids=imported_ids)
         msg = f"导入成功: {len(imported)} 个 Agent"
         if skipped:
             msg += f"（{len(skipped)} 个 ID 冲突已重命名: {', '.join(skipped)}）"
@@ -454,6 +462,8 @@ async def import_agent(
 
     _reload_skills(request)
     _invalidate_imported_profile_runtime(request, profile.id)
+    emit_agent_profiles_changed("imported", profile_id=profile.id)
+    emit_agent_categories_changed("profile_imported", profile_id=profile.id)
 
     return {
         "message": "Agent imported successfully",
@@ -625,6 +635,8 @@ async def hub_install_agent(request: Request, agent_id: str, force: bool = False
     profile_store.save(profile)
 
     _reload_skills(request)
+    emit_agent_profiles_changed("installed", profile_id=profile.id)
+    emit_agent_categories_changed("profile_installed", profile_id=profile.id)
 
     return {
         "message": "Agent installed from Hub",

--- a/tests/unit/test_agent_manager_state.py
+++ b/tests/unit/test_agent_manager_state.py
@@ -1,0 +1,55 @@
+from openakita.agents.profile import AgentProfile, ProfileStore
+from openakita.api import agent_events
+from openakita.api.routes.agents import _build_agent_manager_state
+
+
+def test_agent_manager_state_counts_categories_from_same_profile_projection(tmp_path):
+    store = ProfileStore(tmp_path / "agents")
+    store.add_category("special", "Special", "#6b7280")
+    store.save(AgentProfile(id="visible-agent", name="Visible", category="special"))
+    store.save(
+        AgentProfile(
+            id="hidden-agent",
+            name="Hidden",
+            category="special",
+            hidden=True,
+        )
+    )
+
+    state = _build_agent_manager_state(store, include_hidden=True)
+    profiles = state["profiles"]
+    categories = state["categories"]
+
+    special = next(category for category in categories if category["id"] == "special")
+    expected_special_count = sum(
+        1 for profile in profiles if profile.get("category") == "special" and not profile.get("hidden")
+    )
+    assert special["agent_count"] == expected_special_count == 1
+
+    general = next(category for category in categories if category["id"] == "general")
+    expected_general_count = sum(
+        1 for profile in profiles if profile.get("category") == "general" and not profile.get("hidden")
+    )
+    assert general["agent_count"] == expected_general_count
+    assert any(profile["id"] == "default" for profile in profiles)
+
+
+def test_agent_change_events_use_stable_websocket_names(monkeypatch):
+    emitted: list[tuple[str, dict]] = []
+
+    def fake_fire_event(event: str, payload: dict) -> bool:
+        emitted.append((event, payload))
+        return True
+
+    monkeypatch.setattr("openakita.api.routes.websocket.fire_event", fake_fire_event)
+
+    agent_events.emit_agent_profiles_changed("updated", profile_id="agent-a")
+    agent_events.emit_agent_categories_changed("profile_updated", profile_id="agent-a")
+
+    assert emitted == [
+        ("agents:profiles_changed", {"action": "updated", "profile_id": "agent-a"}),
+        (
+            "agents:categories_changed",
+            {"action": "profile_updated", "profile_id": "agent-a"},
+        ),
+    ]


### PR DESCRIPTION
## Summary
- Add an authoritative Agent Manager state endpoint shared by profile and category reads.
- Emit stable profile/category WebSocket invalidation events after Agent mutations.
- Refresh Agent Manager from the unified state and derive category badges from the same profile list.

## Tests
- `uv run --no-sync pytest tests/unit/test_agent_manager_state.py`
- `uv run --no-sync ruff check src/openakita/api/agent_events.py src/openakita/api/routes/agents.py src/openakita/api/routes/hub.py src/openakita/agents/profile.py tests/unit/test_agent_manager_state.py`
- `npm run lint -- --quiet`
- `npm run build`

Fixes #718