### PR TITLE
fix the feedback screenshot thumbnail remove button so it only appears as a subtle hover control

### DIFF
--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -2082,7 +2082,8 @@
     "systemInfo": "System Information (auto-collected)",
     "submit": "Submit Report",
     "submitting": "Submitting...",
-    "submitSuccess": "Report submitted successfully (ID: {{id}}). You can check progress in My Feedback."
+    "submitSuccess": "Report submitted successfully (ID: {{id}}). You can check progress in My Feedback.",
+    "removeImage": "Remove screenshot"
   },
   "featureRequest": {
     "title": "Feature Request",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -2082,7 +2082,8 @@
     "systemInfo": "系统信息（自动采集）",
     "submit": "提交报告",
     "submitting": "提交中...",
-    "submitSuccess": "报告提交成功（ID: {{id}}）。您可以在「我的反馈」中查看处理进度。"
+    "submitSuccess": "报告提交成功（ID: {{id}}）。您可以在「我的反馈」中查看处理进度。",
+    "removeImage": "删除截图"
   },
   "featureRequest": {
     "title": "需求建议",

--- a/apps/setup-center/src/views/FeedbackModal.tsx
+++ b/apps/setup-center/src/views/FeedbackModal.tsx
@@ -740,14 +740,19 @@ export function FeedbackModal({ open, onClose, apiBase, initialMode = "bug", pre
             {imagePreviews.length > 0 && (
               <div className="flex gap-1.5 flex-wrap mt-1.5">
                 {imagePreviews.map((src, i) => (
-                  <div key={i} className="relative w-14 h-14 rounded-md overflow-hidden border border-border">
+                  <div key={i} className="group relative w-14 h-14 rounded-md overflow-hidden border border-border">
                     <img src={src} alt="" className="w-full h-full object-cover" />
-                    <button
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label={t("bugReport.removeImage")}
+                      title={t("bugReport.removeImage")}
                       onClick={(e) => { e.stopPropagation(); removeImage(i); }}
-                      className="absolute top-0.5 right-0.5 w-4 h-4 rounded-full border-0 bg-black/60 text-white text-[9px] flex items-center justify-center cursor-pointer p-0"
+                      className="pointer-events-none absolute top-0.5 right-0.5 size-5 rounded-full border border-destructive/45 bg-transparent p-0 text-destructive opacity-0 shadow-none transition-[opacity,border-color] hover:border-destructive/70 hover:!bg-transparent hover:!text-destructive focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-destructive/30 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 dark:hover:!bg-transparent [&_svg]:drop-shadow-[0_1px_1px_rgb(255_255_255_/_0.9)]"
                     >
-                      <IconX size={8} />
-                    </button>
+                      <IconX size={12} strokeWidth={2.5} />
+                    </Button>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Make screenshot thumbnail removal a subtle hover-only control.
- Keep the remove affordance accessible with localized labels and avoid legacy global button styling.

## Tests
- `npx tsc -b`
- `npm run build:web`

Fixes #589