### PR TITLE
Fix scheduler delivery isolation for user-created tasks

### DIFF
--- a/src/openakita/api/routes/scheduler.py
+++ b/src/openakita/api/routes/scheduler.py
@@ -19,6 +19,8 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from openakita.scheduler.delivery import is_im_delivery_channel
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -146,7 +148,13 @@ async def create_task(request: Request, body: TaskCreateRequest):
     if scheduler is None:
         return JSONResponse(status_code=503, content={"error": "Agent not initialized"})
 
-    from openakita.scheduler.task import ScheduledTask, TaskSource, TaskType, TriggerType
+    from openakita.scheduler.task import (
+        ScheduledTask,
+        TaskDeliveryPolicy,
+        TaskSource,
+        TaskType,
+        TriggerType,
+    )
 
     _ok, _err = _validate_task_name(body.name)
     if not _ok:
@@ -171,6 +179,19 @@ async def create_task(request: Request, body: TaskCreateRequest):
     except ValueError as e:
         return JSONResponse(status_code=422, content={"error": str(e)})
 
+    channel_id = (body.channel_id or "").strip() or None
+    chat_id = (body.chat_id or "").strip() or None
+    if bool(channel_id) != bool(chat_id):
+        return JSONResponse(
+            status_code=422,
+            content={"error": "channel_id and chat_id must be provided together"},
+        )
+    if channel_id and not is_im_delivery_channel(channel_id):
+        return JSONResponse(
+            status_code=422,
+            content={"error": f"Invalid scheduler delivery channel: {channel_id}"},
+        )
+
     description = body.reminder_message or body.prompt or body.name
     task = ScheduledTask.create(
         name=body.name,
@@ -182,10 +203,16 @@ async def create_task(request: Request, body: TaskCreateRequest):
         prompt=body.prompt,
     )
     task.task_source = TaskSource.MANUAL
-    task.channel_id = body.channel_id or None
-    task.chat_id = body.chat_id or None
+    task.delivery_policy = TaskDeliveryPolicy.OWNER_ONLY
+    task.channel_id = channel_id
+    task.chat_id = chat_id
     task.agent_profile_id = agent_profile_id
     task.enabled = body.enabled
+    task.metadata["origin"] = {
+        "source": "scheduler_api",
+        "agent_profile_id": agent_profile_id,
+    }
+    task.metadata["delivery_target_source"] = "scheduler_api" if channel_id else "none"
 
     try:
         task_id = await scheduler.add_task(task)
@@ -419,8 +446,6 @@ async def list_channels(request: Request):
     seen: dict[tuple[str, str], int] = {}
     session_manager = getattr(gateway, "session_manager", None)
 
-    skip_channels = {"desktop"}
-
     def _add_or_merge(entry: dict) -> None:
         """Add a channel entry, merging chat_name into existing if needed."""
         pair = (entry["channel_id"], entry["chat_id"])
@@ -447,7 +472,7 @@ async def list_channels(request: Request):
                     continue
                 ch = getattr(s, "channel", None)
                 cid = getattr(s, "chat_id", None)
