### PR TITLE
fix desktop conversation export to use the native save dialog

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -3007,11 +3007,17 @@ export function ChatView({
         setMessages((prev) => [...prev, { id: genId(), role: "system", content: `当前思考程度: ${currentLabel}\n用法: /thinking_depth low|medium|high|max`, timestamp: Date.now() }]);
       }
     }},
-    { id: "export", label: t("chat.exportLabel", "导出会话"), description: t("chat.exportDesc", "导出当前对话 (md/json)"), action: (args) => {
+    { id: "export", label: t("chat.exportLabel", "导出会话"), description: t("chat.exportDesc", "导出当前对话 (md/json)"), action: async (args) => {
       const fmt = args?.trim().toLowerCase() === "json" ? "json" : "md";
       const conv = conversations.find((c) => c.id === activeConvId);
-      exportConversation(messages, conv?.title || t("chat.conversation", "对话"), fmt as "md" | "json");
-      setMessages((prev) => [...prev, { id: genId(), role: "system", content: t("chat.exportDone", { format: fmt.toUpperCase(), defaultValue: `已导出为 ${fmt.toUpperCase()} 格式` }), timestamp: Date.now() }]);
+      try {
+        const saved = await exportConversation(messages, conv?.title || t("chat.conversation", "对话"), fmt);
+        if (saved) {
+          setMessages((prev) => [...prev, { id: genId(), role: "system", content: t("chat.exportDone", { format: fmt.toUpperCase(), defaultValue: `已导出为 ${fmt.toUpperCase()} 格式` }), timestamp: Date.now() }]);
+        }
+      } catch (error) {
+        toast.error(t("chat.exportFailed", "导出会话失败"), { description: String(error) });
+      }
     }},
     { id: "memory", label: t("chat.memoryCmd", "记忆管理"), description: t("chat.memoryCmdDesc", "查看/管理 AI 记忆条目"), action: (args) => {
       if (args === "list" || !args) {
@@ -6569,13 +6575,17 @@ export function ChatView({
                 label: t("chat.exportConversation", "导出会话"),
                 icon: <IconDownload size={13} />,
                 danger: false,
-                action: () => {
+                action: async () => {
                   const conv = conversations.find((c) => c.id === ctxMenu.convId);
                   const convMsgs = ctxMenu.convId === activeConvId
                     ? messages
                     : loadMessagesFromStorage(STORAGE_KEY_MSGS_PREFIX + ctxMenu.convId);
-                  exportConversation(convMsgs, conv?.title || t("chat.conversation", "对话"), "md");
                   setCtxMenu(null);
+                  try {
+                    await exportConversation(convMsgs, conv?.title || t("chat.conversation", "对话"), "md");
+                  } catch (error) {
+                    toast.error(t("chat.exportFailed", "导出会话失败"), { description: String(error) });
+                  }
                 },
               },
               {

--- a/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.export.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.export.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "../chatTypes";
+
+const messages: ChatMessage[] = [
+  { id: "message-1", role: "user", content: "Hello", timestamp: 1 },
+];
+
+async function loadExporter(options: { tauri: boolean; savePath?: string | null }) {
+  const saveFileDialog = vi.fn().mockResolvedValue(options.savePath ?? null);
+  const writeTextFile = vi.fn().mockResolvedValue(undefined);
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+
+  vi.doMock("../../../../platform", () => ({
+    IS_TAURI: options.tauri,
+    logger,
+    saveFileDialog,
+    writeTextFile,
+  }));
+  vi.doMock("../../../../platform/auth", () => ({ getAccessToken: vi.fn() }));
+
+  const { exportConversation } = await import("../chatHelpers");
+  return { exportConversation, logger, saveFileDialog, writeTextFile };
+}
+
+describe("exportConversation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("uses the native save dialog and filesystem in Tauri", async () => {
+    const { exportConversation, saveFileDialog, writeTextFile } = await loadExporter({
+      tauri: true,
+      savePath: "C:\\Users\\tester\\Desktop\\Chat.md",
+    });
+
+    await expect(exportConversation(messages, "Chat", "md")).resolves.toBe(true);
+    expect(saveFileDialog).toHaveBeenCalledWith({
+      title: "导出会话",
+      defaultPath: "Chat.md",
+      filters: [{ name: "Markdown", extensions: ["md"] }],
+    });
+    expect(writeTextFile).toHaveBeenCalledWith(
+      "C:\\Users\\tester\\Desktop\\Chat.md",
+      expect.stringContaining("Hello"),
+    );
+  });
+
+  it("does not write when the native save dialog is cancelled", async () => {
+    const { exportConversation, writeTextFile } = await loadExporter({
+      tauri: true,
+      savePath: null,
+    });
+
+    await expect(exportConversation(messages, "Chat", "json")).resolves.toBe(false);
+    expect(writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps browser downloads for the web build", async () => {
+    const { exportConversation, saveFileDialog, writeTextFile } = await loadExporter({ tauri: false });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    const createObjectURL = vi.fn().mockReturnValue("blob:conversation");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperties(URL, {
+      createObjectURL: { configurable: true, value: createObjectURL },
+      revokeObjectURL: { configurable: true, value: revokeObjectURL },
+    });
+
+    await expect(exportConversation(messages, "Chat", "json")).resolves.toBe(true);
+    expect(click).toHaveBeenCalledOnce();
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(saveFileDialog).not.toHaveBeenCalled();
+    expect(writeTextFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/chatHelpers.ts
+++ b/apps/setup-center/src/views/chat/utils/chatHelpers.ts
@@ -17,7 +17,7 @@ import type {
   ChainSummaryItem,
   ChainTimelineGroup,
 } from "./chatTypes";
-import { IS_TAURI } from "../../../platform";
+import { IS_TAURI, logger, saveFileDialog, writeTextFile } from "../../../platform";
 import { getAccessToken } from "../../../platform/auth";
 
 // ── 持久化 Key 常量 ──
@@ -120,7 +120,11 @@ export const SVG_PATHS: Record<string, string> = {
 
 // ── 对话导出 ──
 
-export function exportConversation(msgs: ChatMessage[], title: string, format: "md" | "json") {
+export async function exportConversation(
+  msgs: ChatMessage[],
+  title: string,
+  format: "md" | "json",
+): Promise<boolean> {
   let content: string;
   let mimeType: string;
   let ext: string;
@@ -147,13 +151,40 @@ export function exportConversation(msgs: ChatMessage[], title: string, format: "
     mimeType = "text/markdown";
     ext = "md";
   }
-  const blob = new Blob([content], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${title.replace(/[/\\?%*:|"<>]/g, "_").slice(0, 50)}.${ext}`;
-  a.click();
-  setTimeout(() => URL.revokeObjectURL(url), 5000);
+  const filename = `${title.replace(/[/\\?%*:|"<>]/g, "_").slice(0, 50)}.${ext}`;
+  logger.info("Chat.Export", "start", { format: ext, msgCount: msgs.length });
+
+  try {
+    if (IS_TAURI) {
+      const savePath = await saveFileDialog({
+        title: "导出会话",
+        defaultPath: filename,
+        filters: [{ name: format === "json" ? "JSON" : "Markdown", extensions: [ext] }],
+      });
+      if (!savePath) {
+        logger.info("Chat.Export", "cancelled", { format: ext });
+        return false;
+      }
+      await writeTextFile(savePath, content);
+      logger.info("Chat.Export", "success", { format: ext, path: savePath });
+      return true;
+    }
+
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 5000);
+    logger.info("Chat.Export", "success", { format: ext });
+    return true;
+  } catch (error) {
+    logger.error("Chat.Export", "error", { format: ext, error: String(error) });
+    throw error;
+  }
 }
 
 // ── Auth token helper ──


### PR DESCRIPTION
## Summary

- Use the native save dialog and filesystem writer when exporting conversations from the desktop app.
- Preserve browser downloads for web builds and report export failures to users.
- Add regression coverage for desktop saves, cancelled dialogs, and web downloads.

## Tests

- `npm run test:run -- src/views/chat/utils/__tests__/chatHelpers.export.test.ts`
- `npm run build`
- `npx eslint src/views/ChatView.tsx src/views/chat/utils/chatHelpers.ts src/views/chat/utils/__tests__/chatHelpers.export.test.ts`

Fixes #728
