### PR TITLE
Fix streaming context usage persistence per conversation

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -4332,6 +4332,20 @@ export function ChatView({
                   chainGroups = chainGroups.map((g, i) => i === chainGroups.length - 1 ? currentChainGroup! : g);
                 }
                 break;
+              case "context_usage": {
+                const eventConversationId: string = event.conversation_id || convId;
+                if (eventConversationId === convId && isTargetConversationActive()) {
+                  const ctxTokens = event.history_context_tokens ?? event.context_tokens;
+                  const ctxLimit = event.history_context_limit ?? event.context_limit;
+                  if (typeof ctxTokens === "number" && Number.isFinite(ctxTokens)) {
+                    setContextTokens(Math.max(0, ctxTokens));
+                  }
+                  if (typeof ctxLimit === "number" && Number.isFinite(ctxLimit) && ctxLimit > 0) {
+                    setContextLimit(ctxLimit);
+                  }
+                }
+                break;
+              }
               case "text_delta":
                 currentStreamStatus = null;
                 currentContent += event.content;

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -116,6 +116,21 @@ export type StreamEvent =
   | { type: "org_command_done"; org_id: string; command_id: string; result?: Record<string, unknown>; error?: string }
   | { type: "iteration_start"; iteration: number }
   | { type: "context_compressed"; before_tokens: number; after_tokens: number }
+  | {
+      type: "context_usage";
+      conversation_id?: string;
+      context_tokens: number;
+      context_limit: number;
+      history_context_tokens?: number;
+      history_context_limit?: number;
+      remaining_tokens?: number;
+      percent?: number;
+      updated_at?: number;
+      source?: string;
+      usage_estimated?: boolean;
+      endpoint_name?: string;
+      model?: string;
+    }
   | { type: "thinking_start" }
   | { type: "thinking_delta"; content: string }
   | { type: "thinking_end"; duration_ms?: number; has_thinking?: boolean }

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -20,7 +20,11 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from openakita.core.ask_user_context import AskUserReplyContext
 from openakita.core.confirmation_state import ConfirmationDecision, get_confirmation_store
-from openakita.core.context_stats import get_context_snapshot, merge_context_snapshot_into_usage
+from openakita.core.context_stats import (
+    context_snapshot_from_dict,
+    get_context_snapshot,
+    merge_context_snapshot_into_usage,
+)
 from openakita.core.engine_bridge import engine_stream, is_dual_loop, to_engine
 from openakita.core.security_actions import execute_controlled_action
 from openakita.core.trusted_paths import grant_session_trust
@@ -1367,6 +1371,7 @@ async def _stream_chat(
     _agent_done = asyncio.Event()
     _agent_queue: asyncio.Queue = asyncio.Queue()
     _save_done = False
+    _latest_context_snapshot: dict | None = None
     _pending_approval = False
     _plan_ready_for_approval = False
     session = None
@@ -1711,6 +1716,17 @@ async def _stream_chat(
             if _mcp_call:
                 _collected_mcp_calls.append(_mcp_call)
 
+            if event_type == "context_usage":
+                event_conversation_id = str(event.get("conversation_id") or conversation_id)
+                if not conversation_id or event_conversation_id == conversation_id:
+                    _latest_context_snapshot = {
+                        key: value for key, value in event.items() if key != "type"
+                    }
+                    if session is not None:
+                        session.set_metadata("context_usage", _latest_context_snapshot)
+                        if session_manager is not None:
+                            session_manager.mark_dirty()
+
             if event_type == "__agent_error__":
                 _agent_errored = True
                 _agent_error_msg = event.get("__exc_msg__") or "Unknown error"
@@ -1838,7 +1854,12 @@ async def _stream_chat(
                             _usage_data["usage_source"] = (
                                 "mixed" if len(usage_sources) > 1 else next(iter(usage_sources))
                             )
-            _snapshot = get_context_snapshot(actual_agent)
+            _snapshot = context_snapshot_from_dict(
+                _latest_context_snapshot
+            ) or get_context_snapshot(
+                actual_agent,
+                conversation_id=conversation_id or None,
+            )
             _usage_data = merge_context_snapshot_into_usage(_usage_data, _snapshot)
         except Exception:
             pass

--- a/src/openakita/api/routes/token_stats.py
+++ b/src/openakita/api/routes/token_stats.py
@@ -18,7 +18,11 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, Query, Request
 
 from openakita.config import settings
-from openakita.core.context_stats import get_context_snapshot
+from openakita.core.context_stats import (
+    context_snapshot_from_dict,
+    get_context_snapshot,
+    update_context_snapshot,
+)
 from openakita.storage.database import Database
 
 logger = logging.getLogger(__name__)
@@ -426,13 +430,52 @@ async def pricing_overview(request: Request):
 @router.get("/context")
 async def context(request: Request, conversation_id: str | None = Query(default=None)):
     """Return the current session's context token usage and limit."""
+    session = None
+    session_manager = None
+    if conversation_id:
+        session_manager = getattr(request.app.state, "session_manager", None)
+        if session_manager is not None:
+            try:
+                session = session_manager.get_session(
+                    channel="desktop",
+                    chat_id=conversation_id,
+                    user_id="desktop_user",
+                    create_if_missing=False,
+                )
+                persisted = context_snapshot_from_dict(
+                    session.get_metadata("context_usage") if session is not None else None
+                )
+                if persisted is not None:
+                    return persisted.to_dict()
+            except Exception as e:
+                logger.debug("[TokenStats] persisted context lookup failed: %s", e)
+
     agent = _get_existing_agent(request, conversation_id)
     actual = getattr(agent, "_local_agent", agent) if agent else None
     if actual is None:
         return {"error": "agent not available"}
 
     try:
-        snapshot = get_context_snapshot(actual, conversation_id=conversation_id)
+        snapshot = get_context_snapshot(
+            actual,
+            conversation_id=conversation_id,
+            allow_estimate=False,
+        )
+        if snapshot is None and session is not None:
+            messages = list(getattr(getattr(session, "context", None), "messages", None) or [])
+            if messages:
+                snapshot = update_context_snapshot(
+                    actual,
+                    conversation_id=conversation_id,
+                    messages=messages,
+                    source="persisted_history_estimate",
+                )
+                if snapshot is not None:
+                    session.set_metadata("context_usage", snapshot.to_dict())
+                    if session_manager is not None:
+                        session_manager.mark_dirty()
+        if snapshot is None:
+            snapshot = get_context_snapshot(actual, conversation_id=conversation_id)
         if snapshot is not None:
             return snapshot.to_dict()
     except Exception as e:

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -7040,6 +7040,44 @@ class Agent:
                 """
                 _stream_text = ""
                 _stream_failed = False
+                from ._context_manager_legacy import ContextManager
+                from .context_stats import update_context_snapshot
+
+                _context_base = ContextManager.static_estimate_tokens(_system or "")
+                _context_base += ContextManager.static_estimate_tokens(message or "")
+                _context_output_tokens = 0
+                _context_last_tokens = _context_base
+                _context_last_emit = time.monotonic()
+
+                def _context_event(
+                    tokens: int,
+                    *,
+                    source: str,
+                    usage_estimated: bool,
+                    usage: dict | None = None,
+                ) -> dict | None:
+                    snapshot = update_context_snapshot(
+                        self,
+                        conversation_id,
+                        usage=usage,
+                        source=source,
+                        measured_context_tokens=tokens,
+                    )
+                    if snapshot is None:
+                        return None
+                    event = snapshot.to_dict()
+                    event["type"] = "context_usage"
+                    event["usage_estimated"] = usage_estimated
+                    return event
+
+                _initial_context_event = _context_event(
+                    _context_base,
+                    source="stream_estimate",
+                    usage_estimated=True,
+                )
+                if _initial_context_event is not None:
+                    yield _initial_context_event
+
                 # —— 路径 A：尝试真流式 ——
                 try:
                     async for _evt in self.brain.think_lightweight_stream(
@@ -7062,7 +7100,98 @@ class Agent:
                                 f"{_evt.get('message', '')}"
                             )
                         elif _et == "done":
+                            _usage = dict(_evt.get("usage") or {})
+                            result_holder["usage"] = _usage or None
+                            _in_tokens = int(
+                                _usage.get("input_tokens") or _usage.get("prompt_tokens") or 0
+                            )
+                            _out_tokens = int(
+                                _usage.get("output_tokens") or _usage.get("completion_tokens") or 0
+                            )
+                            _final_tokens = (
+                                _in_tokens + _out_tokens
+                                if (_in_tokens or _out_tokens)
+                                else _context_base + _context_output_tokens
+                            )
+                            _final_context_event = _context_event(
+                                _final_tokens,
+                                source=(
+                                    "provider" if (_in_tokens or _out_tokens) else "stream_estimate"
+                                ),
+                                usage_estimated=not bool(_in_tokens or _out_tokens),
+                                usage=_usage,
+                            )
+                            if _final_context_event is not None:
+                                yield _final_context_event
+                            if _in_tokens or _out_tokens:
+                                try:
+                                    from .token_tracking import record_usage as _record_usage
+
+                                    _cache_read = int(_usage.get("cache_read_input_tokens") or 0)
+                                    _cache_create = int(
+                                        _usage.get("cache_creation_input_tokens") or 0
+                                    )
+                                    _endpoint_info = self.brain.get_current_endpoint_info() or {}
+                                    _endpoint_name = _endpoint_info.get("name", "")
+                                    _model = _endpoint_info.get("model", "")
+                                    _cost = 0.0
+                                    for _endpoint in self.brain._llm_client.endpoints:
+                                        if _endpoint.name == _endpoint_name:
+                                            _cost = _endpoint.calculate_cost(
+                                                input_tokens=_in_tokens,
+                                                output_tokens=_out_tokens,
+                                                cache_read_tokens=_cache_read,
+                                            )
+                                            break
+                                    _tracking_token = set_tracking_context(
+                                        TokenTrackingContext(
+                                            session_id=conversation_id or "",
+                                            request_id=_request_id,
+                                            turn_id=_turn_id,
+                                            operation_type="chat_fast_reply_stream",
+                                            operation_detail="provider",
+                                            channel="api",
+                                            agent_profile_id=_agent_profile_id,
+                                        )
+                                    )
+                                    try:
+                                        _record_usage(
+                                            model=_model,
+                                            endpoint_name=_endpoint_name,
+                                            input_tokens=_in_tokens,
+                                            output_tokens=_out_tokens,
+                                            cache_creation_tokens=_cache_create,
+                                            cache_read_tokens=_cache_read,
+                                            context_tokens=_in_tokens + _out_tokens,
+                                            estimated_cost=_cost,
+                                        )
+                                    finally:
+                                        reset_tracking_context(_tracking_token)
+                                except Exception as _tracking_error:
+                                    logger.debug(
+                                        "[FastReply-Stream] token tracking failed: %s",
+                                        _tracking_error,
+                                    )
                             break
+
+                        if _et in ("text_delta", "thinking_delta"):
+                            _piece = str(_evt.get("content") or "")
+                            _context_output_tokens += ContextManager.static_estimate_tokens(_piece)
+                            _current_context_tokens = _context_base + _context_output_tokens
+                            _now = time.monotonic()
+                            if (
+                                _current_context_tokens - _context_last_tokens >= 16
+                                or _now - _context_last_emit >= 0.25
+                            ):
+                                _context_last_tokens = _current_context_tokens
+                                _context_last_emit = _now
+                                _stream_context_event = _context_event(
+                                    _current_context_tokens,
+                                    source="stream_estimate",
+                                    usage_estimated=True,
+                                )
+                                if _stream_context_event is not None:
+                                    yield _stream_context_event
                 except Exception as exc:
                     _stream_failed = True
                     logger.warning(f"[{log_prefix}] streaming path failed: {exc}")
@@ -7070,7 +7199,6 @@ class Agent:
                 _cleaned = clean_llm_response(_stream_text) if _stream_text else ""
                 if _cleaned and not _stream_failed:
                     result_holder["text"] = _cleaned
-                    result_holder["usage"] = None
                     result_holder["ok"] = True
                     return
 
@@ -7088,6 +7216,17 @@ class Agent:
                         result_holder["text"] = _fb_text
                         result_holder["usage"] = _resp.usage
                         result_holder["ok"] = True
+                        _fallback_usage = dict(_resp.usage or {})
+                        _fallback_in = int(_fallback_usage.get("input_tokens") or 0)
+                        _fallback_out = int(_fallback_usage.get("output_tokens") or 0)
+                        _fallback_context_event = _context_event(
+                            _fallback_in + _fallback_out,
+                            source="provider",
+                            usage_estimated=False,
+                            usage=_fallback_usage,
+                        )
+                        if _fallback_context_event is not None:
+                            yield _fallback_context_event
                         return
                 except Exception as exc:
                     logger.error(f"[{log_prefix}] non-stream fallback also failed: {exc}")

--- a/src/openakita/core/_brain_legacy.py
+++ b/src/openakita/core/_brain_legacy.py
@@ -420,7 +420,7 @@ class Brain:
                 yield ("error", exc)
                 return
             decision = acc.build_decision()
-            yield ("done", decision)
+            yield ("done", (decision, dict(acc.usage or {})))
             logger.info(
                 f"[LLM] think_lightweight_stream completed via {label} endpoint "
                 f"(yielded_text={yielded_text})"
@@ -445,6 +445,7 @@ class Brain:
                     self._compiler_on_failure(str(payload))
                 break
             elif kind == "done":
+                _decision, _usage = payload
                 if use_compiler:
                     self._compiler_on_success()
                 self._dump_llm_response(
@@ -452,7 +453,7 @@ class Brain:
                     caller=f"think_lightweight_stream_{primary_label}",
                     request_id=req_id,
                 )
-                yield {"type": "done"}
+                yield {"type": "done", "usage": _usage}
                 return
 
         # 失败回退：仅当 compiler 链路报错且主端点尚未被使用时
@@ -481,12 +482,13 @@ class Brain:
                     yield {"type": "done"}
                     return
                 elif kind == "done":
+                    _decision, _usage = payload
                     self._dump_llm_response(
                         None,
                         caller="think_lightweight_stream_main_fallback",
                         request_id=req_id,
                     )
-                    yield {"type": "done"}
+                    yield {"type": "done", "usage": _usage}
                     return
 
         if compiler_failed_exc is not None and not use_compiler:

--- a/src/openakita/core/_reasoning_engine_legacy.py
+++ b/src/openakita/core/_reasoning_engine_legacy.py
@@ -4069,6 +4069,63 @@ class ReasoningEngine:
                             "after_tokens": _after_tokens,
                         }
 
+                # Publish context occupancy before the provider starts and keep
+                # updating it while output streams. Provider usage later
+                # calibrates this estimate with the exact input/output counts.
+                try:
+                    _stream_context_base = ContextManager.static_estimate_tokens(
+                        effective_prompt or ""
+                    )
+                    _stream_context_base += self._context_manager.estimate_messages_tokens(
+                        working_messages
+                    )
+                    _stream_context_base += self._context_manager.estimate_tools_tokens(tools)
+                except Exception:
+                    _stream_context_base = 0
+                try:
+                    _stream_context_limit = self._context_manager.get_max_context_tokens(
+                        conversation_id=conversation_id
+                    )
+                except Exception:
+                    _stream_context_limit = 0
+                _stream_context_output_tokens = 0
+                _stream_context_last_tokens = _stream_context_base
+                _stream_context_last_emit = time.monotonic()
+
+                def _context_usage_event(
+                    tokens: int,
+                    *,
+                    source: str,
+                    usage_estimated: bool,
+                    context_limit: int = _stream_context_limit,
+                    model: str = current_model,
+                ) -> dict:
+                    _tokens = max(int(tokens or 0), 0)
+                    _limit = max(int(context_limit or 0), 0)
+                    _ep_info = self._brain.get_current_endpoint_info() or {}
+                    return {
+                        "type": "context_usage",
+                        "conversation_id": conversation_id,
+                        "context_tokens": _tokens,
+                        "history_context_tokens": _tokens,
+                        "context_limit": _limit,
+                        "history_context_limit": _limit,
+                        "remaining_tokens": max(_limit - _tokens, 0),
+                        "percent": round((_tokens / _limit) * 100, 1) if _limit else 0,
+                        "updated_at": time.time(),
+                        "source": source,
+                        "usage_estimated": usage_estimated,
+                        "endpoint_name": _ep_info.get("name", ""),
+                        "model": model or _ep_info.get("model", ""),
+                    }
+
+                if _stream_context_limit > 0:
+                    yield _context_usage_event(
+                        _stream_context_base,
+                        source="stream_estimate",
+                        usage_estimated=True,
+                    )
+
                 # --- 思维链: 迭代开始事件 ---
                 yield {"type": "iteration_start", "iteration": _iteration + 1}
 
@@ -4121,9 +4178,45 @@ class ReasoningEngine:
                         elif _evt_type == "text_delta":
                             yield stream_event
                             _streamed_text = True
+                            _stream_context_output_tokens += ContextManager.static_estimate_tokens(
+                                str(stream_event.get("content") or "")
+                            )
+                            _current_context_tokens = (
+                                _stream_context_base + _stream_context_output_tokens
+                            )
+                            _now = time.monotonic()
+                            if (
+                                _current_context_tokens - _stream_context_last_tokens >= 16
+                                or _now - _stream_context_last_emit >= 0.25
+                            ):
+                                _stream_context_last_tokens = _current_context_tokens
+                                _stream_context_last_emit = _now
+                                yield _context_usage_event(
+                                    _current_context_tokens,
+                                    source="stream_estimate",
+                                    usage_estimated=True,
+                                )
                         elif _evt_type == "thinking_delta":
                             yield stream_event
                             _streamed_thinking = True
+                            _stream_context_output_tokens += ContextManager.static_estimate_tokens(
+                                str(stream_event.get("content") or "")
+                            )
+                            _current_context_tokens = (
+                                _stream_context_base + _stream_context_output_tokens
+                            )
+                            _now = time.monotonic()
+                            if (
+                                _current_context_tokens - _stream_context_last_tokens >= 16
+                                or _now - _stream_context_last_emit >= 0.25
+                            ):
+                                _stream_context_last_tokens = _current_context_tokens
+                                _stream_context_last_emit = _now
+                                yield _context_usage_event(
+                                    _current_context_tokens,
+                                    source="stream_estimate",
+                                    usage_estimated=True,
+                                )
                         elif _evt_type == "endpoint_meta":
                             # 由 LLMClient 注入的端点元信息（vision_degraded 等）
                             # 转换成前端协议一致的 endpoint_notice。
@@ -4376,6 +4469,17 @@ class ReasoningEngine:
                     self._budget.record_tokens(_in_tokens, _out_tokens)
                     if _in_tokens and not _usage_estimated:
                         _last_real_input_tokens = _in_tokens
+                if _stream_context_limit > 0:
+                    _final_context_tokens = (
+                        _in_tokens + _out_tokens
+                        if (_in_tokens or _out_tokens)
+                        else _stream_context_last_tokens
+                    )
+                    yield _context_usage_event(
+                        _final_context_tokens,
+                        source=_usage_source or "stream_estimate",
+                        usage_estimated=_usage_estimated or not bool(_usage_source),
+                    )
                 # 流式路径下 brain 不落 token_tracking（详见 brain.messages_create_stream
                 # 注释），需在此显式落库以保留 cache_read/cache_create 命中统计。
                 if _in_tokens or _out_tokens or _cache_read or _cache_create:

--- a/src/openakita/core/context_stats.py
+++ b/src/openakita/core/context_stats.py
@@ -149,7 +149,11 @@ def resolve_context_limit(agent: Any, conversation_id: str | None = None) -> dic
                 if raw <= 0:
                     raw = int(DEFAULT_CONTEXT_WINDOW)
                 raw_context_window = raw
-                effective = min(raw, settings.context_max_window) if settings.context_max_window > 0 else raw
+                effective = (
+                    min(raw, settings.context_max_window)
+                    if settings.context_max_window > 0
+                    else raw
+                )
                 effective_context_window = int(effective)
                 reserve = int(getattr(ep, "max_tokens", 0) or 4096)
                 output_reserve = min(reserve, max(effective_context_window // 3, 0))
@@ -196,6 +200,13 @@ def _snapshot_from_dict(data: dict[str, Any]) -> ContextUsageSnapshot | None:
     )
 
 
+def context_snapshot_from_dict(data: dict[str, Any] | None) -> ContextUsageSnapshot | None:
+    """Parse a persisted or wire-format context snapshot."""
+    if not isinstance(data, dict):
+        return None
+    return _snapshot_from_dict(data)
+
+
 def update_context_snapshot(
     agent: Any,
     conversation_id: str | None = None,
@@ -204,6 +215,7 @@ def update_context_snapshot(
     usage: dict[str, Any] | None = None,
     pressure: dict[str, Any] | None = None,
     source: str = "estimated",
+    measured_context_tokens: int | None = None,
 ) -> ContextUsageSnapshot | None:
     """Estimate and store the latest context usage snapshot on runtime objects."""
 
@@ -214,7 +226,11 @@ def update_context_snapshot(
     ctx_mgr = _context_manager(actual)
     if messages is None:
         messages = _last_messages(actual)
-    context_tokens = _estimate_tokens(ctx_mgr, messages)
+    context_tokens = (
+        max(int(measured_context_tokens), 0)
+        if measured_context_tokens is not None
+        else _estimate_tokens(ctx_mgr, messages)
+    )
     limit_info = resolve_context_limit(actual, conversation_id)
     context_limit = int(limit_info.get("context_limit") or 0)
     if context_limit <= 0:
@@ -243,8 +259,20 @@ def update_context_snapshot(
     )
 
     actual._last_context_usage_snapshot = snapshot
+    snapshots = getattr(actual, "_context_usage_snapshots", None)
+    if not isinstance(snapshots, dict):
+        snapshots = {}
+        actual._context_usage_snapshots = snapshots
+    if conversation_id:
+        snapshots[conversation_id] = snapshot
     if re is not None:
         re._last_context_usage_snapshot = snapshot
+        re_snapshots = getattr(re, "_context_usage_snapshots", None)
+        if not isinstance(re_snapshots, dict):
+            re_snapshots = {}
+            re._context_usage_snapshots = re_snapshots
+        if conversation_id:
+            re_snapshots[conversation_id] = snapshot
     return snapshot
 
 
@@ -261,14 +289,30 @@ def get_context_snapshot(
         return None
     re = _reasoning_engine(actual)
 
+    if conversation_id:
+        for owner in (actual, re):
+            snapshots = (
+                getattr(owner, "_context_usage_snapshots", None) if owner is not None else None
+            )
+            if isinstance(snapshots, dict):
+                snapshot = snapshots.get(conversation_id)
+                if isinstance(snapshot, ContextUsageSnapshot):
+                    return snapshot
+                if isinstance(snapshot, dict):
+                    parsed = _snapshot_from_dict(snapshot)
+                    if parsed:
+                        return parsed
+
     for owner in (actual, re):
-        snapshot = getattr(owner, "_last_context_usage_snapshot", None) if owner is not None else None
+        snapshot = (
+            getattr(owner, "_last_context_usage_snapshot", None) if owner is not None else None
+        )
         if isinstance(snapshot, ContextUsageSnapshot):
-            if conversation_id is None or snapshot.conversation_id in (None, conversation_id):
+            if conversation_id is None or snapshot.conversation_id == conversation_id:
                 return snapshot
         if isinstance(snapshot, dict):
             parsed = _snapshot_from_dict(snapshot)
-            if parsed and (conversation_id is None or parsed.conversation_id in (None, conversation_id)):
+            if parsed and (conversation_id is None or parsed.conversation_id == conversation_id):
                 return parsed
 
     cached = getattr(actual, "_last_usage_summary", None)

--- a/tests/integration/test_api_chat.py
+++ b/tests/integration/test_api_chat.py
@@ -99,6 +99,75 @@ class TestChatEndpoint:
         assert captured_kwargs["mode"] == "agent"
         assert captured_kwargs["plan_mode"] is False
 
+    async def test_chat_streams_and_persists_context_usage(
+        self, client, app, mock_agent, monkeypatch, tmp_path
+    ):
+        from openakita.sessions.manager import SessionManager
+
+        conversation_id = "test-conv-context-stream"
+        storage = tmp_path / "sessions"
+        app.state.session_manager = SessionManager(storage_path=storage)
+        mock_agent._last_usage_summary = None
+        mock_agent._last_finalized_trace = []
+        mock_agent.reasoning_engine = SimpleNamespace(_last_react_trace=[])
+        mock_agent.build_tool_trace_summary.return_value = ""
+
+        async def fake_stream(*args, **kwargs):
+            yield {
+                "type": "context_usage",
+                "conversation_id": conversation_id,
+                "context_tokens": 100,
+                "context_limit": 1000,
+                "remaining_tokens": 900,
+                "percent": 10.0,
+                "source": "stream_estimate",
+                "usage_estimated": True,
+            }
+            yield {"type": "text_delta", "content": "streaming"}
+            yield {
+                "type": "context_usage",
+                "conversation_id": conversation_id,
+                "context_tokens": 120,
+                "context_limit": 1000,
+                "remaining_tokens": 880,
+                "percent": 12.0,
+                "source": "stream_estimate",
+                "usage_estimated": True,
+            }
+            yield {
+                "type": "context_usage",
+                "conversation_id": conversation_id,
+                "context_tokens": 140,
+                "context_limit": 1000,
+                "remaining_tokens": 860,
+                "percent": 14.0,
+                "source": "provider",
+                "usage_estimated": False,
+            }
+            yield {"type": "done"}
+
+        monkeypatch.setattr(mock_agent, "chat_with_session_stream", fake_stream)
+
+        response = await client.post(
+            "/api/chat",
+            json={"message": "Hello", "conversation_id": conversation_id},
+        )
+
+        assert response.status_code == 200
+        assert response.text.count('"type": "context_usage"') == 3
+        session = next(
+            session
+            for session in app.state.session_manager.list_sessions()
+            if session.chat_id == conversation_id
+        )
+        assert session.get_metadata("context_usage")["context_tokens"] == 140
+
+        restored = SessionManager(storage_path=storage)
+        restored_session = next(
+            session for session in restored.list_sessions() if session.chat_id == conversation_id
+        )
+        assert restored_session.get_metadata("context_usage")["context_tokens"] == 140
+
     async def test_chat_passes_normal_ask_user_reply_to_agent(
         self, client, mock_agent, monkeypatch
     ):

--- a/tests/unit/test_brain_lightweight_stream_usage.py
+++ b/tests/unit/test_brain_lightweight_stream_usage.py
@@ -1,0 +1,46 @@
+import pytest
+
+from openakita.core._brain_legacy import Brain
+
+
+class _StreamingClient:
+    async def chat_stream(self, **_kwargs):
+        yield {
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 10, "output_tokens": 0}},
+        }
+        yield {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text", "text": "hello"},
+        }
+        yield {
+            "type": "message_stop",
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        }
+
+
+@pytest.mark.asyncio
+async def test_think_lightweight_stream_preserves_provider_usage():
+    brain = Brain.__new__(Brain)
+    brain._llm_client = _StreamingClient()
+    brain._compiler_client = None
+    brain._compiler_available = lambda: False
+    brain._dump_llm_request = lambda *args, **kwargs: "request-id"
+    brain._dump_llm_response = lambda *args, **kwargs: None
+
+    events = [
+        event
+        async for event in brain.think_lightweight_stream(
+            prompt="hi",
+            system="system",
+        )
+    ]
+
+    assert events == [
+        {"type": "text_delta", "content": "hello"},
+        {
+            "type": "done",
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        },
+    ]

--- a/tests/unit/test_context_stats_snapshot.py
+++ b/tests/unit/test_context_stats_snapshot.py
@@ -66,6 +66,30 @@ def test_get_context_snapshot_reuses_stored_snapshot():
     assert get_context_snapshot(agent, "conv-1") is created
 
 
+def test_context_snapshots_are_isolated_by_conversation():
+    agent = _make_agent()
+    first = update_context_snapshot(
+        agent,
+        "conv-1",
+        measured_context_tokens=111,
+        source="provider",
+    )
+    agent.reasoning_engine._context_manager.get_max_context_tokens = lambda conversation_id=None: (
+        1000
+    )
+    second = update_context_snapshot(
+        agent,
+        "conv-2",
+        measured_context_tokens=222,
+        source="provider",
+    )
+
+    assert first is not None
+    assert second is not None
+    assert get_context_snapshot(agent, "conv-1").context_tokens == 111
+    assert get_context_snapshot(agent, "conv-2").context_tokens == 222
+
+
 def test_merge_context_snapshot_into_usage_preserves_billable_fields():
     agent = _make_agent()
     snapshot = update_context_snapshot(agent, "conv-1")

--- a/tests/unit/test_token_context_persistence.py
+++ b/tests/unit/test_token_context_persistence.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openakita.api.routes.token_stats import router
+from openakita.sessions.manager import SessionManager
+
+
+def _snapshot(conversation_id: str, tokens: int) -> dict:
+    return {
+        "conversation_id": conversation_id,
+        "context_tokens": tokens,
+        "context_limit": 1000,
+        "remaining_tokens": 1000 - tokens,
+        "percent": tokens / 10,
+        "updated_at": 123.0,
+        "source": "provider",
+        "endpoint_name": "primary",
+        "model": "test-model",
+    }
+
+
+def test_context_route_restores_independent_snapshots_after_restart(tmp_path):
+    storage = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage)
+    first = manager.get_session("desktop", "conv-1", "desktop_user")
+    second = manager.get_session("desktop", "conv-2", "desktop_user")
+    first.set_metadata("context_usage", _snapshot("conv-1", 111))
+    second.set_metadata("context_usage", _snapshot("conv-2", 222))
+    manager.persist()
+
+    restored = SessionManager(storage_path=storage)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = restored
+    app.state.agent_pool = None
+    app.state.agent = None
+    client = TestClient(app)
+
+    first_response = client.get("/api/stats/tokens/context?conversation_id=conv-1")
+    second_response = client.get("/api/stats/tokens/context?conversation_id=conv-2")
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json()["context_tokens"] == 111
+    assert second_response.json()["context_tokens"] == 222
+    assert first_response.json()["conversation_id"] == "conv-1"
+    assert second_response.json()["conversation_id"] == "conv-2"
+
+
+def test_context_route_backfills_missing_snapshot_from_persisted_history(tmp_path):
+    storage = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage)
+    session = manager.get_session("desktop", "legacy-conv", "desktop_user")
+    session.context.messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    manager.persist()
+
+    context_manager = SimpleNamespace(
+        estimate_messages_tokens=lambda _messages: 77,
+        get_max_context_tokens=lambda conversation_id=None: 1000,
+    )
+    agent = SimpleNamespace(
+        context_manager=context_manager,
+        brain=SimpleNamespace(
+            get_current_model_info=lambda conversation_id=None: {
+                "name": "primary",
+                "model": "test-model",
+            },
+            _llm_client=SimpleNamespace(endpoints=[]),
+        ),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = SessionManager(storage_path=storage)
+    app.state.agent_pool = SimpleNamespace(get_existing=lambda _conversation_id: agent)
+    app.state.agent = None
+    client = TestClient(app)
+
+    response = client.get("/api/stats/tokens/context?conversation_id=legacy-conv")
+
+    assert response.status_code == 200
+    assert response.json()["context_tokens"] == 77
+    assert response.json()["source"] == "persisted_history_estimate"
+    restored_session = app.state.session_manager.get_session(
+        "desktop",
+        "legacy-conv",
+        "desktop_user",
+        create_if_missing=False,
+    )
+    assert restored_session.get_metadata("context_usage")["context_tokens"] == 77


### PR DESCRIPTION
## Summary

- Stream context occupancy updates while LLM output is in progress, including lightweight chat and query fast paths.
- Persist context snapshots per conversation and restore them after backend restarts, with history-based recovery for affected legacy sessions.
- Preserve provider usage for streamed fast replies and attribute it to token statistics.

## Tests

- `uv run --no-sync pytest tests/unit/test_brain_lightweight_stream_usage.py tests/unit/test_context_stats_snapshot.py tests/unit/test_token_context_persistence.py tests/integration/test_api_chat.py::TestChatEndpoint::test_chat_streams_and_persists_context_usage tests/unit/test_token_stats_sessions.py tests/integration/test_context_length_api.py -q`
- `uv run --no-sync ruff check` on all changed Python files and tests.
- `npm run build -- --emptyOutDir=false`
- Verified live SSE updates, per-conversation isolation, token attribution, and snapshot restoration across backend restarts.

Fixes #557
