### PR TITLE
Remove Beta labels from stable sidebar entries

### DIFF
--- a/apps/setup-center/src/components/Sidebar.tsx
+++ b/apps/setup-center/src/components/Sidebar.tsx
@@ -259,17 +259,17 @@ export function Sidebar({
             )}
             {!disabledViews.includes("mcp") && (
               <div className={`navItem ${view === "mcp" ? "navItemActive" : ""}`} onClick={() => onViewChange("mcp")} role="button" tabIndex={0} title="MCP">
-                <IconPlug size={16} /> {!collapsed && <span>MCP {BETA_SUP}</span>}
+                <IconPlug size={16} /> {!collapsed && <span>MCP</span>}
               </div>
             )}
             <div className={`navItem ${view === "plugins" ? "navItemActive" : ""}`} onClick={() => onViewChange("plugins")} role="button" tabIndex={0} title={t("sidebar.plugins")}>
               <IconPuzzle size={16} /> {!collapsed && <span>{t("sidebar.plugins")} {BETA_SUP}</span>}
             </div>
             <div className={`navItem ${view === "memory" ? "navItemActive" : ""}`} onClick={() => onViewChange("memory")} role="button" tabIndex={0} title={t("sidebar.memory")} style={disabledViews.includes("memory") ? { opacity: 0.4 } : undefined}>
-              <IconBrain size={16} /> {!collapsed && <span>{t("sidebar.memory")} {BETA_SUP}</span>}
+              <IconBrain size={16} /> {!collapsed && <span>{t("sidebar.memory")}</span>}
             </div>
             <div className={`navItem ${view === "scheduler" ? "navItemActive" : ""}`} onClick={() => onViewChange("scheduler")} role="button" tabIndex={0} title={t("sidebar.scheduler")} style={disabledViews.includes("scheduler") ? { opacity: 0.4 } : undefined}>
-              <IconCalendar size={16} /> {!collapsed && <span>{t("sidebar.scheduler")} {BETA_SUP}</span>}
+              <IconCalendar size={16} /> {!collapsed && <span>{t("sidebar.scheduler")}</span>}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- Remove the Beta labels from the MCP, memory, and scheduler entries in the sidebar while preserving the plugin Beta label.

## Tests

- `npm exec eslint src/components/Sidebar.tsx -- --max-warnings=9999` (passes with one pre-existing `react-hooks/exhaustive-deps` warning)
