### PR TITLE
Fix mobile chat controls and dropdown overflow

### DIFF
--- a/apps/setup-center/e2e/mobile-chat-layout.spec.ts
+++ b/apps/setup-center/e2e/mobile-chat-layout.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+
+for (const width of [320, 393, 430]) {
+  test(`mobile chat controls stay inside a ${width}px viewport`, async ({ page }) => {
+    await page.setViewportSize({ width, height: width === 320 ? 720 : 852 });
+    await page.goto("/#/chat", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => undefined);
+
+    const textarea = page.getByTestId("chat-input-textarea");
+    const toolbar = page.getByTestId("chat-input-toolbar");
+
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+    await expect(toolbar).toBeVisible();
+    await expect(textarea).toHaveAttribute("placeholder", /^(输入消息\.\.\.|Type a message\.\.\.)$/);
+
+    const layout = await page.evaluate(() => {
+      const requiredSelectors = [
+        ".topbar",
+        '[data-testid="topbar-actions"]',
+        '[data-testid="topbar-remote-access"]',
+        '[data-testid="chat-input-pickers"]',
+        '[data-testid="chat-input-toolbar"]',
+        '[data-testid="chat-input-textarea"]',
+      ];
+      const optionalSelectors = ['[data-testid="chat-context-usage"]'].filter((selector) =>
+        document.querySelector(selector),
+      );
+      const selectors = [...requiredSelectors, ...optionalSelectors];
+      const boxes = selectors.map((selector) => {
+        const element = document.querySelector<HTMLElement>(selector);
+        if (!element) return { selector, missing: true };
+        const rect = element.getBoundingClientRect();
+        return {
+          selector,
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+        };
+      });
+      const toolbarIcons = Array.from(
+        document.querySelectorAll<SVGElement>('[data-testid="chat-input-toolbar"] button > svg'),
+      ).map((icon) => {
+        const rect = icon.getBoundingClientRect();
+        return {
+          width: rect.width,
+          height: rect.height,
+          declaredWidth: Number(icon.getAttribute("width")) || 0,
+          declaredHeight: Number(icon.getAttribute("height")) || 0,
+        };
+      });
+      const visibleLabels = Array.from(
+        document.querySelectorAll<HTMLElement>(".chatInputIconLabel"),
+      ).filter((label) => getComputedStyle(label).display !== "none").length;
+      const remoteIcon = document.querySelector<SVGElement>(
+        '[data-testid="topbar-remote-access"] > svg',
+      )?.getBoundingClientRect();
+      const remoteLabel = document.querySelector<HTMLElement>(".topbarRemoteLabel");
+      return {
+        viewportWidth: window.innerWidth,
+        documentWidth: document.documentElement.scrollWidth,
+        boxes,
+        toolbarIcons,
+        visibleLabels,
+        remoteIcon: remoteIcon ? { width: remoteIcon.width, height: remoteIcon.height } : null,
+        remoteLabelVisible: remoteLabel ? getComputedStyle(remoteLabel).display !== "none" : null,
+      };
+    });
+
+    expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth);
+    for (const box of layout.boxes) {
+      expect(box.missing, `${box.selector} should be rendered`).not.toBe(true);
+      expect(box.left, `${box.selector} should not overflow left`).toBeGreaterThanOrEqual(0);
+      expect(box.right, `${box.selector} should not overflow right`).toBeLessThanOrEqual(
+        layout.viewportWidth + 0.5,
+      );
+    }
+    expect(layout.toolbarIcons.length).toBeGreaterThan(0);
+    for (const icon of layout.toolbarIcons) {
+      expect(icon.width + 0.5).toBeGreaterThanOrEqual(icon.declaredWidth);
+      expect(icon.height + 0.5).toBeGreaterThanOrEqual(icon.declaredHeight);
+    }
+    expect(layout.visibleLabels).toBe(0);
+    expect(layout.remoteIcon).toEqual({ width: 16, height: 16 });
+    expect(layout.remoteLabelVisible).toBe(false);
+
+    await page.getByTestId("chat-mode-trigger").click();
+    const modeMenu = page.getByTestId("chat-mode-menu");
+    await expect(modeMenu).toBeVisible();
+    const menuBox = await modeMenu.boundingBox();
+    expect(menuBox).not.toBeNull();
+    expect(menuBox!.x).toBeGreaterThanOrEqual(0);
+    expect(menuBox!.x + menuBox!.width).toBeLessThanOrEqual(layout.viewportWidth + 0.5);
+  });
+}
+
+test("mobile organization menu stays inside the viewport", async ({ page }) => {
+  const apiBase = "http://127.0.0.1:18900";
+  const templatesResponse = await page.request.get(`${apiBase}/api/v2/orgs/templates`);
+  expect(templatesResponse.status()).toBe(200);
+  const templates = (await templatesResponse.json()) as Array<{ id: string }>;
+  expect(templates.length).toBeGreaterThan(0);
+
+  const createResponse = await page.request.post(`${apiBase}/api/v2/orgs/from-template`, {
+    data: { template_id: templates[0].id, name: `mobile-menu-${Date.now()}` },
+    headers: { "Content-Type": "application/json" },
+  });
+  expect(createResponse.status()).toBe(201);
+  const orgId = ((await createResponse.json()) as { id: string }).id;
+
+  try {
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.goto("/#/chat", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle").catch(() => undefined);
+
+    const trigger = page.getByTestId("chat-org-trigger");
+    await expect(trigger).toBeVisible({ timeout: 15_000 });
+    await trigger.click();
+
+    const menu = page.getByTestId("chat-org-menu");
+    await expect(menu).toBeVisible();
+    const box = await menu.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(393.5);
+  } finally {
+    await page.request.delete(`${apiBase}/api/v2/orgs/${orgId}`);
+  }
+});

--- a/apps/setup-center/src/components/Topbar.tsx
+++ b/apps/setup-center/src/components/Topbar.tsx
@@ -119,12 +119,14 @@ export function Topbar({
     <div className="topbar">
       <div className="topbarStatusRow">
         {onToggleMobileSidebar && (
-          <button className="topbarHamburger mobileOnly" onClick={onToggleMobileSidebar} aria-label="Menu">
+          <button data-slot="topbar" type="button" className="topbarHamburger mobileOnly" onClick={onToggleMobileSidebar} aria-label="Menu">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
           </button>
         )}
         {onServerManager && serverName && (
           <button
+            data-slot="topbar"
+            type="button"
             className="topbarServerBtn"
             onClick={onServerManager}
             title={t("server.switchServer", { defaultValue: "切换服务器" })}
@@ -253,26 +255,29 @@ export function Topbar({
         {serviceRunning && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <span
+              <button
+                data-slot="topbar"
+                data-testid="topbar-remote-access"
+                type="button"
+                className="topbarRemoteAccess"
+                aria-label={t("topbar.copyRemoteUrl", "复制远程访问地址")}
                 title={t("topbar.copyRemoteUrl", "复制远程访问地址")}
                 style={{
-                  cursor: "pointer", fontSize: 11, display: "inline-flex", alignItems: "center", gap: 2,
                   color: remoteCopyState === "copied" ? "var(--ok, #10b981)"
                     : remoteCopyState === "no_ip" ? "var(--warning-text, #92400e)"
                     : "var(--accent, #5B8DEF)",
                   opacity: remoteCopyState !== "idle" ? 1 : 0.7,
-                  transition: "color 0.2s",
                 }}
                 onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.opacity = "1"; }}
                 onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = remoteCopyState !== "idle" ? "1" : "0.7"; }}
               >
                 <IconClipboard size={11} />
-                <span>{
+                <span className="topbarRemoteLabel">{
                   remoteCopyState === "copied" ? t("common.copied", "已复制")
                   : remoteCopyState === "no_ip" ? t("topbar.ipNotFound")
                   : t("topbar.remoteUrl", "远程地址")
                 }</span>
-              </span>
+              </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="min-w-[180px]">
               <DropdownMenuItem onClick={copyRemoteUrl} className="gap-2 text-xs">
@@ -308,7 +313,7 @@ export function Topbar({
         )}
       </div>
       <TooltipProvider delayDuration={300}>
-        <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+        <div className="topbarActions" data-testid="topbar-actions">
           {isWeb ? (
             onLogout && (
               <Tooltip>
@@ -352,7 +357,7 @@ export function Topbar({
             </>
           )}
 
-          <div className="h-4 w-px bg-border" />
+          <div className="topbarActionDivider h-4 w-px bg-border" />
 
           {onOpenInbox && (
             <Tooltip>
@@ -376,7 +381,7 @@ export function Topbar({
             </Tooltip>
           )}
 
-          {onOpenInbox && <div className="h-4 w-px bg-border" />}
+          {onOpenInbox && <div className="topbarActionDivider h-4 w-px bg-border" />}
 
           <Tooltip>
             <TooltipTrigger asChild>
@@ -387,7 +392,7 @@ export function Topbar({
             <TooltipContent side="bottom">{t("topbar.refresh")}</TooltipContent>
           </Tooltip>
 
-          <div className="h-4 w-px bg-border" />
+          <div className="topbarActionDivider h-4 w-px bg-border" />
 
           <DropdownMenu>
             {/* span 作为 Tooltip 触发层，避免 TooltipTrigger+DropdownMenuTrigger 双层 asChild 导致悬停/ ref 失效 */}
@@ -428,7 +433,7 @@ export function Topbar({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <div className="h-4 w-px bg-border" />
+          <div className="topbarActionDivider h-4 w-px bg-border" />
 
           <DropdownMenu>
             <Tooltip>

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -196,7 +196,7 @@
     "noData": "No skill usage data"
   },
   "chat": {
-    "placeholder": "Type a message... (Enter to send, Shift+Enter for newline)",
+    "placeholder": "Type a message...",
     "send": "Send",
     "newConversation": "New Conversation",
     "selectModel": "Auto",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -196,7 +196,7 @@
     "noData": "暂无技能用量数据"
   },
   "chat": {
-    "placeholder": "输入消息... (Enter 发送, Shift+Enter 换行)",
+    "placeholder": "输入消息...",
     "send": "发送",
     "newConversation": "新对话",
     "selectModel": "自动选择",

--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -645,6 +645,36 @@ a:hover {
   gap: 14px;
   font-size: 12px;
   color: var(--muted);
+  min-width: 0;
+}
+
+.topbarActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.topbarRemoteAccess {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  flex: 0 0 auto;
+  padding: 2px 4px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  white-space: nowrap;
+  transition: color 0.2s, opacity 0.2s;
+}
+
+.topbarRemoteAccess svg {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
 }
 
 .topbarWs {
@@ -3562,7 +3592,15 @@ button.btnApplyRestart:hover {
   padding: 8px 12px 0 12px;
   display: flex;
   align-items: center;
-  gap: 0;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chatPickerGroup {
+  position: relative;
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 220px;
 }
 
 .chatModelSelect {
@@ -3580,8 +3618,12 @@ button.btnApplyRestart:hover {
 .chatModelPickerBtn {
   display: inline-flex;
   align-items: center;
+  justify-content: space-between;
   gap: 4px;
   padding: 2px 8px;
+  width: 100%;
+  height: 32px;
+  min-width: 0;
   border-radius: 6px;
   border: 1px solid var(--line);
   background: var(--panel2);
@@ -3589,10 +3631,30 @@ button.btnApplyRestart:hover {
   font-size: 12px;
   cursor: pointer;
   max-width: 220px;
+  white-space: nowrap;
   transition: background 0.15s, border-color 0.15s;
+}
+.chatModelPickerBtn > svg,
+.chatPickerValue > svg,
+.chatPickerValue > img {
+  flex: 0 0 auto;
 }
 .chatModelPickerBtn:hover { background: var(--bg-app); border-color: var(--brand); }
 .chatModelPickerLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chatPickerValue {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+.chatPickerText {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3649,6 +3711,7 @@ button.btnApplyRestart:hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 4px;
   padding: 4px 8px 8px 8px;
 }
 
@@ -3657,12 +3720,14 @@ button.btnApplyRestart:hover {
   align-items: center;
   gap: 2px;
   min-width: 0;
+  flex: 0 1 auto;
 }
 
 .chatInputToolbarRight {
   display: flex;
   align-items: center;
   gap: 4px;
+  flex: 0 0 auto;
 }
 
 .chatContextUsage {
@@ -3675,6 +3740,8 @@ button.btnApplyRestart:hover {
   border-radius: 9px;
   background: rgba(148, 163, 184, 0.09);
   transition: background 0.2s ease, border-color 0.2s ease;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 
 .chatContextUsage:hover {
@@ -3693,6 +3760,7 @@ button.btnApplyRestart:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   font-variant-numeric: tabular-nums;
+  min-width: 0;
 }
 
 .chatContextUsageText.chatContextUsageWarn {
@@ -3768,19 +3836,24 @@ button.btnApplyRestart:hover {
 
 @media (max-width: 768px) {
   .chatContextUsage {
-    gap: 6px;
-    margin-left: 4px;
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(48px, 1fr);
+    gap: 8px;
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
     padding: 2px 6px;
   }
 
   .chatContextUsageText {
-    max-width: 155px;
+    max-width: none;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .chatContextBar {
-    width: 48px;
+    width: auto;
+    min-width: 48px;
   }
 }
 
@@ -3795,7 +3868,14 @@ button.btnApplyRestart:hover {
   color: var(--muted2) !important;
   cursor: pointer;
   font-size: 12px;
+  min-height: 28px;
+  flex: 0 0 auto;
+  white-space: nowrap;
   transition: color 0.15s, background 0.15s;
+}
+
+.chatInputIconBtn > svg {
+  flex: 0 0 auto;
 }
 
 .chatInputIconBtn:hover {
@@ -5773,6 +5853,26 @@ button.btnApplyRestart:hover {
     min-width: 0;
     overflow: hidden;
   }
+  .topbarActions {
+    gap: 2px !important;
+  }
+  .topbarActionDivider {
+    display: none !important;
+  }
+  .topbarRemoteAccess {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    flex: 0 0 32px;
+  }
+  .topbarRemoteAccess svg {
+    width: 16px;
+    height: 16px;
+    flex-basis: 16px;
+  }
+  .topbarRemoteLabel {
+    display: none;
+  }
   .topbarServerBtn { max-width: 64px !important; padding: 1px 5px !important; font-size: 10px !important; }
   .topbarWs { font-size: 11px !important; padding: 1px 5px !important; max-width: 64px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .topbarEpCount { display: none !important; }
@@ -5791,14 +5891,67 @@ button.btnApplyRestart:hover {
     align-items: center;
     justify-content: center;
     border-radius: 6px;
+    width: 36px;
+    height: 36px;
+    flex: 0 0 36px;
     -webkit-tap-highlight-color: transparent;
   }
   .topbarHamburger:active { background: rgba(128,128,128,0.15); }
 
   /* chat input: larger touch target, prevent iOS zoom */
-  .chatInput { padding: 8px !important; }
   .chatInputBox textarea { font-size: 16px !important; }
   .chatInputBox { border-radius: 12px !important; }
+  .chatInputTop {
+    gap: 6px;
+    padding: 8px 8px 0;
+  }
+  .chatPickerGroup {
+    max-width: none;
+  }
+  .chatModelMenu {
+    max-width: calc(100vw - 32px);
+  }
+  .chatPickerGroupAgent .chatModelMenu {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .chatPickerGroupOrg .chatModelMenu {
+    right: 0;
+    left: auto;
+    transform: none;
+  }
+  .chatModelPickerBtn {
+    max-width: none;
+    height: 34px;
+    padding: 4px 7px;
+  }
+
+  .chatInputToolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "tools send"
+      "context context";
+    align-items: center;
+    column-gap: 6px;
+    row-gap: 4px;
+  }
+  .chatInputToolbarLeft {
+    grid-area: tools;
+    overflow: visible;
+  }
+  .chatInputToolbarRight {
+    grid-area: send;
+  }
+  .chatContextUsage {
+    grid-area: context;
+  }
+  .chatInputIconBtn {
+    padding: 5px 6px !important;
+  }
+  .chatInputTextarea {
+    max-height: min(120px, 30dvh);
+  }
 
   /* chat top bar: compact */
   .chatTopBar { padding: 6px 8px !important; gap: 4px !important; }
@@ -5890,6 +6043,29 @@ button.btnApplyRestart:hover {
     border-bottom: 1px solid var(--border, #e2e8f0);
     padding-right: 0 !important;
     padding-bottom: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .chatModeMenu {
+    left: 0;
+    transform: none;
+  }
+
+  .chatInputIconLabel {
+    display: none;
+  }
+
+  .chatInputToolbarLeft {
+    gap: 1px;
+  }
+
+  .topbarServerBtn {
+    max-width: 48px !important;
+  }
+
+  .topbarWs {
+    max-width: 58px;
   }
 }
 

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -7179,11 +7179,14 @@ export function ChatView({
 
           <div className={`chatInputBox ${chatMode === "plan" ? "chatInputBoxPlan" : chatMode === "ask" ? "chatInputBoxAsk" : ""}`}>
             {/* Top row: compact model picker */}
-            <div className="chatInputTop" ref={modelMenuRef} style={{ position: "relative" }}>
-              <button
-                className="chatModelPickerBtn"
-                onClick={() => setModelMenuOpen((v) => !v)}
-              >
+            <div className="chatInputTop" data-testid="chat-input-pickers">
+              <div className="chatPickerGroup" ref={modelMenuRef}>
+                <button
+                  data-slot="chat-picker"
+                  type="button"
+                  className="chatModelPickerBtn"
+                  onClick={() => setModelMenuOpen((v) => !v)}
+                >
                 <span className="chatModelPickerLabel">
                   {selectedEndpoint === "auto"
                     ? (() => {
@@ -7197,10 +7200,10 @@ export function ChatView({
                       })()
                     : (() => { const ep = endpoints.find(e => e.name === selectedEndpoint); return ep ? ep.model : selectedEndpoint; })()}
                 </span>
-                <IconChevronDown size={12} />
-              </button>
-              {modelMenuOpen && (
-                <div className="chatModelMenu">
+                  <IconChevronDown size={12} />
+                </button>
+                {modelMenuOpen && (
+                  <div className="chatModelMenu">
                   <div
                     className={`chatModelMenuItem ${selectedEndpoint === "auto" ? "chatModelMenuItemActive" : ""}`}
                     onClick={() => { setSelectedEndpoint("auto"); setSelectedEndpointPolicy("prefer"); setModelMenuOpen(false); }}
@@ -7250,22 +7253,24 @@ export function ChatView({
                       </button>
                     </div>
                   )}
-                </div>
-              )}
+                  </div>
+                )}
+              </div>
               {agentProfiles.length > 0 && !orgMode && (
-                <div ref={agentMenuRef} style={{ position: "relative", marginLeft: 8 }}>
+                <div ref={agentMenuRef} className="chatPickerGroup chatPickerGroupAgent">
                   <button
+                    data-slot="chat-picker"
+                    type="button"
                     className="chatModelPickerBtn"
                     onClick={() => setAgentMenuOpen((v) => !v)}
-                    style={{ gap: 4 }}
                   >
-                    <span style={{ fontSize: 13 }}>
+                    <span className="chatPickerValue">
                       {(() => {
                         const ap = agentProfiles.find(p => p.id === selectedAgent);
                         return ap ? (
-                          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                          <span className="chatPickerValue">
                             <AgentIcon icon={ap.icon} size={14} apiBaseUrl={apiBaseUrl} />
-                            <span>{ap.name}</span>
+                            <span className="chatPickerText">{ap.name}</span>
                           </span>
                         ) : t("chat.agentDefault");
                       })()}
@@ -7301,8 +7306,11 @@ export function ChatView({
               )}
               {/* Org mode selector */}
               {orgList.length > 0 && (
-                <div ref={orgMenuRef} style={{ position: "relative", marginLeft: 8 }}>
+                <div ref={orgMenuRef} className="chatPickerGroup chatPickerGroupOrg">
                   <button
+                    data-slot="chat-picker"
+                    data-testid="chat-org-trigger"
+                    type="button"
                     className="chatModelPickerBtn"
                     onClick={() => {
                       if (orgMode) {
@@ -7315,21 +7323,22 @@ export function ChatView({
                       }
                     }}
                     style={{
-                      gap: 4,
                       background: orgMode ? "rgba(14,165,233,0.15)" : undefined,
                       borderColor: orgMode ? "var(--primary)" : undefined,
                     }}
                   >
-                    <span style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+                    <span className="chatPickerValue">
                       <IconBuilding size={13} />
-                      {orgMode && selectedOrgId
-                        ? (() => { const o = orgList.find(x => x.id === selectedOrgId); return o ? o.name : "组织"; })()
-                        : "组织"}
+                      <span className="chatPickerText">
+                        {orgMode && selectedOrgId
+                          ? (() => { const o = orgList.find(x => x.id === selectedOrgId); return o ? o.name : "组织"; })()
+                          : "组织"}
+                      </span>
                     </span>
                     {orgMode ? <IconX size={10} /> : <IconChevronDown size={12} />}
                   </button>
                   {orgMenuOpen && (
-                    <div className="chatModelMenu" style={{ minWidth: 200 }}>
+                    <div className="chatModelMenu" data-testid="chat-org-menu" style={{ minWidth: 200 }}>
                       {orgList.map((o) => (
                         <div
                           key={o.id}
@@ -7380,12 +7389,14 @@ export function ChatView({
 
             {/* Textarea */}
             <textarea
+              data-slot="chat-input"
+              data-testid="chat-input-textarea"
               ref={inputRef}
               aria-label={t("chat.inputAriaLabel", "输入消息")}
               onChange={handleInputChange}
               onKeyDown={handleInputKeyDown}
               onPaste={handlePaste}
-              placeholder={orgCommandPending ? t("chat.orgProcessing", "组织正在处理中...") : orgMode ? (selectedOrgNodeId ? t("chat.orgSendToNode", "输入指令发送给 {{node}}...", { node: selectedOrgNodeId }) : t("chat.orgSendToOrg", "输入指令发送给组织...")) : isCurrentConvStreaming ? `Enter ${t("chat.queueHint")}${t("chat.commaEscStop", "，Esc 停止")}` : chatMode === "plan" ? t("chat.planModePlaceholder", { enterSend: t("chat.enterSend") }) : chatMode === "ask" ? t("chat.askModePlaceholder") : `${t("chat.placeholder")}  · ${t("chat.enterSendSlash", "Enter 发送，Shift+Enter 换行，/ 命令")}`}
+              placeholder={orgCommandPending ? t("chat.orgProcessing", "组织正在处理中...") : orgMode ? (selectedOrgNodeId ? t("chat.orgSendToNode", "输入指令发送给 {{node}}...", { node: selectedOrgNodeId }) : t("chat.orgSendToOrg", "输入指令发送给组织...")) : isCurrentConvStreaming ? `Enter ${t("chat.queueHint")}${t("chat.commaEscStop", "，Esc 停止")}` : chatMode === "plan" ? t("chat.planModePlaceholder", { enterSend: t("chat.enterSend") }) : chatMode === "ask" ? t("chat.askModePlaceholder") : t("chat.placeholder")}
               rows={1}
               className="chatInputTextarea"
               onInput={(e) => {
@@ -7396,11 +7407,11 @@ export function ChatView({
             />
 
             {/* Bottom toolbar */}
-            <div className="chatInputToolbar">
+            <div className="chatInputToolbar" data-testid="chat-input-toolbar">
               <div className="chatInputToolbarLeft">
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <button data-slot="toolbar" onClick={() => fileInputRef.current?.click()} className="chatInputIconBtn">
+                    <button data-slot="toolbar" type="button" aria-label={t("chat.attach")} onClick={() => fileInputRef.current?.click()} className="chatInputIconBtn">
                       <IconPaperclip size={16} />
                     </button>
                   </TooltipTrigger>
@@ -7410,7 +7421,7 @@ export function ChatView({
 
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <button data-slot="toolbar" onClick={toggleRecording} className={`chatInputIconBtn ${isRecording ? "chatInputIconBtnDanger" : ""}`} style={isRecording ? { animation: "pulse 1.5s ease-in-out infinite" } : undefined}>
+                    <button data-slot="toolbar" type="button" aria-label={isRecording ? t("chat.stopRecording") : t("chat.voice")} onClick={toggleRecording} className={`chatInputIconBtn ${isRecording ? "chatInputIconBtnDanger" : ""}`} style={isRecording ? { animation: "pulse 1.5s ease-in-out infinite" } : undefined}>
                       {isRecording ? <IconStopCircle size={16} /> : <IconMic size={16} />}
                       {isRecording && recordingDuration > 0 && (
                         <span style={{ fontSize: 10, marginLeft: 2, fontWeight: 600 }}>
@@ -7425,18 +7436,21 @@ export function ChatView({
                 <div ref={modeMenuRef} style={{ position: "relative", display: "inline-flex" }}>
                   <button
                     data-slot="toolbar"
+                    data-testid="chat-mode-trigger"
+                    type="button"
+                    aria-label={chatMode === "agent" ? t("chat.modeAgentTitle") : chatMode === "plan" ? t("chat.modePlanTitle") : t("chat.modeAskTitle")}
                     onClick={() => setModeMenuOpen((v) => !v)}
                     className={`chatInputIconBtn ${chatMode === "plan" ? "chatInputIconBtnPlan" : chatMode === "ask" ? "chatInputIconBtnAsk" : ""}`}
                     title={chatMode === "agent" ? t("chat.modeAgentTitle") : chatMode === "plan" ? t("chat.modePlanTitle") : t("chat.modeAskTitle")}
                   >
                     {{ agent: <IconBot size={16} />, plan: <IconPlan size={16} />, ask: <IconSearch size={16} /> }[chatMode]}
-                    <span style={{ fontSize: 11, marginLeft: 2 }}>
+                    <span className="chatInputIconLabel" style={{ fontSize: 11, marginLeft: 2 }}>
                       {chatMode === "agent" ? t("chat.modeAgent") : chatMode === "plan" ? t("chat.modePlan") : t("chat.modeAsk")}
                     </span>
                     <IconChevronDown size={10} style={{ marginLeft: 2, opacity: 0.5 }} />
                   </button>
                   {modeMenuOpen && (
-                    <div className="chatModeMenu">
+                    <div className="chatModeMenu" data-testid="chat-mode-menu">
                       <div className="chatModeMenuSection">{t("chat.executionMode")}</div>
                       {([
                         { key: "agent" as const, icon: <IconBot size={14} />, label: t("chat.modeAgent"), desc: t("chat.modeAgentDesc") },
@@ -7464,6 +7478,8 @@ export function ChatView({
                   <TooltipTrigger asChild>
                     <button
                       data-slot="toolbar"
+                      type="button"
+                      aria-label={thinkingMode === "on" ? t("chat.thinkingOn") : thinkingMode === "off" ? t("chat.thinkingOff") : t("chat.thinkingAuto")}
                       onMouseEnter={() => setThinkingModeTipOpen(true)}
                       onMouseLeave={() => setThinkingModeTipOpen(false)}
                       onClick={() => {
@@ -7478,7 +7494,7 @@ export function ChatView({
                       className={`chatInputIconBtn ${thinkingMode === "on" ? "chatInputIconBtnActive" : thinkingMode === "off" ? "chatInputIconBtnOff" : ""}`}
                     >
                       <IconZap size={16} />
-                      <span style={{ fontSize: 11, marginLeft: 2 }}>
+                      <span className="chatInputIconLabel" style={{ fontSize: 11, marginLeft: 2 }}>
                         {thinkingMode === "on" ? t("chat.thinkingBtnOn") : thinkingMode === "off" ? t("chat.thinkingBtnOff") : t("chat.thinkingBtnAuto")}
                       </span>
                     </button>
@@ -7492,6 +7508,8 @@ export function ChatView({
                     <TooltipTrigger asChild>
                       <button
                         data-slot="toolbar"
+                        type="button"
+                        aria-label={{ low: t("chat.depthTipLow"), medium: t("chat.depthTipMedium"), high: t("chat.depthTipHigh"), max: t("chat.depthTipMax") }[thinkingDepth]}
                         onMouseEnter={() => setThinkingDepthTipOpen(true)}
                         onMouseLeave={() => setThinkingDepthTipOpen(false)}
                         onClick={() => {
@@ -7505,7 +7523,7 @@ export function ChatView({
                           <rect x="10" y="2" width="3" height="11" rx="0.5" fill="currentColor" opacity={thinkingDepth === "high" || thinkingDepth === "max" ? 1 : 0.25} />
                           <rect x="14.5" y="0.5" width="2.5" height="12.5" rx="0.5" fill="currentColor" opacity={thinkingDepth === "max" ? 1 : 0.25} />
                         </svg>
-                        <span style={{ fontSize: 10 }}>{{ low: t("chat.depthLow"), medium: t("chat.depthMedium"), high: t("chat.depthHigh"), max: t("chat.depthMax") }[thinkingDepth]}</span>
+                        <span className="chatInputIconLabel" style={{ fontSize: 10 }}>{{ low: t("chat.depthLow"), medium: t("chat.depthMedium"), high: t("chat.depthHigh"), max: t("chat.depthMax") }[thinkingDepth]}</span>
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-xs" onPointerDownOutside={(e) => e.preventDefault()}>
@@ -7514,14 +7532,16 @@ export function ChatView({
                     </TooltipContent>
                   </Tooltip>
                 )}
-                {/* Context usage bar */}
-                {contextLimit > 0 && (() => {
+              </div>
+
+              {/* Context usage bar */}
+              {contextLimit > 0 && (() => {
                   const usagePercent = Math.min((contextTokens / contextLimit) * 100, 100);
                   const remaining = Math.max(0, contextLimit - contextTokens);
                   const toneClass = usagePercent > 80 ? "chatContextUsageDanger" : usagePercent > 60 ? "chatContextUsageWarn" : "";
                   const fillClass = usagePercent > 80 ? "chatContextBarFillDanger" : usagePercent > 60 ? "chatContextBarFillWarn" : "";
                   return (
-                    <div className="chatContextUsage">
+                    <div className="chatContextUsage" data-testid="chat-context-usage">
                       <span className={`chatContextUsageText ${toneClass}`}>
                         {formatContextTokens(contextTokens)} /
                         <Tooltip>
@@ -7547,14 +7567,15 @@ export function ChatView({
                       </div>
                     </div>
                   );
-                })()}
-              </div>
+              })()}
 
               <div className="chatInputToolbarRight">
                 {isCurrentConvStreaming || orgCommandPending ? (
                   (hasInputText || pendingAttachments.length > 0) && !orgCommandPending ? (
                     <button
                       data-slot="steer"
+                      type="button"
+                      aria-label={t("chat.steerHint", "注入到当前任务")}
                       onClick={() => submitWhileStreaming()}
                       className="chatInputSendBtn"
                       title={t("chat.steerHint", "注入到当前任务（不打断，回车发送 / Ctrl+Enter 排队）")}
@@ -7564,6 +7585,8 @@ export function ChatView({
                   ) : (
                     <button
                       data-slot="stop"
+                      type="button"
+                      aria-label={orgCommandPending ? "停止组织命令" : t("chat.stopGeneration")}
                       onClick={handleCancelTask}
                       className="chatInputSendBtn chatInputStopBtn"
                       title={orgCommandPending ? "停止组织命令" : t("chat.stopGeneration")}
@@ -7574,6 +7597,7 @@ export function ChatView({
                 ) : (
                   <button
                     data-slot="send"
+                    type="button"
                     onClick={() => sendMessage()}
                     className="chatInputSendBtn"
                     disabled={!hasInputText && pendingAttachments.length === 0}


### PR DESCRIPTION
## Summary

- keep the mobile chat composer placeholder, picker controls, icons, and context usage within the viewport
- anchor execution-mode and organization menus so they remain visible and fully on-screen on narrow devices

## Tests

- `npx tsc -b --pretty false`
- `npm run test:run` (55 passed)
- `npx playwright test e2e/mobile-chat-layout.spec.ts --grep "organization menu"`
- `npm run build:cap`
- `npm run build:web`

Fixes #729
