### PR TITLE
Include commit hashes in packaged version metadata

### DIFF
--- a/build/openakita.spec
+++ b/build/openakita.spec
@@ -544,22 +544,12 @@ if providers_json.exists():
 # In bundled mode this path won't work, so we write a version file directly
 _pyproject_path = PROJECT_ROOT / "pyproject.toml"
 if _pyproject_path.exists():
-    import tomllib
-    import subprocess as _sp
-    with open(_pyproject_path, "rb") as _f:
-        _pyproject_version = tomllib.load(_f)["project"]["version"]
-    # Capture git short hash at build time
-    _git_hash = "unknown"
-    try:
-        _git_hash = _sp.check_output(
-            ["git", "-C", str(PROJECT_ROOT), "rev-parse", "--short=7", "HEAD"],
-            stderr=_sp.DEVNULL, text=True
-        ).strip()
-    except Exception:
-        pass
-    # Write version+hash to build dir (not source tree) so local builds don't dirty git
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from scripts.write_build_version import build_version_string
+
+    # Write version+hash to build dir (not source tree) so local builds don't dirty git.
     _version_file = PROJECT_ROOT / "build" / "_bundled_version.txt"
-    _version_file.write_text(f"{_pyproject_version}+{_git_hash}", encoding="utf-8")
+    _version_file.write_text(build_version_string(), encoding="utf-8")
     datas.append((str(_version_file), "openakita"))
 
 # lark_oapi (飞书 SDK): 10K+ 自动生成的 API 文件，PyInstaller hidden_imports 无法

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -47,6 +47,11 @@ python scripts/version.py check          # 校验所有文件版本是否一致
 
 同步范围：`VERSION` → `pyproject.toml` → `package.json` → `tauri.conf.json` → `Cargo.toml` → `Cargo.lock` → `_bundled_version.txt` → `build.gradle`
 