-                if not ch or not cid or ch in skip_channels:
+                if not ch or not cid or not is_im_delivery_channel(ch):
                     continue
                 _add_or_merge(
                     {
@@ -474,7 +499,7 @@ async def list_channels(request: Request):
                         ch = s.get("channel")
                         cid = s.get("chat_id")
                         state = s.get("state", "")
-                        if not ch or not cid or state == "closed" or ch in skip_channels:
+                        if not ch or not cid or state == "closed" or not is_im_delivery_channel(ch):
                             continue
                         _add_or_merge(
                             {
@@ -494,7 +519,7 @@ async def list_channels(request: Request):
         registry = getattr(session_manager, "_channel_registry", None)
         if registry and isinstance(registry, dict):
             for ch, entry in registry.items():
-                if ch in skip_channels:
+                if not is_im_delivery_channel(ch):
                     continue
                 # 兼容新格式（list of dicts）和旧格式（单 dict）
                 items = (
@@ -525,7 +550,7 @@ async def list_channels(request: Request):
     adapters = getattr(gateway, "_adapters", {})
     started = getattr(gateway, "_started_adapters", set())
     for adapter_name, adapter in adapters.items():
-        if adapter_name in skip_channels:
+        if not is_im_delivery_channel(adapter_name):
             continue
         if not getattr(adapter, "is_running", False) and adapter_name not in started:
             continue

--- a/src/openakita/api/routes/workspace_io.py
+++ b/src/openakita/api/routes/workspace_io.py
@@ -182,11 +182,17 @@ def _sync_backup_scheduler_task(settings: dict) -> None:
     enabled = settings.get("enabled", False) and bool(settings.get("backup_path"))
 
     if existing:
+        from openakita.scheduler.task import TaskDeliveryPolicy, TaskSource
+
         updates: dict = {}
         cron = settings.get("cron", "0 2 * * *")
         if existing.trigger_config.get("cron") != cron:
             updates["trigger_config"] = {"cron": cron}
             updates["trigger_type"] = _get_cron_trigger_type()
+        if getattr(existing, "task_source", None) != TaskSource.SYSTEM:
+            updates["task_source"] = TaskSource.SYSTEM
+        if getattr(existing, "delivery_policy", None) != TaskDeliveryPolicy.FALLBACK_ALLOWED:
+            updates["delivery_policy"] = TaskDeliveryPolicy.FALLBACK_ALLOWED
 
         async def _apply():
             if updates:
@@ -210,7 +216,13 @@ def _sync_backup_scheduler_task(settings: dict) -> None:
 
 def _register_backup_task(scheduler: object, settings: dict) -> None:
     """Register the workspace backup system task."""
-    from openakita.scheduler.task import ScheduledTask, TaskType, TriggerType
+    from openakita.scheduler.task import (
+        ScheduledTask,
+        TaskDeliveryPolicy,
+        TaskSource,
+        TaskType,
+        TriggerType,
+    )
 
     cron = settings.get("cron", "0 2 * * *")
     task = ScheduledTask(
@@ -222,6 +234,8 @@ def _register_backup_task(scheduler: object, settings: dict) -> None:
         prompt="执行工作区数据备份",
         description="定时备份工作区配置和用户数据",
         task_type=TaskType.TASK,
+        task_source=TaskSource.SYSTEM,
+        delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
         enabled=True,
         deletable=False,
     )

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -1151,7 +1151,13 @@ class MessageGateway:
             try:
                 from ..config import settings
                 from ..scheduler.executor import TaskExecutor
-                from ..scheduler.task import ScheduledTask, TaskType, TriggerType
+                from ..scheduler.task import (
+                    ScheduledTask,
+                    TaskDeliveryPolicy,
+                    TaskSource,
+                    TaskType,
+                    TriggerType,
+                )
 
                 executor = TaskExecutor(
                     gateway=self,
@@ -1169,6 +1175,8 @@ class MessageGateway:
                     channel_id=message.channel,
                     chat_id=message.chat_id,
                     user_id=message.user_id,
+                    task_source=TaskSource.CHAT,
+                    delivery_policy=TaskDeliveryPolicy.OWNER_ONLY,
                 )
 
                 success, result = await executor.execute(task)

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -3012,10 +3012,28 @@ class Agent:
         from ..config import settings
         from ..scheduler import ScheduledTask, TriggerType
         from ..scheduler.consolidation_tracker import ConsolidationTracker
-        from ..scheduler.task import TaskType
+        from ..scheduler.task import TaskDeliveryPolicy, TaskSource, TaskType
 
         if not self.task_scheduler:
             return
+
+        def _ensure_system_task_contract(task: ScheduledTask, action: str) -> bool:
+            """Normalize built-in tasks to the system delivery contract."""
+
+            changed = False
+            if task.deletable:
+                task.deletable = False
+                changed = True
+            if getattr(task, "action", None) != action:
+                task.action = action
+                changed = True
+            if getattr(task, "task_source", None) != TaskSource.SYSTEM:
+                task.task_source = TaskSource.SYSTEM
+                changed = True
+            if getattr(task, "delivery_policy", None) != TaskDeliveryPolicy.FALLBACK_ALLOWED:
+                task.delivery_policy = TaskDeliveryPolicy.FALLBACK_ALLOWED
+                changed = True
+            return changed
 
         # 初始化整理时间追踪器
         tracker = ConsolidationTracker(settings.project_root / "data" / "scheduler")
@@ -3058,6 +3076,8 @@ class Agent:
                 prompt="执行记忆整理：整理对话历史，提取精华记忆，刷新 MEMORY.md",
                 description=desired_desc,
                 task_type=TaskType.TASK,
+                task_source=TaskSource.SYSTEM,
+                delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
                 enabled=True,
                 deletable=False,
             )
@@ -3066,12 +3086,9 @@ class Agent:
         else:
             changed = False
             if existing_memory_task:
-                if existing_memory_task.deletable:
-                    existing_memory_task.deletable = False
-                    changed = True
-                if not getattr(existing_memory_task, "action", None):
-                    existing_memory_task.action = "system:daily_memory"
-                    changed = True
+                changed = _ensure_system_task_contract(
+                    existing_memory_task, "system:daily_memory"
+                )
                 # 适应期 ↔ 正常期切换时，更新触发器
                 user_custom_trigger = bool(
                     (existing_memory_task.metadata or {}).get("user_custom_trigger")
@@ -3105,6 +3122,8 @@ class Agent:
                 prompt="执行系统自检：分析 ERROR 日志，尝试修复工具问题，生成报告",
                 description="分析 ERROR 日志、尝试修复工具问题、生成报告",
                 task_type=TaskType.TASK,
+                task_source=TaskSource.SYSTEM,
+                delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
                 enabled=True,
                 deletable=False,
             )
@@ -3113,19 +3132,20 @@ class Agent:
         else:
             existing_task = self.task_scheduler.get_task("system_daily_selfcheck")
             if existing_task:
-                changed = False
-                if existing_task.deletable:
-                    existing_task.deletable = False
-                    changed = True
-                if not getattr(existing_task, "action", None):
-                    existing_task.action = "system:daily_selfcheck"
-                    changed = True
+                changed = _ensure_system_task_contract(
+                    existing_task, "system:daily_selfcheck"
+                )
                 if changed:
                     await self.task_scheduler.save()
 
         # 任务 3: 活人感心跳（默认关闭；用户显式启用 proactive_enabled 后注册）
         try:
             heartbeat_task_id = "system_proactive_heartbeat"
+            existing_heartbeat = self.task_scheduler.get_task(heartbeat_task_id)
+            if existing_heartbeat and _ensure_system_task_contract(
+                existing_heartbeat, "system:proactive_heartbeat"
+            ):
+                await self.task_scheduler.save()
             if settings.proactive_enabled:
                 interval_min = max(120, int(settings.proactive_min_interval_minutes or 120))
                 if heartbeat_task_id not in existing_ids:
@@ -3138,6 +3158,8 @@ class Agent:
                         prompt="检查是否需要发送主动消息（问候/提醒/跟进）",
                         description="定时检查并发送主动消息",
                         task_type=TaskType.TASK,
+                        task_source=TaskSource.SYSTEM,
+                        delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
                         enabled=True,
                         deletable=False,
                         metadata={"notify_on_start": False, "notify_on_complete": False},
@@ -3148,7 +3170,6 @@ class Agent:
                         interval_min,
                     )
             else:
-                existing_heartbeat = self.task_scheduler.get_task(heartbeat_task_id)
                 if existing_heartbeat and existing_heartbeat.enabled:
                     await self.task_scheduler.disable_task(heartbeat_task_id)
                     logger.info("Disabled proactive_heartbeat task (feature disabled in settings)")
@@ -3158,6 +3179,11 @@ class Agent:
         # 任务 4: 记忆回顾（Memory Nudge）
         try:
             nudge_task_id = "system_memory_nudge"
+            existing_nudge = self.task_scheduler.get_task(nudge_task_id)
+            if existing_nudge and _ensure_system_task_contract(
+                existing_nudge, "system:memory_nudge_review"
+            ):
+                await self.task_scheduler.save()
             if settings.memory_nudge_enabled and settings.memory_nudge_interval > 0:
                 interval_min = max(5, settings.memory_nudge_interval * 3)
                 if nudge_task_id not in existing_ids:
@@ -3170,6 +3196,8 @@ class Agent:
                         prompt="审视最近对话，提取遗漏的重要记忆",
                         description=f"每 {interval_min} 分钟审视最近对话提取遗漏记忆",
                         task_type=TaskType.TASK,
+                        task_source=TaskSource.SYSTEM,
+                        delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
                         enabled=True,
                         deletable=False,
                         metadata={"notify_on_start": False, "notify_on_complete": False},
@@ -3177,7 +3205,6 @@ class Agent:
                     await self.task_scheduler.add_task(nudge_task)
                     logger.info(f"Registered system task: memory_nudge (every {interval_min} min)")
             else:
-                existing_nudge = self.task_scheduler.get_task(nudge_task_id)
                 if existing_nudge and existing_nudge.enabled:
                     await self.task_scheduler.disable_task(nudge_task_id)
                     logger.info("Disabled memory_nudge task (feature disabled in settings)")
@@ -3191,6 +3218,11 @@ class Agent:
             bs = read_backup_settings(settings.project_root)
             backup_enabled = bs.get("enabled", False) and bool(bs.get("backup_path"))
             backup_task_id = "system_workspace_backup"
+            existing_bt = self.task_scheduler.get_task(backup_task_id)
+            if existing_bt and _ensure_system_task_contract(
+                existing_bt, "system:workspace_backup"
+            ):
+                await self.task_scheduler.save()
 
             if backup_task_id not in existing_ids:
                 if backup_enabled:
@@ -3204,6 +3236,8 @@ class Agent:
                         prompt="执行工作区数据备份",
                         description="定时备份工作区配置和用户数据",
                         task_type=TaskType.TASK,
+                        task_source=TaskSource.SYSTEM,
+                        delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
                         enabled=True,
                         deletable=False,
                         metadata={"notify_on_start": False, "notify_on_complete": False},
@@ -3211,7 +3245,6 @@ class Agent:
                     await self.task_scheduler.add_task(backup_task)
                     logger.info(f"Registered system task: workspace_backup (cron={cron})")
             else:
-                existing_bt = self.task_scheduler.get_task(backup_task_id)
                 if existing_bt and existing_bt.enabled != backup_enabled:
                     if backup_enabled:
                         await self.task_scheduler.enable_task(backup_task_id)

--- a/src/openakita/scheduler/__init__.py
+++ b/src/openakita/scheduler/__init__.py
@@ -11,13 +11,14 @@
 from .consolidation_tracker import ConsolidationTracker
 from .executor import TaskExecutor
 from .scheduler import TaskScheduler
-from .task import ScheduledTask, TaskStatus, TriggerType
+from .task import ScheduledTask, TaskDeliveryPolicy, TaskStatus, TriggerType
 from .triggers import CronTrigger, IntervalTrigger, OnceTrigger, Trigger
 
 __all__ = [
     "ScheduledTask",
     "TriggerType",
     "TaskStatus",
+    "TaskDeliveryPolicy",
     "Trigger",
     "OnceTrigger",
     "IntervalTrigger",

--- a/src/openakita/scheduler/delivery.py
+++ b/src/openakita/scheduler/delivery.py
@@ -1,0 +1,41 @@
+"""Delivery boundary helpers for scheduled task notifications."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .task import TaskDeliveryPolicy
+
+NON_IM_DELIVERY_CHANNELS = frozenset({"desktop", "api", "cli", "sse", "in-app", "scheduler"})
+
+
+def is_im_delivery_channel(channel: str | None) -> bool:
+    """Return whether a channel name represents an externally deliverable IM target."""
+
+    normalized = (channel or "").strip().lower()
+    return bool(normalized) and normalized not in NON_IM_DELIVERY_CHANNELS
+
+
+def coerce_delivery_policy(
+    value: TaskDeliveryPolicy | str | None,
+    default: TaskDeliveryPolicy = TaskDeliveryPolicy.OWNER_ONLY,
+) -> TaskDeliveryPolicy:
+    """Normalize API/storage values into a TaskDeliveryPolicy enum."""
+
+    if isinstance(value, TaskDeliveryPolicy):
+        return value
+    if value is None:
+        return default
+    try:
+        return TaskDeliveryPolicy(str(value))
+    except ValueError:
+        return default
+
+
+def allows_global_im_fallback(task: Any) -> bool:
+    """Return whether a task may search known IM sessions outside its owner target."""
+
+    return (
+        coerce_delivery_policy(getattr(task, "delivery_policy", None))
+        == TaskDeliveryPolicy.FALLBACK_ALLOWED
+    )

--- a/src/openakita/scheduler/executor.py
+++ b/src/openakita/scheduler/executor.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ..channels.base import ChannelDeliveryUnavailable
 from ..memory.json_utils import coerce_text
+from .delivery import allows_global_im_fallback, is_im_delivery_channel
 from .task import ScheduledTask
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,18 @@ class TaskExecutor:
             if normalized in {"0", "false", "no", "off"}:
                 return False
         return bool(value)
+
+    @staticmethod
+    def _is_im_delivery_channel(channel: str | None) -> bool:
+        """Return whether a channel name is an externally deliverable IM channel."""
+
+        return is_im_delivery_channel(channel)
+
+    @staticmethod
+    def _allows_global_im_fallback(task: ScheduledTask) -> bool:
+        """Only explicitly opted-in tasks may search unrelated IM sessions."""
+
+        return allows_global_im_fallback(task)
 
     def _escape_telegram_chars(self, text: str) -> str:
         """
@@ -179,8 +192,9 @@ class TaskExecutor:
 
             if task.channel_id and task.chat_id and self.gateway:
                 message_sent = await self._deliver_reminder_message(task, message)
-            elif self.gateway:
-                # 有网关但任务未配置通道，尝试所有已知通道
+            elif self.gateway and self._allows_global_im_fallback(task):
+                # 只有系统/管理类任务可以扫描全局 IM 目标；用户创建的提醒
+                # 没有显式目标时只能走桌面兜底，避免跨会话串台。
                 message_sent = await self._deliver_via_fallback_channels(task, message)
             # else: 无网关，无法发送
 
@@ -255,12 +269,25 @@ class TaskExecutor:
 
         logger.warning(
             f"TaskExecutor: reminder {task.id} failed on primary channel "
-            f"{channel_id}/{chat_id} (inactive), trying fallback channels"
+            f"{channel_id}/{chat_id} (inactive)"
         )
+        if not self._allows_global_im_fallback(task):
+            logger.info(
+                "TaskExecutor: reminder %s is owner-scoped; skipping global IM fallback",
+                task.id,
+            )
+            return False
         return await self._deliver_via_fallback_channels(task, message)
 
     async def _deliver_via_fallback_channels(self, task: ScheduledTask, message: str) -> bool:
         """尝试通过所有已知的备用 IM 通道投递提醒"""
+        if not self._allows_global_im_fallback(task):
+            logger.info(
+                "TaskExecutor: task %s is not allowed to use global IM fallback",
+                task.id,
+            )
+            return False
+
         targets = self._find_all_im_targets()
         primary = (task.channel_id, task.chat_id)
 
@@ -763,19 +790,25 @@ class TaskExecutor:
             except ChannelDeliveryUnavailable as exc:
                 last_unavailable = exc
 
-        for channel, chat_id in self._find_all_im_targets():
-            if (channel, chat_id) == primary:
-                continue
-            try:
-                if await self._send_gateway_text(channel=channel, chat_id=chat_id, text=text):
-                    logger.info(
-                        f"TaskExecutor: notification for {task.id} delivered via fallback "
-                        f"{channel}/{chat_id}"
-                    )
-                    return True
-            except ChannelDeliveryUnavailable as exc:
-                last_unavailable = exc
-                continue
+        if self._allows_global_im_fallback(task):
+            for channel, chat_id in self._find_all_im_targets():
+                if (channel, chat_id) == primary:
+                    continue
+                try:
+                    if await self._send_gateway_text(channel=channel, chat_id=chat_id, text=text):
+                        logger.info(
+                            f"TaskExecutor: notification for {task.id} delivered via fallback "
+                            f"{channel}/{chat_id}"
+                        )
+                        return True
+                except ChannelDeliveryUnavailable as exc:
+                    last_unavailable = exc
+                    continue
+        else:
+            logger.info(
+                "TaskExecutor: task %s is owner-scoped; skipping notification fallback",
+                task.id,
+            )
 
         if last_unavailable is not None:
             raise last_unavailable
@@ -1581,6 +1614,8 @@ class TaskExecutor:
             for session in sessions:
                 if getattr(session, "state", None) and str(session.state.value) == "closed":
                     continue
+                if not self._is_im_delivery_channel(getattr(session, "channel", "")):
+                    continue
                 pair = (session.channel, session.chat_id)
                 if pair not in seen:
                     seen.add(pair)
@@ -1599,7 +1634,12 @@ class TaskExecutor:
                     channel = s.get("channel")
                     chat_id = s.get("chat_id")
                     state = s.get("state", "")
-                    if not channel or not chat_id or state == "closed":
+                    if (
+                        not channel
+                        or not chat_id
+                        or state == "closed"
+                        or not self._is_im_delivery_channel(channel)
+                    ):
                         continue
                     pair = (channel, chat_id)
                     if pair not in seen:

--- a/src/openakita/scheduler/scheduler.py
+++ b/src/openakita/scheduler/scheduler.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from ..utils.atomic_io import atomic_json_write, safe_write
 from ._naming import quarantine_invalid_task_name, validate_task_name
+from .delivery import coerce_delivery_policy
 from .locks import (
     HEARTBEAT_INTERVAL_SECONDS,
     ExecLock,
@@ -33,7 +34,15 @@ from .locks import (
     set_current_scheduled_task_id,
     unlink_orphan,
 )
-from .task import ScheduledTask, TaskDurability, TaskExecution, TaskStatus, TriggerType
+from .task import (
+    ScheduledTask,
+    TaskDurability,
+    TaskExecution,
+    TaskSource,
+    TaskStatus,
+    TaskType,
+    TriggerType,
+)
 from .triggers import Trigger
 
 logger = logging.getLogger(__name__)
@@ -517,10 +526,32 @@ class TaskScheduler:
         "chat_id",
         "user_id",
         "agent_profile_id",
+        "task_source",
+        "delivery_policy",
         "metadata",
         "script_path",
         "action",
     }
+
+    @staticmethod
+    def _normalize_update_value(key: str, value: Any) -> Any:
+        """Coerce enum fields accepted by update_task into domain values."""
+
+        if key == "delivery_policy":
+            return coerce_delivery_policy(value)
+        if key == "task_source" and not isinstance(value, TaskSource):
+            try:
+                return TaskSource(str(value))
+            except ValueError:
+                return TaskSource.MANUAL
+        if key == "task_type" and not isinstance(value, TaskType):
+            try:
+                return TaskType(str(value))
+            except ValueError:
+                return TaskType.TASK
+        if key == "trigger_type" and not isinstance(value, TriggerType):
+            return TriggerType(str(value))
+        return value
 
     async def update_task(self, task_id: str, updates: dict) -> bool:
         """更新任务（仅允许白名单字段）"""
@@ -536,7 +567,7 @@ class TaskScheduler:
 
             for key, value in updates.items():
                 if key in self._UPDATABLE_FIELDS and hasattr(task, key):
-                    setattr(task, key, value)
+                    setattr(task, key, self._normalize_update_value(key, value))
 
             task.updated_at = datetime.now()
 

--- a/src/openakita/scheduler/task.py
+++ b/src/openakita/scheduler/task.py
@@ -101,6 +101,19 @@ class TaskDurability(Enum):
     SESSION = "session"
 
 
+class TaskDeliveryPolicy(Enum):
+    """How scheduler notifications may choose a delivery target.
+
+    OWNER_ONLY is the default for user-created tasks: deliver only to the
+    task's recorded channel/chat, or fall back to desktop notification if no
+    IM target exists. FALLBACK_ALLOWED is reserved for system/admin flows that
+    are explicitly allowed to scan known IM channels.
+    """
+
+    OWNER_ONLY = "owner_only"
+    FALLBACK_ALLOWED = "fallback_allowed"
+
+
 class TaskStatus(Enum):
     """任务状态"""
 
@@ -234,6 +247,7 @@ class ScheduledTask:
     # 领域边界
     task_source: TaskSource = TaskSource.MANUAL
     durability: TaskDurability = TaskDurability.PERSISTENT
+    delivery_policy: TaskDeliveryPolicy = TaskDeliveryPolicy.OWNER_ONLY
 
     # 状态
     enabled: bool = True
@@ -599,6 +613,23 @@ class ScheduledTask:
         """是否是简单提醒任务"""
         return self.task_type == TaskType.REMINDER
 
+    @property
+    def allows_global_im_fallback(self) -> bool:
+        """Whether this task may search unrelated IM sessions for delivery."""
+        if isinstance(self.delivery_policy, TaskDeliveryPolicy):
+            return self.delivery_policy == TaskDeliveryPolicy.FALLBACK_ALLOWED
+        return str(self.delivery_policy) == TaskDeliveryPolicy.FALLBACK_ALLOWED.value
+
+    @property
+    def delivery_policy_value(self) -> str:
+        """Serialized delivery policy value, tolerant of legacy string assignments."""
+        if isinstance(self.delivery_policy, TaskDeliveryPolicy):
+            return self.delivery_policy.value
+        try:
+            return TaskDeliveryPolicy(str(self.delivery_policy)).value
+        except ValueError:
+            return TaskDeliveryPolicy.OWNER_ONLY.value
+
     def to_dict(self) -> dict:
         """序列化"""
         return {
@@ -618,6 +649,7 @@ class ScheduledTask:
             "agent_profile_id": self.agent_profile_id,
             "task_source": self.task_source.value,
             "durability": self.durability.value,
+            "delivery_policy": self.delivery_policy_value,
             "enabled": self.enabled,
             "status": self.status.value,
             "deletable": self.deletable,
@@ -705,6 +737,19 @@ class ScheduledTask:
             durability = TaskDurability.PERSISTENT
 
         try:
+            delivery_policy = TaskDeliveryPolicy(data.get("delivery_policy", ""))
+        except ValueError:
+            # Back-compat: old persisted tasks did not record the delivery
+            # policy. Only system-owned tasks keep broad IM fallback behavior;
+            # every user/chat/manual task becomes owner-scoped on load.
+            action = data.get("action") or ""
+            source_raw = data.get("task_source", "manual")
+            if str(action).startswith("system:") or source_raw == TaskSource.SYSTEM.value:
+                delivery_policy = TaskDeliveryPolicy.FALLBACK_ALLOWED
+            else:
+                delivery_policy = TaskDeliveryPolicy.OWNER_ONLY
+
+        try:
             status = TaskStatus(data.get("status", "pending"))
         except ValueError:
             status = TaskStatus.PENDING
@@ -734,6 +779,7 @@ class ScheduledTask:
             agent_profile_id=data.get("agent_profile_id", "default"),
             task_source=task_source,
             durability=durability,
+            delivery_policy=delivery_policy,
             enabled=_safe_bool(data.get("enabled", True), True),
             status=status,
             deletable=_safe_bool(data.get("deletable", True), True),

--- a/src/openakita/tools/handlers/scheduled.py
+++ b/src/openakita/tools/handlers/scheduled.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from ...core.policy_v2 import ApprovalClass
+from ...scheduler.delivery import is_im_delivery_channel
 
 if TYPE_CHECKING:
     from ...agent.core import Agent
@@ -74,6 +75,23 @@ class ScheduledHandler:
                 return profile_id
         return getattr(self.agent, "_agent_profile_id", "default") or "default"
 
+    @staticmethod
+    def _task_origin_metadata(session: Any | None, agent_profile_id: str) -> dict[str, str]:
+        """Persist where a chat-created scheduled task came from."""
+
+        if session is None:
+            return {"agent_profile_id": agent_profile_id}
+
+        origin = {
+            "session_id": str(getattr(session, "id", "") or ""),
+            "channel": str(getattr(session, "channel", "") or ""),
+            "chat_id": str(getattr(session, "chat_id", "") or ""),
+            "user_id": str(getattr(session, "user_id", "") or ""),
+            "bot_instance_id": str(getattr(session, "bot_instance_id", "") or ""),
+            "agent_profile_id": agent_profile_id,
+        }
+        return {key: value for key, value in origin.items() if value}
+
     async def handle(self, tool_name: str, params: dict[str, Any]) -> str:
         """处理工具调用"""
         scheduler = self._get_scheduler()
@@ -100,7 +118,7 @@ class ScheduledHandler:
         """创建定时任务"""
         from ...core.im_context import get_im_session
         from ...scheduler import ScheduledTask, TriggerType
-        from ...scheduler.task import TaskSource, TaskType
+        from ...scheduler.task import TaskDeliveryPolicy, TaskSource, TaskType
 
         # 必填字段校验
         for field in ("name", "description", "trigger_type", "trigger_config"):
@@ -145,13 +163,18 @@ class ScheduledHandler:
             except ValueError:
                 pass
 
-        # 获取当前 IM 会话信息
+        # 获取当前会话。IM context 只在 IM/带 gateway 的执行路径中可靠；
+        # 桌面/API 路径用 agent._current_session 作为 owner 记录。
         channel_id = chat_id = user_id = None
-        session = get_im_session()
+        session = get_im_session() or getattr(self.agent, "_current_session", None)
+        current_agent_profile_id = self._current_agent_profile_id()
+        delivery_target_source = "none"
         if session:
+            user_id = getattr(session, "user_id", None)
+        if session and is_im_delivery_channel(getattr(session, "channel", None)):
             channel_id = session.channel
             chat_id = session.chat_id
-            user_id = session.user_id
+            delivery_target_source = "current_im_session"
 
         # 如果用户指定了 target_channel，尝试解析到已配置的通道
         target_channel = params.get("target_channel")
@@ -159,6 +182,7 @@ class ScheduledHandler:
             resolved = self._resolve_target_channel(target_channel)
             if resolved:
                 channel_id, chat_id = resolved
+                delivery_target_source = "target_channel"
                 logger.info(f"Using target_channel={target_channel}: {channel_id}/{chat_id}")
             else:
                 # 通道未配置或无可用 session，给出明确提示
@@ -179,11 +203,14 @@ class ScheduledHandler:
             user_id=user_id,
             channel_id=channel_id,
             chat_id=chat_id,
-            agent_profile_id=self._current_agent_profile_id(),
+            agent_profile_id=current_agent_profile_id,
             task_source=TaskSource.CHAT,
+            delivery_policy=TaskDeliveryPolicy.OWNER_ONLY,
         )
         task.silent = bool(params.get("silent", False))
         task.no_schedule_tools = bool(params.get("no_schedule_tools", False))
+        task.metadata["origin"] = self._task_origin_metadata(session, current_agent_profile_id)
+        task.metadata["delivery_target_source"] = delivery_target_source
         if params.get("skill_ids"):
             task.skill_ids = list(params["skill_ids"])
         task.metadata["notify_on_start"] = params.get("notify_on_start", True)
@@ -360,6 +387,9 @@ class ScheduledHandler:
         if not gateway:
             logger.warning("No gateway available to resolve target_channel")
             return None
+        if not is_im_delivery_channel(target_channel):
+            logger.warning("Channel '%s' is not an IM delivery channel", target_channel)
+            return None
 
         # 1. 检查适配器是否存在
         adapters = getattr(gateway, "_adapters", {})
@@ -441,6 +471,8 @@ class ScheduledHandler:
 
         running = []
         for name, adapter in adapters.items():
+            if not is_im_delivery_channel(name):
+                continue
             status = "✓" if getattr(adapter, "is_running", False) else "✗"
             running.append(f"{name}({status})")
 

--- a/tests/unit/test_scheduler_executor_status.py
+++ b/tests/unit/test_scheduler_executor_status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from openakita.channels.base import ChannelDeliveryUnavailable
 from openakita.scheduler.executor import TaskExecutor
 from openakita.scheduler.scheduler import TaskScheduler
-from openakita.scheduler.task import ScheduledTask
+from openakita.scheduler.task import ScheduledTask, TaskDeliveryPolicy
 
 
 @dataclass
@@ -295,6 +296,7 @@ async def test_completion_notification_falls_back_to_known_im_target(tmp_path):
     executor = TaskExecutor(agent_factory=lambda: _SuccessfulAgent(), gateway=gateway)
     scheduler = await _make_scheduler(tmp_path, executor=executor.execute)
     task = _make_task(channel_id="qqbot:xiababy", chat_id="chat-1")
+    task.delivery_policy = TaskDeliveryPolicy.FALLBACK_ALLOWED
     task.metadata["notify_on_start"] = False
     task_id = await scheduler.add_task(task)
 
@@ -306,3 +308,48 @@ async def test_completion_notification_falls_back_to_known_im_target(tmp_path):
         ("qqbot:xiababy", "chat-1"),
         ("feishu:bot", "chat-2"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_completion_notification_does_not_fallback_to_other_im_target(
+    tmp_path,
+):
+    gateway = _FallbackGateway(tmp_path)
+    executor = TaskExecutor(agent_factory=lambda: _SuccessfulAgent(), gateway=gateway)
+    scheduler = await _make_scheduler(tmp_path, executor=executor.execute)
+    task = _make_task(channel_id="qqbot:xiababy", chat_id="chat-1")
+    task.metadata["notify_on_start"] = False
+    task_id = await scheduler.add_task(task)
+
+    execution = await scheduler.trigger_now(task_id)
+
+    assert execution is not None
+    assert execution.status == "failed"
+    assert execution.error == "任务已完成，但结果通知发送失败，请检查 IM 通道连接状态。"
+    assert gateway.calls == [("qqbot:xiababy", "chat-1")]
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_reminder_without_target_uses_desktop_not_global_im(
+    tmp_path,
+    monkeypatch,
+):
+    gateway = _FallbackGateway(tmp_path)
+    executor = TaskExecutor(gateway=gateway)
+    task = ScheduledTask.create_reminder(
+        name="owner-only reminder",
+        description="owner-only reminder",
+        run_at=datetime.now() + timedelta(minutes=5),
+        message="stand up",
+    )
+
+    async def fake_desktop_fallback(_task, _message):
+        return True
+
+    monkeypatch.setattr(executor, "_try_desktop_notify_fallback", fake_desktop_fallback)
+
+    success, message = await executor.execute(task)
+
+    assert success is True
+    assert "桌面通知" in message
+    assert gateway.calls == []

--- a/tests/unit/test_scheduler_tasks.py
+++ b/tests/unit/test_scheduler_tasks.py
@@ -5,7 +5,14 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 from openakita.scheduler.executor import TaskExecutor
-from openakita.scheduler.task import ScheduledTask, TaskStatus, TaskType, TriggerType
+from openakita.scheduler.task import (
+    ScheduledTask,
+    TaskDeliveryPolicy,
+    TaskSource,
+    TaskStatus,
+    TaskType,
+    TriggerType,
+)
 from openakita.scheduler.triggers import CronTrigger, IntervalTrigger, OnceTrigger, Trigger
 
 
@@ -239,6 +246,100 @@ class TestTaskAgentProfiles:
 
         assert "已创建" in result
         assert captured["task"].agent_profile_id == "researcher"
+        assert captured["task"].delivery_policy == TaskDeliveryPolicy.OWNER_ONLY
+        assert captured["task"].channel_id is None
+        assert captured["task"].chat_id is None
+        assert captured["task"].metadata["origin"]["agent_profile_id"] == "researcher"
+        assert captured["task"].metadata["delivery_target_source"] == "none"
+
+    async def test_desktop_created_task_records_origin_without_im_target(self):
+        from openakita.tools.handlers.scheduled import ScheduledHandler
+
+        captured: dict[str, ScheduledTask] = {}
+
+        class FakeScheduler:
+            async def add_task(self, task):
+                captured["task"] = task
+                return task.id
+
+        agent = SimpleNamespace(
+            task_scheduler=FakeScheduler(),
+            _current_session=SimpleNamespace(
+                id="desktop-session",
+                channel="desktop",
+                chat_id="local-window",
+                user_id="desktop-user",
+                context=SimpleNamespace(agent_profile_id="desktop-profile"),
+            ),
+            _agent_profile_id="default",
+        )
+        handler = ScheduledHandler(agent)
+
+        result = await handler._schedule_task(
+            {
+                "name": "desktop-reminder",
+                "description": "desktop reminder",
+                "task_type": "reminder",
+                "trigger_type": "once",
+                "trigger_config": {"run_at": (datetime.now() + timedelta(minutes=5)).isoformat()},
+                "reminder_message": "stand up",
+            }
+        )
+
+        task = captured["task"]
+        assert "已创建" in result
+        assert task.channel_id is None
+        assert task.chat_id is None
+        assert task.user_id == "desktop-user"
+        assert task.agent_profile_id == "desktop-profile"
+        assert task.delivery_policy == TaskDeliveryPolicy.OWNER_ONLY
+        assert task.metadata["origin"]["channel"] == "desktop"
+        assert task.metadata["origin"]["chat_id"] == "local-window"
+        assert task.metadata["delivery_target_source"] == "none"
+
+    async def test_im_created_task_records_exact_owner_target(self):
+        from openakita.tools.handlers.scheduled import ScheduledHandler
+
+        captured: dict[str, ScheduledTask] = {}
+
+        class FakeScheduler:
+            async def add_task(self, task):
+                captured["task"] = task
+                return task.id
+
+        agent = SimpleNamespace(
+            task_scheduler=FakeScheduler(),
+            _current_session=SimpleNamespace(
+                id="im-session",
+                channel="feishu:bot-a",
+                chat_id="oc_owner",
+                user_id="im-user",
+                context=SimpleNamespace(agent_profile_id="assistant-a"),
+            ),
+            _agent_profile_id="default",
+        )
+        handler = ScheduledHandler(agent)
+
+        result = await handler._schedule_task(
+            {
+                "name": "im-reminder",
+                "description": "im reminder",
+                "task_type": "reminder",
+                "trigger_type": "once",
+                "trigger_config": {"run_at": (datetime.now() + timedelta(minutes=5)).isoformat()},
+                "reminder_message": "ping",
+            }
+        )
+
+        task = captured["task"]
+        assert "已创建" in result
+        assert task.channel_id == "feishu:bot-a"
+        assert task.chat_id == "oc_owner"
+        assert task.user_id == "im-user"
+        assert task.agent_profile_id == "assistant-a"
+        assert task.delivery_policy == TaskDeliveryPolicy.OWNER_ONLY
+        assert task.metadata["origin"]["channel"] == "feishu:bot-a"
+        assert task.metadata["delivery_target_source"] == "current_im_session"
 
 
 class TestSystemTaskRegistration:
@@ -298,6 +399,9 @@ class TestSystemTaskRegistration:
         assert scheduler.updates == []
         assert task.trigger_type == TriggerType.INTERVAL
         assert task.trigger_config == {"interval_minutes": 720}
+        assert task.task_source == TaskSource.SYSTEM
+        assert task.delivery_policy == TaskDeliveryPolicy.FALLBACK_ALLOWED
+        assert scheduler.saved is True
 
 
 class TestTaskSerialization:
@@ -308,12 +412,50 @@ class TestTaskSerialization:
             trigger_type=TriggerType.INTERVAL,
             trigger_config={"interval_minutes": 30},
             prompt="Do it",
+            delivery_policy=TaskDeliveryPolicy.FALLBACK_ALLOWED,
         )
         d = task.to_dict()
         assert d["name"] == "serialize-test"
+        assert d["delivery_policy"] == "fallback_allowed"
         restored = ScheduledTask.from_dict(d)
         assert restored.name == task.name
         assert restored.prompt == task.prompt
+        assert restored.delivery_policy == TaskDeliveryPolicy.FALLBACK_ALLOWED
+
+    def test_legacy_user_task_without_delivery_policy_loads_owner_only(self):
+        task = ScheduledTask.create(
+            name="legacy-user",
+            description="legacy user task",
+            trigger_type=TriggerType.ONCE,
+            trigger_config={"run_at": (datetime.now() + timedelta(minutes=5)).isoformat()},
+            prompt="",
+            task_source=TaskSource.CHAT,
+        )
+        data = task.to_dict()
+        data.pop("delivery_policy")
+
+        restored = ScheduledTask.from_dict(data)
+
+        assert restored.delivery_policy == TaskDeliveryPolicy.OWNER_ONLY
+        assert restored.allows_global_im_fallback is False
+
+    def test_legacy_system_task_without_delivery_policy_loads_fallback_allowed(self):
+        task = ScheduledTask.create(
+            name="legacy-system",
+            description="legacy system task",
+            trigger_type=TriggerType.CRON,
+            trigger_config={"cron": "0 3 * * *"},
+            prompt="",
+            action="system:daily_memory",
+            task_source=TaskSource.SYSTEM,
+        )
+        data = task.to_dict()
+        data.pop("delivery_policy")
+
+        restored = ScheduledTask.from_dict(data)
+
+        assert restored.delivery_policy == TaskDeliveryPolicy.FALLBACK_ALLOWED
+        assert restored.allows_global_im_fallback is True
 
 
 class TestTriggers:


### PR DESCRIPTION
## Summary
- Add explicit scheduler delivery policies so user-created tasks are owner-scoped by default.
- Preserve global IM fallback only for system/admin scheduler tasks and shared IM channel discovery.

## Tests
- uv run --no-sync pytest tests/unit/test_scheduler_tasks.py tests/unit/test_scheduler_executor_status.py
- uv run --no-sync pytest tests/unit/test_scheduler_task_boundaries.py
- uv run --no-sync ruff check src/openakita/scheduler src/openakita/tools/handlers/scheduled.py src/openakita/api/routes/scheduler.py src/openakita/api/routes/workspace_io.py src/openakita/channels/gateway.py src/openakita/core/_agent_legacy.py tests/unit/test_scheduler_tasks.py tests/unit/test_scheduler_executor_status.py
- uv run --no-sync python -c "import openakita.tools.handlers.scheduled; import openakita.api.routes.scheduler; import openakita.scheduler.delivery; print('import-ok')"

Fixes #713