### PR TITLE
make desktop runtime startup failures repairable and diagnosable

### DIFF
--- a/apps/setup-center/src-tauri/src/main.rs
+++ b/apps/setup-center/src-tauri/src/main.rs
@@ -15,11 +15,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::Instant;
+use std::thread;
+use std::time::{Duration, Instant};
 use tauri::Emitter;
 use tauri::Manager;
 #[cfg(desktop)]
@@ -47,6 +49,8 @@ static AUTO_START_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static AUTO_START_STARTED_AT_MS: AtomicU64 = AtomicU64::new(0);
 static DESKTOP_SESSION_TOKEN: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
 const AUTO_START_TIMEOUT_MS: u64 = 180_000;
+const RUNTIME_SETUP_TIMEOUT: Duration = Duration::from_secs(180);
+const RUNTIME_PROXY_PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// 后端启动宽限期（秒）。Backend cold-start 在 dual-venv hack 下：
 ///   * Python 解释器 import 整个生态 ≈ 30s
@@ -1415,6 +1419,7 @@ fn apply_runtime_env_builder(
 
 fn apply_runtime_bootstrap_env(cmd: &mut Command, pip_index: Option<&RuntimePipIndex>) {
     apply_runtime_env_builder(cmd, RuntimeEnvPurpose::Bootstrap, pip_index);
+    bypass_unreachable_runtime_proxies(cmd);
 
     // 仅在 bootstrap 路径上钉死 uv 的 Python 发现策略。Core / Agent 子进程
     // 已经直接通过 venv 内 python 调用，不走 uv 解释器解析。
@@ -1437,6 +1442,70 @@ fn apply_runtime_bootstrap_env(cmd: &mut Command, pip_index: Option<&RuntimePipI
     cmd.env("UV_CACHE_DIR", runtime_uv_cache_dir());
 }
 
+fn runtime_proxy_endpoint(value: &str) -> Option<(String, u16)> {
+    let parsed = reqwest::Url::parse(value).ok()?;
+    let host = parsed.host_str()?.to_string();
+    let port = parsed.port_or_known_default().or_else(|| match parsed.scheme() {
+        "socks" | "socks4" | "socks5" | "socks5h" => Some(1080),
+        _ => None,
+    })?;
+    Some((host, port))
+}
+
+fn proxy_endpoint_is_reachable(host: &str, port: u16) -> bool {
+    let Ok(addresses) = (host, port).to_socket_addrs() else {
+        return false;
+    };
+    addresses
+        .take(4)
+        .any(|address| TcpStream::connect_timeout(&address, RUNTIME_PROXY_PROBE_TIMEOUT).is_ok())
+}
+
+/// uv and pip honor proxy environment variables, but a stale local proxy can
+/// turn every package operation into a long retry cascade. Only remove proxy
+/// variables from this child command after the configured endpoint has been
+/// positively identified as unreachable; the desktop process environment is
+/// left untouched.
+fn bypass_unreachable_runtime_proxies(cmd: &mut Command) {
+    let proxy_keys = [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ];
+    let mut reachability: HashMap<String, bool> = HashMap::new();
+
+    for key in proxy_keys {
+        let Ok(value) = std::env::var(key) else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        let Some((host, port)) = runtime_proxy_endpoint(value) else {
+            log_to_file(&format!(
+                "[runtime] proxy preflight skipped malformed {} value",
+                key
+            ));
+            continue;
+        };
+        let endpoint = format!("{}:{}", host, port);
+        let reachable = *reachability
+            .entry(endpoint.clone())
+            .or_insert_with(|| proxy_endpoint_is_reachable(&host, port));
+        if !reachable {
+            cmd.env_remove(key);
+            log_to_file(&format!(
+                "[runtime] proxy preflight: {} endpoint {} is unreachable; bypassing it for runtime setup",
+                key, endpoint
+            ));
+        }
+    }
+}
+
 fn apply_runtime_core_env(cmd: &mut Command) {
     apply_runtime_env_builder(cmd, RuntimeEnvPurpose::Core, None);
     prepend_path(cmd, &runtime_venv_bin_dir(&agent_venv_dir()));
@@ -1456,26 +1525,78 @@ fn apply_runtime_core_env(cmd: &mut Command) {
     }
 }
 
-fn run_and_log(mut cmd: Command, log_path: &Path) -> Result<(), String> {
-    let output = cmd
-        .output()
-        .map_err(|e| format!("run command failed: {e}"))?;
+fn run_and_log(mut cmd: Command, log_path: &Path, deadline: Instant) -> Result<(), String> {
+    let command_debug = format!("{:?}", cmd);
+    if Instant::now() >= deadline {
+        return Err(format!(
+            "RUNTIME_INSTALL_TIMEOUT|runtime setup exceeded {} seconds before running {}",
+            RUNTIME_SETUP_TIMEOUT.as_secs(),
+            command_debug
+        ));
+    }
     let mut log = OpenOptions::new()
         .create(true)
         .append(true)
         .open(log_path)
         .map_err(|e| format!("open runtime log {} failed: {e}", log_path.display()))?;
-    let _ = writeln!(log, "\n$ {:?}", cmd);
-    let _ = log.write_all(&output.stdout);
-    let _ = log.write_all(&output.stderr);
-    if output.status.success() {
+    let _ = writeln!(log, "\n$ {}", command_debug);
+    let stdout_log = log
+        .try_clone()
+        .map_err(|e| format!("clone runtime stdout log failed: {e}"))?;
+    let stderr_log = log
+        .try_clone()
+        .map_err(|e| format!("clone runtime stderr log failed: {e}"))?;
+    cmd.stdout(Stdio::from(stdout_log));
+    cmd.stderr(Stdio::from(stderr_log));
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("run command failed: {e}"))?;
+
+    let mut timed_out = false;
+    let mut wait_error = None;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(100)),
+            Ok(None) => {
+                timed_out = true;
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            Err(e) => {
+                wait_error = Some(e);
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+
+    if let Some(error) = wait_error {
+        Err(format!("wait for command failed: {error}"))
+    } else if timed_out {
+        let detail = format!(
+            "RUNTIME_INSTALL_TIMEOUT|runtime setup exceeded {} seconds while running {}",
+            RUNTIME_SETUP_TIMEOUT.as_secs(),
+            command_debug
+        );
+        let _ = writeln!(log, "\n{}", detail);
+        Err(detail)
+    } else if status.is_some_and(|status| status.success()) {
         Ok(())
     } else {
-        Err(format!("command failed with status {}", output.status))
+        Err(format!(
+            "command failed with status {}",
+            status
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        ))
     }
 }
 
-fn health_check_python(py: &Path, code: &str, log_path: &Path) -> bool {
+fn health_check_python(py: &Path, code: &str, log_path: &Path, deadline: Instant) -> bool {
     if !py.exists() {
         return false;
     }
@@ -1483,23 +1604,7 @@ fn health_check_python(py: &Path, code: &str, log_path: &Path) -> bool {
     cmd.args(["-c", code]);
     apply_runtime_bootstrap_env(&mut cmd, None);
     apply_no_window(&mut cmd);
-    match cmd.output() {
-        Ok(output) if output.status.success() => true,
-        Ok(output) => {
-            let mut log = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(log_path)
-                .ok();
-            if let Some(ref mut log) = log {
-                let _ = writeln!(log, "health check failed for {}", py.display());
-                let _ = log.write_all(&output.stdout);
-                let _ = log.write_all(&output.stderr);
-            }
-            false
-        }
-        Err(_) => false,
-    }
+    run_and_log(cmd, log_path, deadline).is_ok()
 }
 
 fn quarantine_runtime_uv_cache(report: &mut String) {
@@ -1679,7 +1784,12 @@ fn pyvenv_cfg_home_is_disallowed(venv_dir: &Path) -> Option<String> {
 /// 额外地：直接拒绝 `pyvenv.cfg::home` 指向 Anaconda/pyenv/Homebrew 等
 /// 受污染发行版的 venv（v1.27.10 启动失败的根因）。共享 `BAD_BASE_PYTHON_MARKERS`
 /// 让 Rust 与 Python 两侧的判定逻辑严格对齐。
-fn venv_is_real_isolated(venv_dir: &Path, py: &Path, log_path: &Path) -> bool {
+fn venv_is_real_isolated(
+    venv_dir: &Path,
+    py: &Path,
+    log_path: &Path,
+    deadline: Instant,
+) -> bool {
     if !py.exists() {
         return false;
     }
@@ -1705,6 +1815,7 @@ fn venv_is_real_isolated(venv_dir: &Path, py: &Path, log_path: &Path) -> bool {
         py,
         "import sys, pip; assert sys.prefix != sys.base_prefix, 'venv launcher fell back to base interpreter'",
         log_path,
+        deadline,
     )
 }
 
@@ -1845,9 +1956,14 @@ print(json.dumps(report, ensure_ascii=False, indent=2))
     )
 }
 
-fn ensure_venv(venv_dir: &Path, python_version: &str, log_path: &Path) -> Result<PathBuf, String> {
+fn ensure_venv(
+    venv_dir: &Path,
+    python_version: &str,
+    log_path: &Path,
+    deadline: Instant,
+) -> Result<PathBuf, String> {
     let py = runtime_venv_python_path(venv_dir);
-    if venv_is_real_isolated(venv_dir, &py, log_path) {
+    if venv_is_real_isolated(venv_dir, &py, log_path, deadline) {
         return Ok(py);
     }
 
@@ -1911,8 +2027,8 @@ fn ensure_venv(venv_dir: &Path, python_version: &str, log_path: &Path) -> Result
     cmd.arg(venv_dir);
     apply_runtime_bootstrap_env(&mut cmd, None);
     apply_no_window(&mut cmd);
-    run_and_log(cmd, log_path)?;
-    if venv_is_real_isolated(venv_dir, &py, log_path) {
+    run_and_log(cmd, log_path, deadline)?;
+    if venv_is_real_isolated(venv_dir, &py, log_path, deadline) {
         Ok(py)
     } else {
         let has_cfg = venv_dir.join("pyvenv.cfg").exists();
@@ -1928,6 +2044,7 @@ fn ensure_venv(venv_dir: &Path, python_version: &str, log_path: &Path) -> Result
 fn ensure_app_venv(
     bootstrap: &BootstrapManifest,
     pip_index: &RuntimePipIndex,
+    deadline: Instant,
 ) -> Result<PathBuf, String> {
     let started = Instant::now();
     let log_path = runtime_logs_dir().join("app-venv.log");
@@ -1937,7 +2054,14 @@ fn ensure_app_venv(
         .as_ref()
         .map(|m| runtime_manifest_mismatch(m, bootstrap, pip_index).is_none())
         .unwrap_or(false);
-    if manifest_ok && health_check_python(&app_py, &app_runtime_health_code(&app_venv_dir()), &log_path) {
+    if manifest_ok
+        && health_check_python(
+            &app_py,
+            &app_runtime_health_code(&app_venv_dir()),
+            &log_path,
+            deadline,
+        )
+    {
         log_to_file(&format!(
             "[runtime] ensure_app_venv reused existing env in {}ms",
             started.elapsed().as_millis()
@@ -1955,7 +2079,12 @@ fn ensure_app_venv(
     } else {
         log_to_file("[runtime] ensure_app_venv rebuilding app runtime: missing manifest");
     }
-    let app_py = ensure_venv(&app_venv_dir(), &bootstrap.python_version, &log_path)?;
+    let app_py = ensure_venv(
+        &app_venv_dir(),
+        &bootstrap.python_version,
+        &log_path,
+        deadline,
+    )?;
     let wheel_path = bootstrap_resource_dir().join(&bootstrap.wheel.name);
     if !wheel_path.exists() {
         return Err(format!(
@@ -2008,12 +2137,17 @@ fn ensure_app_venv(
     apply_runtime_bootstrap_env(&mut cmd, Some(pip_index));
     apply_no_window(&mut cmd);
     let install_started = Instant::now();
-    run_and_log(cmd, &log_path)?;
+    run_and_log(cmd, &log_path, deadline)?;
     log_to_file(&format!(
         "[runtime] app wheel install finished in {}ms",
         install_started.elapsed().as_millis()
     ));
-    if health_check_python(&app_py, &app_runtime_health_code(&app_venv_dir()), &log_path) {
+    if health_check_python(
+        &app_py,
+        &app_runtime_health_code(&app_venv_dir()),
+        &log_path,
+        deadline,
+    ) {
         log_to_file(&format!(
             "[runtime] ensure_app_venv ready in {}ms",
             started.elapsed().as_millis()
@@ -2047,10 +2181,16 @@ fn ensure_app_venv(
 fn ensure_agent_venv(
     bootstrap: &BootstrapManifest,
     _pip_index: &RuntimePipIndex,
+    deadline: Instant,
 ) -> Result<PathBuf, String> {
     let started = Instant::now();
     let log_path = runtime_logs_dir().join("agent-venv.log");
-    let result = ensure_venv(&agent_venv_dir(), &bootstrap.python_version, &log_path);
+    let result = ensure_venv(
+        &agent_venv_dir(),
+        &bootstrap.python_version,
+        &log_path,
+        deadline,
+    );
     log_to_file(&format!(
         "[runtime] ensure_agent_venv finished in {}ms status={}",
         started.elapsed().as_millis(),
@@ -2169,6 +2309,7 @@ fn write_runtime_failure_manifest(error: &str) {
 
 fn ensure_dual_runtime_env() -> Result<RuntimeEnvInfo, String> {
     let started = Instant::now();
+    let deadline = started + RUNTIME_SETUP_TIMEOUT;
     log_to_file("[runtime] phase=prepare-runtime-layout");
     ensure_runtime_layout()?;
     let bootstrap = read_bootstrap_manifest()?;
@@ -2179,9 +2320,9 @@ fn ensure_dual_runtime_env() -> Result<RuntimeEnvInfo, String> {
         app_runtime_extras(),
         pip_index.url
     ));
-    let app_python = ensure_app_venv(&bootstrap, &pip_index)?;
+    let app_python = ensure_app_venv(&bootstrap, &pip_index, deadline)?;
     log_to_file("[runtime] phase=ensure-agent-venv");
-    let agent_python = ensure_agent_venv(&bootstrap, &pip_index)?;
+    let agent_python = ensure_agent_venv(&bootstrap, &pip_index, deadline)?;
     let info = RuntimeEnvInfo {
         app_python,
         agent_python,
@@ -9547,6 +9688,12 @@ fn export_diagnostic_bundle(
         "global_logs/crash.log",
         options,
     )?;
+    add_file_to_zip(
+        &mut zip_writer,
+        &global_logs.join("autostart.log"),
+        "global_logs/autostart.log",
+        options,
+    )?;
     for entry in fs::read_dir(&global_logs).into_iter().flatten().flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -10010,6 +10157,27 @@ fn build_feedback_zip(
             );
         }
     }
+
+    zip_add_file(
+        &mut zw,
+        &runtime_manifest_path(),
+        "runtime/manifest.json",
+        opts,
+    );
+    zip_add_dir_capped(
+        &mut zw,
+        &runtime_logs_dir(),
+        "runtime/logs",
+        opts,
+        5 * 1024 * 1024,
+    );
+    zip_add_dir_capped(
+        &mut zw,
+        &runtime_root_dir().join("reports"),
+        "runtime/reports",
+        opts,
+        5 * 1024 * 1024,
+    );
 
     // ── Native crash dumps ──
     // Our SetUnhandledExceptionFilter-based crash handler writes
@@ -11150,6 +11318,63 @@ mod tests {
         assert!(should_cleanup_stale_heartbeat(Some(true), false));
         assert!(!should_cleanup_stale_heartbeat(Some(false), false));
         assert!(!should_cleanup_stale_heartbeat(None, false));
+    }
+
+    #[test]
+    fn test_runtime_proxy_endpoint_parses_http_and_socks_defaults() {
+        assert_eq!(
+            runtime_proxy_endpoint("http://127.0.0.1:9001"),
+            Some(("127.0.0.1".to_string(), 9001))
+        );
+        assert_eq!(
+            runtime_proxy_endpoint("https://proxy.example.test"),
+            Some(("proxy.example.test".to_string(), 443))
+        );
+        assert_eq!(
+            runtime_proxy_endpoint("socks5://localhost"),
+            Some(("localhost".to_string(), 1080))
+        );
+    }
+
+    #[test]
+    fn test_runtime_proxy_endpoint_rejects_malformed_values() {
+        assert_eq!(runtime_proxy_endpoint("127.0.0.1:9001"), None);
+        assert_eq!(runtime_proxy_endpoint("http://"), None);
+    }
+
+    #[test]
+    fn test_runtime_command_timeout_terminates_the_child() {
+        let command = if cfg!(windows) {
+            let mut command = Command::new("ping");
+            command.args(["-n", "30", "127.0.0.1"]);
+            command
+        } else {
+            let mut command = Command::new("sleep");
+            command.arg("30");
+            command
+        };
+        let log_path = std::env::temp_dir().join(format!(
+            "openakita-runtime-timeout-test-{}-{}.log",
+            std::process::id(),
+            now_ms()
+        ));
+        let started = Instant::now();
+
+        let result = run_and_log(
+            command,
+            &log_path,
+            started + Duration::from_millis(200),
+        );
+
+        assert!(
+            result
+                .as_ref()
+                .is_err_and(|error| error.starts_with("RUNTIME_INSTALL_TIMEOUT|")),
+            "unexpected timeout result: {:?}",
+            result
+        );
+        assert!(started.elapsed() < Duration::from_secs(3));
+        let _ = fs::remove_file(log_path);
     }
 
     #[test]

--- a/apps/setup-center/src/App.tsx
+++ b/apps/setup-center/src/App.tsx
@@ -2947,6 +2947,21 @@ function MainApp() {
     }
   }
 
+  async function repairRuntimeAndRestart() {
+    if (!currentWorkspaceId) return;
+    const repairToast = notifyLoading(t("status.runtimeRepairing"));
+    try {
+      try { await doStopService(currentWorkspaceId); } catch { /* best effort */ }
+      const report = await invoke<string>("repair_runtime_env");
+      notifySuccess(report.split("\n").slice(0, 3).join("\n"));
+      await doStartLocalService(currentWorkspaceId);
+    } catch (e) {
+      notifyError(t("status.runtimeRepairFailed", { err: String(e) }));
+    } finally {
+      dismissLoading(repairToast);
+    }
+  }
+
   /**
    * 连接到已有本地服务（冲突对话框的"连接已有"选项）。
    */
@@ -3190,6 +3205,7 @@ function MainApp() {
           doStopService={doStopService}
           restartService={restartService}
           onOpenRuntimeEnvironment={() => setRuntimeDialogOpen(true)}
+          onRepairRuntime={repairRuntimeAndRestart}
           setView={navigateToView}
         />
       </div>
@@ -5271,8 +5287,8 @@ function MainApp() {
           busy={busy}
           currentWorkspaceId={currentWorkspaceId}
           refreshRuntimeDiagnostics={refreshRuntimeDiagnostics}
-          doStopService={doStopService}
           doStartLocalService={doStartLocalService}
+          onRepairRuntime={repairRuntimeAndRestart}
         />
         <Toaster position="top-right" richColors closeButton />
 

--- a/apps/setup-center/src/components/RuntimeEnvironmentPanel.tsx
+++ b/apps/setup-center/src/components/RuntimeEnvironmentPanel.tsx
@@ -4,9 +4,7 @@ import { Activity, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { invoke } from "../platform";
 import { joinPath } from "../utils";
-import { dismissLoading, notifyError, notifyLoading, notifySuccess } from "../utils/notify";
 import type { PlatformInfo } from "../types";
 
 type ToolProbe = { available?: boolean; path?: string; version?: string };
@@ -66,8 +64,8 @@ export type RuntimeEnvironmentPanelProps = {
   busy: string | null;
   currentWorkspaceId: string | null;
   refreshRuntimeDiagnostics: () => Promise<void>;
-  doStopService: (wsId?: string | null) => Promise<void>;
   doStartLocalService: (wsId: string) => Promise<void>;
+  onRepairRuntime: () => Promise<void>;
 };
 
 export function RuntimeEnvironmentPanel({
@@ -83,8 +81,8 @@ export function RuntimeEnvironmentPanel({
   busy,
   currentWorkspaceId,
   refreshRuntimeDiagnostics,
-  doStopService,
   doStartLocalService,
+  onRepairRuntime,
 }: RuntimeEnvironmentPanelProps) {
   const { t } = useTranslation();
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -141,21 +139,6 @@ export function RuntimeEnvironmentPanel({
     ...(nodeInfo?.workspace_cache ? [[t("status.workspaceCache"), nodeInfo.workspace_cache]] : []),
   ];
 
-  const onRepair = async () => {
-    if (!currentWorkspaceId) return;
-    const _b = notifyLoading(t("status.runtimeRepairing"));
-    try {
-      try { await doStopService(currentWorkspaceId); } catch { /* ignore */ }
-      const report = await invoke<string>("repair_runtime_env");
-      notifySuccess(report.split("\n").slice(0, 3).join("\n"));
-      await doStartLocalService(currentWorkspaceId);
-    } catch (e) {
-      notifyError(t("status.runtimeRepairFailed", { err: String(e) }));
-    } finally {
-      dismissLoading(_b);
-    }
-  };
-
   return (
     <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -195,7 +178,7 @@ export function RuntimeEnvironmentPanel({
             size="sm"
             variant="destructive"
             disabled={!!busy || !currentWorkspaceId}
-            onClick={onRepair}
+            onClick={() => void onRepairRuntime()}
             title={t("status.runtimeRepairHint")}
           >
             {t("status.runtimeRepairTitle")}

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -728,6 +728,7 @@
     "runtimePermissionDeniedFallbackToParent": "Directory does not exist yet; opened nearest existing ancestor: {{path}}",
     "runtimeRepairTitle": "Repair Runtime",
     "runtimeRepairHint": "Wipe stale venv & manifest and rebuild the runtime from scratch (use this when venv is corrupted causing repeated unresponsiveness).",
+    "runtimeEnvironmentTitle": "View Runtime",
     "runtimeRepairing": "Rebuilding runtime…",
     "runtimeRepairFailed": "Repair failed: {{err}}",
     "memoryDegradedTitle": "Memory database unavailable",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -728,6 +728,7 @@
     "runtimePermissionDeniedFallbackToParent": "目录尚未创建，已打开最近一级存在的目录：{{path}}",
     "runtimeRepairTitle": "修复运行时",
     "runtimeRepairHint": "删除残骸 venv 与 manifest 后从零重建运行时（用于解决 venv 损坏导致的反复无响应）",
+    "runtimeEnvironmentTitle": "查看运行环境",
     "runtimeRepairing": "正在重建运行环境…",
     "runtimeRepairFailed": "修复失败：{{err}}",
     "memoryDegradedTitle": "记忆数据库不可用",

--- a/apps/setup-center/src/views/StatusView.tsx
+++ b/apps/setup-center/src/views/StatusView.tsx
@@ -91,6 +91,7 @@ export interface StatusViewProps {
   doStopService: (wsId?: string | null) => Promise<void>;
   restartService: () => Promise<void>;
   onOpenRuntimeEnvironment: () => void;
+  onRepairRuntime: () => Promise<void>;
   setView: (view: ViewId) => void;
 }
 
@@ -108,12 +109,13 @@ export function StatusView(props: StatusViewProps) {
     shouldUseHttpApi, httpApiBase,
     startLocalServiceWithConflictCheck, refreshStatus,
     doStopService, restartService,
-    onOpenRuntimeEnvironment,
+    onOpenRuntimeEnvironment, onRepairRuntime,
     setView,
   } = props;
 
   const [healthChecking, setHealthChecking] = useState<string | null>(null);
   const [imChecking, setImChecking] = useState(false);
+  const [repairingRuntime, setRepairingRuntime] = useState(false);
   // Structured runtime error surface (e.g. RUNTIME_PERMISSION_DENIED|...)
   // —— Rust 端 `ensure_runtime_layout` 等核心 IO 失败时会把带前缀的错误写到
   // runtime manifest.last_error，本组件读出后渲染指引 banner，让企业 AD /
@@ -389,14 +391,36 @@ export function StatusView(props: StatusViewProps) {
               ? <><Loader2 className="animate-spin mr-1" size={14} />{busy || t("topbar.starting")}</>
               : <><Play size={14} className="mr-1" />{t("topbar.start")}</>}
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={onOpenRuntimeEnvironment}
-          >
-            <ArrowRight size={14} className="mr-1" />
-            查看运行环境
-          </Button>
+          {backendBootPhase === "error" ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={!!busy || repairingRuntime}
+              title={t("status.runtimeRepairHint")}
+              onClick={async () => {
+                setRepairingRuntime(true);
+                try {
+                  await onRepairRuntime();
+                } finally {
+                  setRepairingRuntime(false);
+                }
+              }}
+            >
+              {repairingRuntime
+                ? <Loader2 className="mr-1 animate-spin" size={14} />
+                : <Wrench size={14} className="mr-1" />}
+              {t("status.runtimeRepairTitle")}
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onOpenRuntimeEnvironment}
+            >
+              <ArrowRight size={14} className="mr-1" />
+              {t("status.runtimeEnvironmentTitle")}
+            </Button>
+          )}
           </CardContent>
         </Card>
       )}

--- a/src/openakita/api/routes/bug_report.py
+++ b/src/openakita/api/routes/bug_report.py
@@ -1048,6 +1048,24 @@ async def _build_bug_zip(
             if crash_data:
                 zf.writestr("logs/crash.log", crash_data)
 
+            # Runtime creation happens in the Tauri shell before the Python
+            # backend starts. These files are therefore the primary evidence
+            # when an upgrade cannot rebuild app-venv and the normal backend
+            # logs never receive the failure.
+            autostart_data = _tail_file(global_logs / "autostart.log", LOG_TAIL_BYTES)
+            if autostart_data:
+                zf.writestr("global_logs/autostart.log", autostart_data)
+
+            runtime_dir = _resolve_openakita_home_dir() / "runtime"
+            _add_file(zf, runtime_dir / "manifest.json", "runtime/manifest.json")
+            for runtime_log_name in ("app-venv.log", "agent-venv.log", "bootstrap.log"):
+                runtime_log_data = _tail_file(
+                    runtime_dir / "logs" / runtime_log_name,
+                    LOG_TAIL_BYTES,
+                )
+                if runtime_log_data:
+                    zf.writestr(f"runtime/logs/{runtime_log_name}", runtime_log_data)
+
             data_dir = _resolve_data_dir()
             _add_dir_recent(
                 zf,

--- a/tests/unit/test_feedback_sanitized_config.py
+++ b/tests/unit/test_feedback_sanitized_config.py
@@ -74,3 +74,50 @@ async def test_bug_report_zip_includes_org_json_state(monkeypatch, tmp_path):
     assert "orgs/org_123/org.json" in names
     assert "orgs/org_123/state.json" in names
     assert "orgs/org_123/events/20260627.jsonl" in names
+
+
+@pytest.mark.asyncio
+async def test_bug_report_zip_includes_desktop_runtime_diagnostics(monkeypatch, tmp_path):
+    data_dir = tmp_path / "workspaces" / "default" / "data"
+    data_dir.mkdir(parents=True)
+    home_dir = tmp_path / "openakita-home"
+    global_logs = home_dir / "logs"
+    runtime_logs = home_dir / "runtime" / "logs"
+    global_logs.mkdir(parents=True)
+    runtime_logs.mkdir(parents=True)
+
+    (global_logs / "autostart.log").write_text("runtime rebuild started\n", encoding="utf-8")
+    (home_dir / "runtime" / "manifest.json").write_text(
+        json.dumps({"legacy_mode": True, "last_error": "install failed"}),
+        encoding="utf-8",
+    )
+    (runtime_logs / "app-venv.log").write_text("app install failed\n", encoding="utf-8")
+    (runtime_logs / "agent-venv.log").write_text("agent install pending\n", encoding="utf-8")
+
+    monkeypatch.setattr(bug_report, "_resolve_data_dir", lambda: data_dir)
+    monkeypatch.setattr(bug_report, "_resolve_global_logs_dir", lambda: global_logs)
+    monkeypatch.setattr(bug_report, "_resolve_openakita_home_dir", lambda: home_dir)
+    monkeypatch.setattr(bug_report, "_collect_sanitized_config", lambda: {})
+    monkeypatch.setattr(bug_report, "_add_windows_crash_artifacts", lambda zf: None)
+
+    zip_bytes = await bug_report._build_bug_zip(
+        report_id="runtime-failure",
+        title="runtime failure",
+        description="backend did not start",
+        steps="",
+        sys_info={},
+        contact_email="",
+        contact_wechat="",
+        images=None,
+        upload_logs=True,
+        upload_debug=False,
+    )
+
+    with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("runtime/manifest.json"))
+
+    assert "global_logs/autostart.log" in names
+    assert "runtime/logs/app-venv.log" in names
+    assert "runtime/logs/agent-venv.log" in names
+    assert manifest["legacy_mode"] is True


### PR DESCRIPTION
## Summary

- expose runtime repair directly when desktop backend startup fails
- bound runtime setup, bypass confirmed-dead bootstrap proxies, and include runtime evidence in every feedback path

## Tests

- `npm run build`
- `npx tsc -b`
- `cargo check --manifest-path apps/setup-center/src-tauri/Cargo.toml`
- `cargo test --manifest-path apps/setup-center/src-tauri/Cargo.toml test_runtime_ -- --nocapture`
- `uv run --no-sync pytest tests/unit/test_feedback_sanitized_config.py -q`
- `uv run --no-sync ruff check src/openakita/api/routes/bug_report.py tests/unit/test_feedback_sanitized_config.py`

Fixes #739
