### PR TITLE
Fix Docker publishing after the Hatch build metadata change

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,8 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
+          build-args: |
+            OPENAKITA_BUILD_GIT_HASH=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml README.md VERSION hatch_build.py ./
+COPY scripts/write_build_version.py scripts/write_build_version.py
 COPY src/ src/
 COPY skills/ skills/
 COPY mcps/ mcps/
@@ -35,6 +36,7 @@ RUN mkdir -p docs-site/.vitepress/dist
 #     docker build --build-arg INSTALL_FINANCE_AUTO=1 -t openakita:fa .
 # Docs: plugins/finance-auto/docs/DEPLOY_DOCKER.md §3.
 ARG INSTALL_FINANCE_AUTO=0
+ARG OPENAKITA_BUILD_GIT_HASH=dev
 
 RUN if [ "$INSTALL_FINANCE_AUTO" = "1" ]; then \
         pip install --no-cache-dir ".[finance-auto]"; \

--- a/tests/integration/test_docker_build_contract.py
+++ b/tests/integration/test_docker_build_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docker_builder_copies_hatch_build_inputs_before_install() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    install_offset = dockerfile.index("pip install --no-cache-dir")
+    builder_setup = dockerfile[:install_offset]
+
+    assert "COPY pyproject.toml README.md VERSION hatch_build.py ./" in builder_setup
+    assert (
+        "COPY scripts/write_build_version.py scripts/write_build_version.py" in builder_setup
+    )
+    assert "ARG OPENAKITA_BUILD_GIT_HASH=dev" in builder_setup
+
+
+def test_docker_publish_passes_the_checked_out_commit_hash() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "docker-publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "OPENAKITA_BUILD_GIT_HASH=${{ github.sha }}" in workflow


### PR DESCRIPTION
## Summary

- Copy the Hatch build hook, version source, and build-version helper into the Docker builder before installing OpenAkita.
- Pass the checked-out GitHub commit SHA into the image build so packaged version metadata identifies the published source commit.
- Add integration coverage for the Docker build inputs and workflow build argument.

## Tests

- `uv run --no-sync pytest tests/integration/test_docker_build_contract.py -q` (`2 passed`)
- `uv run --no-sync ruff check tests/integration/test_docker_build_contract.py`
- `docker build --target builder --build-arg OPENAKITA_BUILD_GIT_HASH=248e38b681c2e9eaa952af68b840a1eeb25e6739 -t openakita-docker-build-contract-test .`
- Verified the builder image contains bundled version `1.27.26+248e38b`.
