### PR TITLE
show the endpoint name field when editing LLM endpoints

### DIFF
--- a/apps/setup-center/src/views/LLMView.tsx
+++ b/apps/setup-center/src/views/LLMView.tsx
@@ -2045,6 +2045,12 @@ export function LLMView(props: LLMViewProps) {
               />
             </div>
 
+            {/* Endpoint name */}
+            <div className="space-y-1.5">
+              <Label>{t("llm.endpointName")}</Label>
+              <Input value={editDraft.name} onChange={(e) => setEditDraft({ ...editDraft, name: e.target.value })} />
+            </div>
+
             {editEndpointType === "endpoints" && <>
             {/* Capabilities */}
             <div className="space-y-1.5">
@@ -2180,13 +2186,6 @@ export function LLMView(props: LLMViewProps) {
             </details>
             </>}
 
-            {/* Endpoint name (for compiler/STT) */}
-            {editEndpointType !== "endpoints" && (
-            <div className="space-y-1.5">
-              <Label>{t("llm.endpointName")}</Label>
-              <Input value={editDraft.name} onChange={(e) => setEditDraft({ ...editDraft, name: e.target.value })} />
-            </div>
-            )}
           </div>}
 
           {connTestResult && (


### PR DESCRIPTION
## Summary

- Show the endpoint name field when editing main LLM endpoints.
- Place the endpoint name directly below the model selector.

## Tests

- `npx tsc -b`
- `uv run --no-sync pytest tests/unit/test_endpoint_manager_original_name.py -q` (5 passed)

Fixes #562
