### PR TITLE
Add hover copy controls to desktop chat Markdown code blocks

### DIFF
--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -1422,6 +1422,52 @@ button.btnApplyRestart:hover {
   color: var(--text);
 }
 
+.markdownCodeBlock {
+  position: relative;
+  margin: 8px 0;
+}
+
+.chatMdContent .markdownCodeBlock pre {
+  margin: 0;
+  padding-right: 44px;
+}
+
+.markdownCodeCopyBtn {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.markdownCodeBlock:hover .markdownCodeCopyBtn,
+.markdownCodeCopyBtn:focus-visible {
+  opacity: 1;
+}
+
+.markdownCodeCopyBtn:hover,
+.markdownCodeCopyBtn:focus-visible {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+@media (hover: none) {
+  .markdownCodeCopyBtn {
+    opacity: 1;
+  }
+}
+
 .chatMdContent code {
   background: var(--bg-app);
   padding: 2px 5px;

--- a/apps/setup-center/src/views/chat/components/MarkdownContent.tsx
+++ b/apps/setup-center/src/views/chat/components/MarkdownContent.tsx
@@ -1,4 +1,8 @@
-import { useDeferredValue, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toText } from "hast-util-to-text";
+import { IconCheck, IconClipboard } from "../../../icons";
+import { copyToClipboard } from "../../../utils/clipboard";
 import { useSmoothReveal } from "../hooks/useSmoothReveal";
 import type { MdModules } from "../utils/chatTypes";
 import { appendAuthToken } from "../utils/chatHelpers";
@@ -11,6 +15,45 @@ function resolveMarkdownImageUrl(src: string, apiBaseUrl?: string): string {
   if (src.startsWith("http")) return appendAuthToken(src);
   if (src.startsWith("/")) return appendAuthToken(`${apiBaseUrl || ""}${src}`);
   return src;
+}
+
+function MarkdownCodeBlock({ node, children, ...props }: any) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const feedbackTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (feedbackTimerRef.current !== null) window.clearTimeout(feedbackTimerRef.current);
+  }, []);
+
+  const handleCopy = async () => {
+    const code = node ? toText(node) : "";
+    if (!await copyToClipboard(code)) return;
+
+    setCopied(true);
+    if (feedbackTimerRef.current !== null) window.clearTimeout(feedbackTimerRef.current);
+    feedbackTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      feedbackTimerRef.current = null;
+    }, 1500);
+  };
+
+  const label = copied ? t("common.copied", "Copied") : t("common.copy", "Copy");
+
+  return (
+    <div className="markdownCodeBlock">
+      <pre {...props}>{children}</pre>
+      <button
+        type="button"
+        className="markdownCodeCopyBtn"
+        onClick={handleCopy}
+        aria-label={label}
+        title={label}
+      >
+        {copied ? <IconCheck size={15} /> : <IconClipboard size={15} />}
+      </button>
+    </div>
+  );
 }
 
 export function MarkdownContent({
@@ -53,9 +96,11 @@ export function MarkdownContent({
   // 从根上压平"逐 token 重解析重提交"的卡顿（记忆化只治 KaTeX，这个治整棵树）。
   const renderContent = useDeferredValue(revealed);
   const markdownComponents = useMemo(() => {
-    if (!onImagePreview) return undefined;
-    return {
-      img: ({ node: _node, src, alt, title, ...props }: any) => {
+    const components: Record<string, any> = {
+      pre: MarkdownCodeBlock,
+    };
+    if (onImagePreview) {
+      components.img = ({ node: _node, src, alt, title, ...props }: any) => {
         const imageUrl = resolveMarkdownImageUrl(String(src || ""), apiBaseUrl);
         return (
           <img
@@ -79,8 +124,9 @@ export function MarkdownContent({
             }}
           />
         );
-      },
-    };
+      };
+    }
+    return components;
   }, [apiBaseUrl, onImagePreview]);
 
   return (

--- a/apps/setup-center/src/views/chat/components/__tests__/MarkdownContent.test.tsx
+++ b/apps/setup-center/src/views/chat/components/__tests__/MarkdownContent.test.tsx
@@ -1,0 +1,61 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "../../../../utils/clipboard";
+import type { MdModules } from "../../utils/chatTypes";
+import { MarkdownContent } from "../MarkdownContent";
+
+vi.mock("../../../../utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+const mdModules: MdModules = {
+  ReactMarkdown,
+  remarkPlugins: [],
+  rehypePlugins: [],
+};
+
+describe("MarkdownContent code block copy", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("copies fenced code and briefly shows success feedback", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+    vi.useFakeTimers();
+
+    render(
+      <MarkdownContent
+        content={'```js\nconsole.log("hello");\n```'}
+        mdModules={mdModules}
+        className="chatMdContent"
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
+    expect(copyToClipboard).toHaveBeenCalledWith('console.log("hello");\n');
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("does not add a copy button to inline code", () => {
+    render(
+      <MarkdownContent
+        content="Run `openakita serve` to start."
+        mdModules={mdModules}
+        className="chatMdContent"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a hover copy control to Markdown code blocks in desktop chat messages.
- Use the cross-platform clipboard helper and show temporary success feedback, with keyboard and touch accessibility.

## Tests

- `npm run test:run -- src/views/chat/components/__tests__/MarkdownContent.test.tsx`
- `npx tsc --noEmit`
- `npx eslint src/views/chat/components/MarkdownContent.tsx src/views/chat/components/__tests__/MarkdownContent.test.tsx --max-warnings=9999`
- `npm run build:web`

Closes #743
