### PR TITLE
Show IM adapter startup errors in the status view

### DIFF
--- a/apps/setup-center/src/views/StatusView.tsx
+++ b/apps/setup-center/src/views/StatusView.tsx
@@ -763,6 +763,7 @@ export function StatusView(props: StatusViewProps) {
             const ih = imHealth[channelId];
             const isOnline = ih && (ih.status === "healthy" || ih.status === "online");
             const isConfigured = ih && ih.status === "configured";
+            const channelError = ih?.error?.trim() || "";
             const effectiveEnabled = ih ? true : c.enabled;
             const serviceRunning = serviceStatus?.running;
             const dot = !effectiveEnabled
@@ -786,8 +787,24 @@ export function StatusView(props: StatusViewProps) {
                 <span className="inline-flex h-4 w-4 items-center justify-center">
                   {LogoComp && <span style={{ display: "inline-flex", flexShrink: 0 }}><LogoComp size={16} /></span>}
                 </span>
-                <span style={{ fontWeight: 600, fontSize: 13, minWidth: 0 }}>{c.name}</span>
-                <span className="imStatusLabel text-right">{label}</span>
+                <span className="min-w-0">
+                  <span className="block truncate text-[13px] font-semibold">{c.name}</span>
+                  {channelError && (
+                    <button
+                      type="button"
+                      className="block max-w-full cursor-copy truncate text-left text-[10px] font-normal text-destructive"
+                      title={`${t("status.clickToCopy", "点击复制")}: ${channelError}`}
+                      aria-label={`${c.name}: ${channelError}`}
+                      onClick={async () => {
+                        const ok = await copyToClipboard(channelError);
+                        if (ok) notifySuccess(t("version.copied"));
+                      }}
+                    >
+                      {channelError}
+                    </button>
+                  )}
+                </span>
+                <span className="imStatusLabel text-right" title={channelError || undefined}>{label}</span>
               </div>
             );
           })}

--- a/tests/api/test_im_channel_status_error.py
+++ b/tests/api/test_im_channel_status_error.py
@@ -1,0 +1,60 @@
+"""Contracts for IM adapter startup errors exposed to Setup Center."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from openakita.api.routes.im import router
+
+
+@pytest.mark.asyncio
+async def test_channel_list_exposes_startup_error_only_while_offline(monkeypatch):
+    monkeypatch.setattr(
+        "openakita.agents.profile.get_profile_store",
+        lambda: SimpleNamespace(list_all=lambda: []),
+    )
+
+    adapter = SimpleNamespace(
+        channel_type="feishu",
+        bot_id="feishu-test",
+        display_name="Test Feishu",
+        agent_profile_id="default",
+        is_running=False,
+        _running=False,
+    )
+    gateway = SimpleNamespace(
+        _adapters={"feishu:feishu-test": adapter},
+        _failed_adapter_reasons={
+            "feishu:feishu-test": "module 'lark_oapi' has no attribute 'LogLevel'"
+        },
+        adapters=[],
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.gateway = gateway
+    app.state.session_manager = None
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/im/channels")
+        assert response.status_code == 200
+        channel = next(
+            item for item in response.json()["channels"] if item["channel"] == "feishu:feishu-test"
+        )
+        assert channel["status"] == "offline"
+        assert "lark_oapi" in channel["error"]
+        assert "LogLevel" in channel["error"]
+
+        adapter.is_running = True
+        adapter._running = True
+        response = await client.get("/api/im/channels")
+        channel = next(
+            item for item in response.json()["channels"] if item["channel"] == "feishu:feishu-test"
+        )
+        assert channel["status"] == "online"
+        assert "error" not in channel


### PR DESCRIPTION
## Summary

- Show IM adapter startup errors directly in the status view.
- Allow users to inspect and copy the complete channel error.
- Cover offline error reporting and online recovery with an API contract test.

## Tests

- `uv run --no-sync pytest tests/api/test_im_channel_status_error.py -q`
- `uv run --no-sync ruff check tests/api/test_im_channel_status_error.py`
- `npx tsc --noEmit`
- `npm run build:web`

Fixes #571