+`scripts/version.py` 只把源码里的 `_bundled_version.txt` 同步为干净版本号。
+构建 wheel / PyInstaller 产物时由 `scripts/write_build_version.py` 写入
+`VERSION+commit`；Tauri resources 继承 PyInstaller 输出，避免发布产物显示
+`1.27.26+unknown`。
+
 ### 工作流
 
 | 工作流 | 作用 |

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from scripts.write_build_version import build_version_string
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict) -> None:
+        if self.target_name != "wheel":
+            return
+
+        generated = ROOT / "build" / "openakita_bundled_version.txt"
+        generated.parent.mkdir(parents=True, exist_ok=True)
+        generated.write_text(build_version_string(), encoding="utf-8", newline="\n")
+        build_data.setdefault("force_include", {})[str(generated)] = (
+            "openakita/_bundled_version.txt"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,8 @@ include = [
     "skills",
     "mcps",
     "identity",
+    "hatch_build.py",
+    "scripts/write_build_version.py",
     "VERSION",
     "pyproject.toml",
     "README.md",
@@ -227,6 +229,9 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openakita"]
+exclude = [
+    "src/openakita/_bundled_version.txt",
+]
 artifacts = [
     # Optional release assets staged by `python scripts/stage_package_assets.py`.
     # They are intentionally package-local build outputs so default
@@ -234,6 +239,9 @@ artifacts = [
     "src/openakita/web/**",
     "src/openakita/docs_dist/**",
 ]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
 
 # 把仓库根目录的系统技能、外部技能、内置 MCP 配置一并打进 wheel，
 # 保证 `pip install openakita` 后可用。

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -170,7 +170,10 @@ def _update_cargo_lock(version: str) -> bool:
 
 
 def _update_bundled_version(version: str) -> bool:
-    """Update _bundled_version.txt with clean version (no git hash; hash is appended at build time)."""
+    """Update _bundled_version.txt with the clean version.
+
+    Build artifacts get VERSION+git_hash from scripts/write_build_version.py.
+    """
     path = ROOT / "src" / "openakita" / "_bundled_version.txt"
     old = path.read_text(encoding="utf-8").strip() if path.exists() else ""
     if old == version:

--- a/scripts/write_build_version.py
+++ b/scripts/write_build_version.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Write build-time version metadata into package artifacts.
+
+`scripts/version.py` keeps `src/openakita/_bundled_version.txt` at the clean
+release version. Build steps call this script, or import its helpers, when the
+artifact needs the immutable `VERSION+git_hash` string.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_VERSION_FILE = ROOT / "src" / "openakita" / "_bundled_version.txt"
+TAURI_RESOURCE_VERSION_FILE = (
+    ROOT
+    / "apps"
+    / "setup-center"
+    / "src-tauri"
+    / "resources"
+    / "openakita-server"
+    / "_internal"
+    / "openakita"
+    / "_bundled_version.txt"
+)
+
+_HASH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def read_release_version() -> str:
+    version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+    if not version:
+        raise RuntimeError("VERSION is empty")
+    if "+" in version:
+        raise RuntimeError("VERSION must not contain '+': _bundled_version.txt reserves it")
+    return version
+
+
+def _normalize_hash(raw: str) -> str | None:
+    value = raw.strip()
+    if not value or value.lower() in {"unknown", "none", "null"}:
+        return None
+    if _HEX_RE.match(value) and len(value) > 7:
+        value = value[:7]
+    if not _HASH_RE.match(value):
+        return None
+    return value
+
+
+def resolve_git_hash(*, require: bool = False) -> str:
+    for env_name in (
+        "OPENAKITA_BUILD_GIT_HASH",
+        "GITHUB_SHA",
+        "CI_COMMIT_SHA",
+        "BUILDKITE_COMMIT",
+    ):
+        value = _normalize_hash(os.environ.get(env_name, ""))
+        if value:
+            return value
+
+    try:
+        value = subprocess.check_output(
+            ["git", "-C", str(ROOT), "rev-parse", "--short=7", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        ).strip()
+    except Exception as exc:
+        if require:
+            raise RuntimeError("unable to resolve git hash from env or local git") from exc
+        return "dev"
+
+    normalized = _normalize_hash(value)
+    if normalized:
+        return normalized
+    if require:
+        raise RuntimeError(f"git returned an invalid short hash: {value!r}")
+    return "dev"
+
+
+def build_version_string(*, require_git: bool = False) -> str:
+    return f"{read_release_version()}+{resolve_git_hash(require=require_git)}"
+
+
+def _resolve_target(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return ROOT / path
+
+
+def _default_targets() -> list[Path]:
+    targets = [SOURCE_VERSION_FILE]
+    if TAURI_RESOURCE_VERSION_FILE.exists():
+        targets.append(TAURI_RESOURCE_VERSION_FILE)
+    return targets
+
+
+def write_build_version(
+    target: Path,
+    version_string: str,
+    *,
+    check: bool = False,
+    dry_run: bool = False,
+    skip_missing: bool = False,
+) -> bool:
+    target = _resolve_target(target)
+    if not target.exists():
+        if skip_missing:
+            print(f"SKIP: {target.relative_to(ROOT)} does not exist")
+            return False
+        raise FileNotFoundError(target)
+
+    old = target.read_text(encoding="utf-8").strip()
+    rel = target.relative_to(ROOT) if target.is_relative_to(ROOT) else target
+    if check:
+        if old != version_string:
+            raise RuntimeError(f"{rel} is {old!r}, expected {version_string!r}")
+        print(f"OK: {rel} already contains {version_string}")
+        return False
+
+    if old == version_string:
+        print(f"OK: {rel} already contains {version_string}")
+        return False
+
+    if dry_run:
+        print(f"DRY-RUN: {rel}: {old!r} -> {version_string!r}")
+        return True
+
+    target.write_text(version_string, encoding="utf-8", newline="\n")
+    print(f"WROTE: {rel}: {old!r} -> {version_string!r}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        action="append",
+        type=Path,
+        help="version file to update, relative paths are resolved from the repo root",
+    )
+    parser.add_argument("--check", action="store_true", help="verify without writing")
+    parser.add_argument("--dry-run", action="store_true", help="print intended writes")
+    parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help="ignore missing target files instead of failing",
+    )
+    parser.add_argument(
+        "--require-git",
+        action="store_true",
+        help="fail if no real git hash can be resolved",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="print the resolved build version and exit",
+    )
+    args = parser.parse_args()
+
+    try:
+        version_string = build_version_string(require_git=args.require_git)
+        if args.print_only:
+            print(version_string)
+            return 0
+
+        targets = [_resolve_target(t) for t in args.target] if args.target else _default_targets()
+        for target in targets:
+            write_build_version(
+                target,
+                version_string,
+                check=args.check,
+                dry_run=args.dry_run,
+                skip_missing=args.skip_missing,
+            )
+        return 0
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openakita/__init__.py
+++ b/src/openakita/__init__.py
@@ -17,8 +17,23 @@ def _resolve_version_info() -> tuple[str, str]:
 
     version = "0.0.0-dev"
     git_hash = "unknown"
+    project_root = Path(__file__).parent.parent.parent
 
-    # 1. PyInstaller 打包模式：读取构建时写入的版本文件（格式: "1.22.7+abc1234"）
+    def _read_git_hash(fallback: str) -> str:
+        try:
+            import subprocess
+
+            return subprocess.check_output(
+                ["git", "-C", str(project_root), "rev-parse", "--short=7", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+            ).strip()
+        except Exception:
+            return fallback
+
+    # 1. 打包模式：读取构建时写入的版本文件（格式: "1.22.7+abc1234"）。
+    # 源码树里的同步文件只有干净版本号；这种情况下仍尝试从 git 获取 hash。
     bundled_ver = Path(__file__).parent / "_bundled_version.txt"
     if bundled_ver.exists():
         try:
@@ -27,12 +42,12 @@ def _resolve_version_info() -> tuple[str, str]:
                 version, git_hash = raw.split("+", 1)
             else:
                 version = raw
+                git_hash = _read_git_hash("unknown")
             return version, git_hash
         except Exception:
             pass
 
     # 2. 尝试读取源码根目录的 pyproject.toml（editable 安装时始终最新）
-    project_root = Path(__file__).parent.parent.parent
     pyproject_path = project_root / "pyproject.toml"
     if pyproject_path.exists():
         try:
@@ -53,17 +68,7 @@ def _resolve_version_info() -> tuple[str, str]:
             pass
 
     # 开发模式下从 git 获取当前哈希
-    try:
-        import subprocess
-
-        git_hash = subprocess.check_output(
-            ["git", "-C", str(project_root), "rev-parse", "--short=7", "HEAD"],
-            stderr=subprocess.DEVNULL,
-            text=True,
-            encoding="utf-8",
-        ).strip()
-    except Exception:
-        git_hash = "dev"
+    git_hash = _read_git_hash("dev")
 
     return version, git_hash
 


### PR DESCRIPTION
## Summary
- Generate build-time VERSION+commit metadata for wheel and PyInstaller artifacts.
- Keep source version sync on clean semver while letting source checkouts fall back to the current git hash.

## Tests
- uv run --with ruff --no-project ruff check src/openakita/__init__.py scripts/write_build_version.py hatch_build.py
- uv run --no-sync python scripts\version.py check
- uv run --no-sync python -m py_compile src\openakita\__init__.py scripts\write_build_version.py hatch_build.py
- uv run --with build --no-sync python -m build --wheel --outdir tools-tmp\build-version-test-isolated
- uv run --with build --with hatchling --no-sync python -m build --sdist --no-isolation --outdir tools-tmp\build-version-test-sdist

Closes #714