### PR TITLE
Fix organization chat lifecycle synchronization

### DIFF
--- a/apps/setup-center/src/components/OrgChatPanel.tsx
+++ b/apps/setup-center/src/components/OrgChatPanel.tsx
@@ -9,6 +9,7 @@ import { Loader2, ShieldAlert, Copy as IconCopy } from "lucide-react";
 import { toast } from "sonner";
 import { safeFetch } from "../providers";
 import { copyToClipboard } from "../utils/clipboard";
+import { localizeOrgCommandStateError } from "../utils/orgStatus";
 import { onWsEvent } from "../platform";
 import { useMdModules } from "../views/chat/hooks/useMdModules";
 import { createV2Stream, type V2StreamEvent } from "../api/v2Stream";
@@ -2375,6 +2376,12 @@ export function OrgChatPanel({ orgId, nodeId, apiBaseUrl, compact, showHeader, t
       // toast.
       if (res.status === 409) {
         const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        const localizedStateError = localizeOrgCommandStateError(t, data);
+        if (localizedStateError) {
+          finalContent = `> ${localizedStateError}`;
+          finalizeResult(finalContent, undefined, "system");
+          return;
+        }
         const existingId =
           (typeof data.command_id === "string" && data.command_id) ||
           (typeof (data.detail as Record<string, unknown> | undefined)?.command_id === "string"

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -3116,10 +3116,14 @@
     },
     "orgStatus": {
       "dormant": "Dormant",
+      "created": "Not Started",
       "active": "Running",
       "running": "Running",
       "paused": "Paused",
-      "archived": "Archived"
+      "stopped": "Stopped",
+      "archived": "Archived",
+      "deleted": "Deleted",
+      "unknown": "Unknown"
     },
     "bbType": {
       "fact": "Fact",
@@ -3386,6 +3390,7 @@
       "taskCompleted": "Task completed",
       "longRunning": "Execution is taking long, org is still processing (elapsed {{duration}})...",
       "sendFailed": "Send failed: {{error}}",
+      "commandUnavailableStatus": "Cannot send instructions to this organization. Current status: {{status}}",
       "conversationTitle": "Chat · {{name}}",
       "commandCenter": "Org Command Center",
       "clearHistory": "Clear history",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -3124,10 +3124,14 @@
     },
     "orgStatus": {
       "dormant": "休眠",
+      "created": "待启动",
       "active": "运行中",
       "running": "运行中",
       "paused": "已暂停",
-      "archived": "已归档"
+      "stopped": "已停止",
+      "archived": "已归档",
+      "deleted": "已删除",
+      "unknown": "未知"
     },
     "bbType": {
       "fact": "事实",
@@ -3401,6 +3405,7 @@
       "continuePreviousTitle": "读取上一轮终止任务、黑板和未完成任务，作为新命令继续推进",
       "continuePreviousPrompt": "请基于刚才被中断的任务继续推进，优先复用已有脚本、图片、asset_ids、视频 URL 和未完成任务，不要重复已经完成的步骤。",
       "sendFailed": "发送失败: {{error}}",
+      "commandUnavailableStatus": "无法下发组织指令。当前状态：{{status}}",
       "conversationTitle": "对话 · {{name}}",
       "commandCenter": "组织指挥台",
       "clearHistory": "清空历史",

--- a/apps/setup-center/src/utils/__tests__/orgStatus.test.ts
+++ b/apps/setup-center/src/utils/__tests__/orgStatus.test.ts
@@ -1,0 +1,42 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+
+import { localizeOrgCommandStateError, localizeOrgStatus } from "../orgStatus";
+
+const labels: Record<string, string> = {
+  "org.orgStatus.dormant": "休眠",
+  "org.orgStatus.stopped": "已停止",
+  "org.orgStatus.unknown": "未知",
+};
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === "org.chat.commandUnavailableStatus") {
+    return `无法下发组织指令。当前状态：${String(options?.status || "")}`;
+  }
+  return labels[key] || key;
+}) as TFunction;
+
+describe("organization status localization", () => {
+  it("localizes all known state values through stable keys", () => {
+    expect(localizeOrgStatus(t, "dormant")).toBe("休眠");
+    expect(localizeOrgStatus(t, "STOPPED")).toBe("已停止");
+  });
+
+  it("localizes structured SSE and REST state errors", () => {
+    expect(localizeOrgCommandStateError(t, {
+      error_code: "org_not_runnable",
+      org_status: "dormant",
+    })).toBe("无法下发组织指令。当前状态：休眠");
+
+    expect(localizeOrgCommandStateError(t, {
+      detail: { code: "org_not_runnable", org_status: "stopped" },
+    })).toBe("无法下发组织指令。当前状态：已停止");
+  });
+
+  it("leaves unrelated command errors to their existing renderer", () => {
+    expect(localizeOrgCommandStateError(t, {
+      code: "org_command_conflict",
+      org_status: "active",
+    })).toBeNull();
+  });
+});

--- a/apps/setup-center/src/utils/__tests__/orgStructureEvents.test.ts
+++ b/apps/setup-center/src/utils/__tests__/orgStructureEvents.test.ts
@@ -14,6 +14,7 @@ describe("orgStructureEvents", () => {
       org_name: "测试组织",
       node_count: 3,
       edge_count: 2,
+      status: "dormant",
       tool_use_id: "call_1",
     })).toEqual({
       action: "created",
@@ -22,7 +23,7 @@ describe("orgStructureEvents", () => {
       templateId: undefined,
       nodeCount: 3,
       edgeCount: 2,
-      status: undefined,
+      status: "dormant",
       toolUseId: "call_1",
     });
   });
@@ -32,11 +33,16 @@ describe("orgStructureEvents", () => {
     window.addEventListener(ORG_STRUCTURE_CHANGED_EVENT, listener);
     try {
       expect(dispatchOrgStructureChanged({ action: "updated" })).toBe(false);
-      expect(dispatchOrgStructureChanged({ action: "updated", org_id: "org_abc" })).toBe(true);
+      expect(dispatchOrgStructureChanged({
+        action: "updated",
+        org_id: "org_abc",
+        status: "dormant",
+      })).toBe(true);
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener.mock.calls[0][0].detail).toMatchObject({
         action: "updated",
         orgId: "org_abc",
+        status: "dormant",
       });
     } finally {
       window.removeEventListener(ORG_STRUCTURE_CHANGED_EVENT, listener);

--- a/apps/setup-center/src/utils/orgStatus.ts
+++ b/apps/setup-center/src/utils/orgStatus.ts
@@ -1,0 +1,42 @@
+import type { TFunction } from "i18next";
+
+export const ORG_STATUS_I18N_KEYS: Record<string, string> = {
+  dormant: "org.orgStatus.dormant",
+  created: "org.orgStatus.created",
+  active: "org.orgStatus.active",
+  running: "org.orgStatus.running",
+  paused: "org.orgStatus.paused",
+  stopped: "org.orgStatus.stopped",
+  archived: "org.orgStatus.archived",
+  deleted: "org.orgStatus.deleted",
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function localizeOrgStatus(t: TFunction, value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  const normalized = raw.toLowerCase();
+  const key = ORG_STATUS_I18N_KEYS[normalized];
+  return key ? t(key) : raw || t("org.orgStatus.unknown");
+}
+
+export function localizeOrgCommandStateError(
+  t: TFunction,
+  payload: unknown,
+): string | null {
+  const outer = asRecord(payload);
+  const detail = asRecord(outer.detail);
+  const errorCode = String(
+    outer.error_code || outer.code || detail.error_code || detail.code || "",
+  );
+  if (errorCode !== "org_not_runnable") return null;
+
+  const status = outer.org_status || detail.org_status;
+  return t("org.chat.commandUnavailableStatus", {
+    status: localizeOrgStatus(t, status),
+  });
+}

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -47,7 +47,13 @@ import type {
 import { genId, timeAgo } from "../utils";
 import { SseStateMachine, type SseFrame } from "../utils/sseStateMachine";
 import { notifyError, notifyInfo } from "../utils/notify";
-import { dispatchOrgStructureChanged } from "../utils/orgStructureEvents";
+import {
+  ORG_STRUCTURE_CHANGED_EVENT,
+  dispatchOrgStructureChanged,
+  normalizeOrgStructureChange,
+  type OrgStructureChangeDetail,
+} from "../utils/orgStructureEvents";
+import { localizeOrgCommandStateError, localizeOrgStatus } from "../utils/orgStatus";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import {
   IconSend, IconPaperclip, IconMic, IconStopCircle,
@@ -73,6 +79,7 @@ import {
   loadMessagesFromStorage, saveMessagesToStorage, STORED_MESSAGE_WINDOW,
   buildChainFromSummary, buildChainFromTimeline, formatAskUserAnswer, patchMessagesWithBackend, patchMessagesWithBackendDetailed,
   chooseHydratedMessages, classifyError, formatToolDescription,
+  messageHistoryRichness,
   shouldRenderConversationMessages,
 } from "./chat/utils/chatHelpers";
 import { useMdModules } from "./chat/hooks/useMdModules";
@@ -1709,7 +1716,7 @@ export function ChatView({
   const hydrateSeqRef = useRef(0);
 
   const mapBackendHistoryToMessages = useCallback(
-    (rows: { id: string; index?: number; role: string; content: string; timestamp: number; chain_summary?: ChainSummaryItem[]; chain_timeline?: ChainTimelineGroup[]; artifacts?: ChatArtifact[]; sources?: ChatSource[]; mcp_calls?: ChatMcpCall[]; attachments?: ChatAttachment[]; org_timeline?: OrgTimelineEntry[]; ask_user?: ChatAskUser; todo?: ChatTodo; progress_events?: ChatProgressEvent[]; parts?: MessagePart[]; usage?: ChatMessage["usage"] }[]): ChatMessage[] => {
+    (rows: { id: string; index?: number; role: string; content: string; timestamp: number; chain_summary?: ChainSummaryItem[]; chain_timeline?: ChainTimelineGroup[]; artifacts?: ChatArtifact[]; sources?: ChatSource[]; mcp_calls?: ChatMcpCall[]; attachments?: ChatAttachment[]; org_timeline?: OrgTimelineEntry[]; ask_user?: ChatAskUser; error_info?: { message?: string; raw?: string; error_code?: string; org_status?: string | null }; todo?: ChatTodo; progress_events?: ChatProgressEvent[]; parts?: MessagePart[]; usage?: ChatMessage["usage"] }[]): ChatMessage[] => {
       return rows.map((m) => ({
         id: m.id,
         ...(typeof m.index === "number" ? { historyIndex: m.index } : {}),
@@ -1731,11 +1738,24 @@ export function ChatView({
         ...(m.todo?.steps?.length ? { todo: m.todo } : {}),
         ...(m.progress_events?.length ? { progressEvents: m.progress_events } : {}),
         ...(m.ask_user ? { askUser: m.ask_user, content: "" } : {}),
+        ...(m.error_info ? {
+          errorInfo: (() => {
+            const message = localizeOrgCommandStateError(t, m.error_info)
+              || m.error_info?.message
+              || "";
+            return {
+              message,
+              category: classifyError(message),
+              raw: m.error_info?.raw || m.error_info?.message,
+            } as ChatErrorInfo;
+          })(),
+          content: "",
+        } : {}),
         ...(m.parts?.length ? { parts: m.parts } : {}),
         ...(m.usage ? { usage: m.usage } : {}),
       }));
     },
-    [],
+    [t],
   );
 
   // Re-attach a still-executing plan (not yet finalized into history) to the
@@ -1787,23 +1807,11 @@ export function ChatView({
     const activeMsgs = canUseActiveMsgs
       ? latestMessagesRef.current.slice(-STORED_MESSAGE_WINDOW)
       : [];
-    const localRichness = (msgs: ChatMessage[]) => msgs.reduce((score, msg) =>
-      score +
-      (msg.todo?.steps?.length ? 1000 + msg.todo.steps.length : 0) +
-      (msg.parts?.length ? 100 + msg.parts.length : 0) +
-      (msg.progressEvents?.length ? 10 + msg.progressEvents.length : 0) +
-      (msg.thinkingChain?.length ? 50 + msg.thinkingChain.length : 0) +
-      (msg.artifacts?.length ? 20 + msg.artifacts.length : 0) +
-      (msg.attachments?.length ? 20 + msg.attachments.length : 0) +
-      (msg.askUser ? 10 : 0) +
-      (msg.streaming ? 5 : 0) +
-      Math.min(msg.content.length, 2000) / 2000,
-    0);
     const localMsgs = [storedMsgs, liveMsgs, activeMsgs].reduce((best, candidate) => {
       if (candidate.length !== best.length) {
         return candidate.length > best.length ? candidate : best;
       }
-      return localRichness(candidate) > localRichness(best) ? candidate : best;
+      return messageHistoryRichness(candidate) > messageHistoryRichness(best) ? candidate : best;
     }, [] as ChatMessage[]);
 
     // Always ask the backend when available.  A completed answer may be saved
@@ -2168,17 +2176,41 @@ export function ChatView({
     fetchProfiles();
   }, [apiBaseUrl, serviceRunning, visible]);
 
+  const fetchOrgs = useCallback(async () => {
+    try {
+      const res = await safeFetch(`${apiBaseUrl}/api/v2/orgs`);
+      const data = await res.json();
+      if (!Array.isArray(data)) return;
+      setOrgList(data.map((o: any) => ({
+        id: o.id,
+        name: o.name,
+        icon: o.icon || "",
+        status: o.status,
+      })));
+    } catch { /* ignore */ }
+  }, [apiBaseUrl]);
+
   useEffect(() => {
     if (!visible || !serviceRunning) return;
-    const fetchOrgs = async () => {
-      try {
-        const res = await safeFetch(`${apiBaseUrl}/api/v2/orgs`);
-        const data = await res.json();
-        setOrgList(data.map((o: any) => ({ id: o.id, name: o.name, icon: o.icon || "", status: o.status })));
-      } catch { /* ignore */ }
+    void fetchOrgs();
+  }, [fetchOrgs, serviceRunning, visible]);
+
+  useEffect(() => {
+    const onOrgStructureChanged = (event: Event) => {
+      const detail = normalizeOrgStructureChange(
+        (event as CustomEvent<OrgStructureChangeDetail>).detail,
+      );
+      if (!detail) return;
+      if (detail.status) {
+        setOrgList((prev) => prev.map((org) =>
+          org.id === detail.orgId ? { ...org, status: detail.status! } : org
+        ));
+      }
+      if (serviceRunning) void fetchOrgs();
     };
-    fetchOrgs();
-  }, [apiBaseUrl, serviceRunning, visible]);
+    window.addEventListener(ORG_STRUCTURE_CHANGED_EVENT, onOrgStructureChanged);
+    return () => window.removeEventListener(ORG_STRUCTURE_CHANGED_EVENT, onOrgStructureChanged);
+  }, [fetchOrgs, serviceRunning]);
 
   // Sync selectedAgent → current conversation's agentProfileId
   // Only react to selectedAgent changes (not activeConvId) to avoid overwriting
@@ -5096,13 +5128,15 @@ export function ChatView({
                 ]);
                 continue;
               }
-              case "error":
+              case "error": {
+                const localizedError = localizeOrgCommandStateError(t, event) || event.message;
                 currentError = {
-                  message: event.message,
-                  category: classifyError(event.message),
+                  message: localizedError,
+                  category: classifyError(localizedError),
                   raw: event.message,
                 };
                 break;
+              }
               case "done":
                 gracefulDone = true;
                 // Crash diagnostics: backend signalled end-of-stream. Only metadata,
@@ -7892,7 +7926,9 @@ export function ChatView({
                         >
                           <IconBuilding size={13} style={{ marginRight: 4, flexShrink: 0 }} />
                           <span style={{ fontWeight: 600 }}>{o.name}</span>
-                          <span style={{ fontSize: 11, opacity: 0.5, marginLeft: 6 }}>{o.status}</span>
+                          <span style={{ fontSize: 11, opacity: 0.5, marginLeft: 6 }}>
+                            {localizeOrgStatus(t, o.status)}
+                          </span>
                         </div>
                       ))}
                     </div>

--- a/apps/setup-center/src/views/OrgEditorView.tsx
+++ b/apps/setup-center/src/views/OrgEditorView.tsx
@@ -73,6 +73,7 @@ import { ZoomIn, ZoomOut, Maximize, X as XIcon, Copy as IconCopy } from "lucide-
 import { copyToClipboard } from "../utils/clipboard";
 import {
   ORG_STRUCTURE_CHANGED_EVENT,
+  dispatchOrgStructureChanged,
   normalizeOrgStructureChange,
   type OrgStructureChangeDetail,
 } from "../utils/orgStructureEvents";
@@ -937,6 +938,7 @@ export function OrgEditorView({
         (event as CustomEvent<OrgStructureChangeDetail>).detail,
       );
       if (!detail) return;
+      if (detail.toolUseId === "__org_editor_lifecycle__") return;
 
       void (async () => {
         await fetchOrgList();
@@ -1113,6 +1115,13 @@ export function OrgEditorView({
       await safeFetch(`${apiBaseUrl}/api/v2/orgs/${currentOrg.id}/start`, { method: "POST" });
       setCurrentOrg({ ...currentOrg, status: "active" });
       setOrgList((prev) => prev.map((o) => o.id === currentOrg.id ? { ...o, status: "active" } : o));
+      dispatchOrgStructureChanged({
+        action: "updated",
+        org_id: currentOrg.id,
+        org_name: currentOrg.name,
+        status: "active",
+        tool_use_id: "__org_editor_lifecycle__",
+      });
       const mode = (currentOrg as any).operation_mode || "command";
       showToast(
         mode === "autonomous"
@@ -1136,6 +1145,13 @@ export function OrgEditorView({
       await safeFetch(`${apiBaseUrl}/api/v2/orgs/${currentOrg.id}/stop`, { method: "POST" });
       setCurrentOrg((prev) => prev ? { ...prev, status: "dormant" } : prev);
       setOrgList((prev) => prev.map((o) => o.id === currentOrg.id ? { ...o, status: "dormant" } : o));
+      dispatchOrgStructureChanged({
+        action: "updated",
+        org_id: currentOrg.id,
+        org_name: currentOrg.name,
+        status: "dormant",
+        tool_use_id: "__org_editor_lifecycle__",
+      });
       // 不再依赖 WS：HTTP 成功立即把所有节点视觉状态清零，避免装机版 WS 被
       // CSP 拦掉时残留 CPO/PM 等"执行中"状态。
       setNodes((prev) => prev.map((n) => ({

--- a/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "../chatTypes";
+import { chooseHydratedMessages, messageHistoryRichness } from "../chatHelpers";
+
+const user: ChatMessage = {
+  id: "user-1",
+  role: "user",
+  content: "你好",
+  timestamp: 1,
+};
+
+describe("chat error hydration", () => {
+  it("prefers a finalized error card over a stale streaming placeholder", () => {
+    const streaming: ChatMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      content: "",
+      timestamp: 2,
+      streaming: true,
+    };
+    const error: ChatMessage = {
+      ...streaming,
+      streaming: false,
+      errorInfo: {
+        message: "无法下发组织指令。当前状态：休眠",
+        category: "unknown",
+      },
+    };
+
+    expect(messageHistoryRichness([user, error]))
+      .toBeGreaterThan(messageHistoryRichness([user, streaming]));
+  });
+
+  it("hydrates a persisted backend error onto the local placeholder", () => {
+    const local: ChatMessage[] = [
+      user,
+      {
+        id: "assistant-local",
+        role: "assistant",
+        content: "",
+        timestamp: 2,
+        streaming: true,
+      },
+    ];
+    const backend: ChatMessage[] = [
+      user,
+      {
+        id: "assistant-backend",
+        role: "assistant",
+        content: "",
+        timestamp: 3,
+        errorInfo: {
+          message: "无法下发组织指令。当前状态：休眠",
+          category: "unknown",
+        },
+      },
+    ];
+
+    const hydrated = chooseHydratedMessages(local, backend);
+
+    expect(hydrated[1].errorInfo?.message).toBe("无法下发组织指令。当前状态：休眠");
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/chatHelpers.ts
+++ b/apps/setup-center/src/views/chat/utils/chatHelpers.ts
@@ -408,6 +408,22 @@ export function chooseHydratedMessages(localMsgs: ChatMessage[], backendMsgs: Ch
   return backendLast && backendLast !== localLast ? backendWithLocalAttachments : cleanLocal;
 }
 
+export function messageHistoryRichness(msgs: ChatMessage[]): number {
+  return msgs.reduce((score, msg) =>
+    score +
+    (msg.todo?.steps?.length ? 1000 + msg.todo.steps.length : 0) +
+    (msg.parts?.length ? 100 + msg.parts.length : 0) +
+    (msg.progressEvents?.length ? 10 + msg.progressEvents.length : 0) +
+    (msg.thinkingChain?.length ? 50 + msg.thinkingChain.length : 0) +
+    (msg.artifacts?.length ? 20 + msg.artifacts.length : 0) +
+    (msg.attachments?.length ? 20 + msg.attachments.length : 0) +
+    (msg.errorInfo ? 20 : 0) +
+    (msg.askUser ? 10 : 0) +
+    (msg.streaming ? 5 : 0) +
+    Math.min(msg.content.length, 2000) / 2000,
+  0);
+}
+
 // ── 思维链 ──
 
 export function buildChainFromSummary(summary: ChainSummaryItem[]): ChainGroup[] {
@@ -682,6 +698,7 @@ type BackendHistoryMessage = {
   usage?: ChatMessage["usage"];
   todo?: ChatTodo | null;
   ask_user?: ChatAskUser | null;
+  errorInfo?: ChatErrorInfo | null;
   parts?: MessagePart[] | null;
 };
 
@@ -861,6 +878,10 @@ export function patchMessagesWithBackendDetailed(
       patches.askUser = m.askUser
         ? { ...m.askUser, ...backend.ask_user, answered: true, answer: backend.ask_user.answer }
         : backend.ask_user;
+    }
+
+    if (backend.errorInfo && !m.errorInfo) {
+      patches.errorInfo = backend.errorInfo;
     }
 
     // Authoritative ordered parts projection from the backend.

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -243,7 +243,12 @@ export type StreamEvent =
       messages_offset: number;
       protocol_version?: number;
     }
-  | { type: "error"; message: string }
+  | {
+      type: "error";
+      message: string;
+      error_code?: string;
+      org_status?: string | null;
+    }
   | { type: "done"; reason?: string; usage?: {
       input_tokens: number;
       output_tokens: number;

--- a/apps/setup-center/src/views/orgEditorConstants.ts
+++ b/apps/setup-center/src/views/orgEditorConstants.ts
@@ -276,18 +276,24 @@ export const STATUS_COLORS: Record<string, string> = {
   offline: "var(--muted)",
   frozen: "#93c5fd",
   dormant: "var(--muted)",
+  created: "var(--muted)",
   active: "var(--ok)",
   running: "var(--primary)",
   paused: "#f59e0b",
+  stopped: "var(--muted)",
   archived: "var(--muted)",
+  deleted: "var(--danger)",
 };
 
 export const ORG_STATUS_LABELS: Record<string, string> = {
   dormant: "org.orgStatus.dormant",
+  created: "org.orgStatus.created",
   active: "org.orgStatus.active",
   running: "org.orgStatus.running",
   paused: "org.orgStatus.paused",
+  stopped: "org.orgStatus.stopped",
   archived: "org.orgStatus.archived",
+  deleted: "org.orgStatus.deleted",
 };
 
 export const EDGE_COLORS: Record<string, string> = {

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -2297,6 +2297,32 @@ async def _stream_org_command_chat(
     _BUSY_REFRESH_INTERVAL = 60.0
     _last_busy_refresh_ts = 0.0
 
+    def _persist_org_error(message: str, *, error_code: str, org_status: str | None) -> None:
+        if session_manager is None:
+            return
+        try:
+            session = session_manager.get_session(
+                channel="desktop",
+                chat_id=conversation_id,
+                user_id="desktop_user",
+                create_if_missing=True,
+            )
+            if session is None:
+                return
+            session.add_message(
+                "assistant",
+                "",
+                error_info={
+                    "message": message,
+                    "raw": message,
+                    "error_code": error_code,
+                    "org_status": org_status,
+                },
+            )
+            session_manager.persist()
+        except Exception:
+            logger.warning("[Chat API] failed to persist org command error", exc_info=True)
+
     async def _refresh_busy_lease(*, force: bool = False) -> None:
         nonlocal _last_busy_refresh_ts
         if not conversation_id or not busy_generation:
@@ -2344,7 +2370,13 @@ async def _stream_org_command_chat(
                 session_manager.mark_dirty()
 
         if svc is None:
-            yield _sse("error", {"message": "OrgCommandService not initialized"})
+            message = "OrgCommandService not initialized"
+            _persist_org_error(
+                message,
+                error_code="org_command_service_unavailable",
+                org_status=None,
+            )
+            yield _sse("error", {"message": message})
             yield _sse("done")
             return
 
@@ -2364,7 +2396,7 @@ async def _stream_org_command_chat(
             )
 
         try:
-            started = svc.submit(
+            started = await svc.submit(
                 OrgCommandRequest(
                     org_id=org_id,
                     content=org_content,
@@ -2377,11 +2409,40 @@ async def _stream_org_command_chat(
                     ),
                     origin_surface=OrgCommandSurface.DESKTOP_CHAT,
                     output_scope=default_scope_for_surface(OrgCommandSurface.DESKTOP_CHAT),
-                    attachments=_history_attachments_from_request(chat_request.attachments),
+                    input_attachments=_history_attachments_from_request(chat_request.attachments),
                 )
             )
         except OrgCommandError as exc:
-            yield _sse("error", {"message": str(exc), "org_id": org_id})
+            error_code = getattr(exc, "error_code", "org_command_error")
+            org_status = getattr(exc, "org_status", None)
+            _persist_org_error(
+                str(exc),
+                error_code=error_code,
+                org_status=org_status,
+            )
+            yield _sse(
+                "error",
+                {
+                    "message": str(exc),
+                    "org_id": org_id,
+                    "error_code": error_code,
+                    "org_status": org_status,
+                },
+            )
+            yield _sse("done")
+            return
+        except Exception:
+            logger.exception("[Chat API] failed to submit org command (org=%s)", org_id)
+            message = "组织命令提交失败，请重试。"
+            _persist_org_error(
+                message,
+                error_code="org_command_submit_failed",
+                org_status=None,
+            )
+            yield _sse(
+                "error",
+                {"message": message, "org_id": org_id},
+            )
             yield _sse("done")
             return
 
@@ -2433,7 +2494,13 @@ async def _stream_org_command_chat(
                 error = item.get("error")
                 attachments: list[dict] = []
                 if isinstance(result, dict):
-                    final_text = str(result.get("result") or result.get("error") or "")
+                    final_text = str(
+                        result.get("result")
+                        or result.get("deliverable")
+                        or result.get("final_message")
+                        or result.get("error")
+                        or ""
+                    )
                     raw_attachments = result.get("file_attachments") or []
                     if isinstance(raw_attachments, list):
                         attachments = [a for a in raw_attachments if isinstance(a, dict)]

--- a/src/openakita/api/routes/orgs_v2_runtime_dispatch.py
+++ b/src/openakita/api/routes/orgs_v2_runtime_dispatch.py
@@ -293,9 +293,10 @@ async def send_command(request: Request, org_id: str, body: CommandSubmit) -> di
         raise HTTPException(
             getattr(exc, "status_code", 409),
             {
-                "code": "org_command_conflict",
+                "code": getattr(exc, "error_code", "org_command_conflict"),
                 "message": str(exc),
                 "command_id": getattr(exc, "command_id", None),
+                "org_status": getattr(exc, "org_status", None),
             },
         ) from exc
     except OrgCommandError as exc:

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -441,6 +441,9 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     ask_user = msg.get("ask_user")
     if ask_user:
         entry["ask_user"] = ask_user
+    error_info = msg.get("error_info")
+    if isinstance(error_info, dict):
+        entry["error_info"] = error_info
     usage = msg.get("usage")
     if isinstance(usage, dict) and (usage.get("input_tokens") or usage.get("output_tokens")):
         entry["usage"] = usage

--- a/src/openakita/orgs/command_models.py
+++ b/src/openakita/orgs/command_models.py
@@ -94,9 +94,18 @@ class OrgCommandConflict(OrgCommandError):
 
     status_code: int = 409
 
-    def __init__(self, message: str, *, command_id: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        command_id: str,
+        error_code: str = "org_command_conflict",
+        org_status: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.command_id = command_id
+        self.error_code = error_code
+        self.org_status = org_status
 
 
 # ---------------------------------------------------------------------------

--- a/src/openakita/orgs/command_service.py
+++ b/src/openakita/orgs/command_service.py
@@ -399,6 +399,7 @@ class OrgCommandService:
                 ]
             ],
         ] = {}
+        self._summary_terminal_published: set[str] = set()
         # Per-command outcome cache populated by event-bus subscriptions
         # so ``get_status`` and the background supervisor finaliser can
         # reflect the real ``agent_run_failed`` / ``agent_run_finished``
@@ -464,6 +465,13 @@ class OrgCommandService:
         "agent_run_failed",
         "agent_run_cancelled",
     )
+    _SUMMARY_PROGRESS_EVENT_NAMES: tuple[str, ...] = (
+        "agent_run_started",
+        "subtask_assigned",
+        "agent_run_finished",
+        "node_review_passed",
+        "node_review_failed",
+    )
 
     def _wire_event_bus(self, event_bus: Any) -> None:
         """Subscribe :meth:`_handle_agent_event` to the executor's events.
@@ -497,6 +505,75 @@ class OrgCommandService:
                     "[OrgCmd] failed to subscribe to event %r; reconciliation degraded",
                     name,
                 )
+        for name in self._SUMMARY_PROGRESS_EVENT_NAMES:
+            try:
+                subscribe(name, self._make_summary_progress_handler(name))
+            except Exception:  # noqa: BLE001 -- progress is best-effort
+                logger.exception(
+                    "[OrgCmd] failed to subscribe to progress event %r",
+                    name,
+                )
+
+    def _make_summary_progress_handler(self, event_name: str) -> Any:
+        async def _h(payload: dict[str, Any]) -> None:
+            await self._publish_summary_progress(event_name, payload)
+
+        return _h
+
+    def _summary_node_label(self, org_id: str, node_id: str) -> str:
+        if not node_id:
+            return "组织节点"
+        try:
+            org = self._lookup.get_org(org_id)
+            node = org.get_node(node_id) if org is not None else None
+            role = str(getattr(node, "role_title", "") or "").strip()
+            if role:
+                return role
+        except Exception:  # noqa: BLE001 -- labels must not block progress
+            pass
+        return node_id
+
+    async def _publish_summary_progress(
+        self, event_name: str, payload: dict[str, Any]
+    ) -> None:
+        if not isinstance(payload, dict):
+            return
+        command_id = str(payload.get("command_id") or "")
+        cmd = self._commands.get(command_id)
+        if not cmd or cmd.get("status") != "running":
+            return
+        org_id = str(cmd.get("org_id") or payload.get("org_id") or "")
+        node_id = str(payload.get("node_id") or "")
+        parent_id = str(payload.get("parent_node_id") or "")
+        child_id = str(payload.get("child_node_id") or "")
+        node_label = self._summary_node_label(org_id, node_id)
+        summaries = {
+            "agent_run_started": f"{node_label} 开始处理任务",
+            "agent_run_finished": f"{node_label} 已完成阶段性工作",
+            "node_review_passed": f"{node_label} 的阶段产出已通过审核",
+            "node_review_failed": f"{node_label} 的阶段产出需要返工",
+        }
+        if event_name == "subtask_assigned":
+            parent_label = self._summary_node_label(org_id, parent_id)
+            child_label = self._summary_node_label(org_id, child_id)
+            summary = f"{parent_label} 已将任务分派给 {child_label}"
+            progress_node_id = child_id
+        else:
+            summary = summaries.get(event_name)
+            progress_node_id = node_id
+        if not summary:
+            return
+        await self.publish_summary(
+            command_id,
+            {
+                "type": "org_progress",
+                "org_id": org_id,
+                "command_id": command_id,
+                "node_id": progress_node_id,
+                "category": event_name,
+                "summary": summary,
+            },
+        )
 
     def _make_event_handler(self, event_name: str) -> Any:
         """Return a sync ``(payload) -> None`` closure that forwards
@@ -1098,19 +1175,7 @@ class OrgCommandService:
         # here as an idempotent fallback: when the cooperative drain DID reflect
         # the outcome, ``emit_command_done``'s per-command guard dedupes this to
         # a no-op; otherwise this is the only terminal event the cancel produces.
-        emit_done = getattr(self._runtime, "emit_command_done", None)
-        if callable(emit_done):
-            try:
-                await emit_done(
-                    org_id,
-                    command_id,
-                    status="cancelled",
-                    result=(self._commands.get(command_id) or {}).get("result"),
-                )
-            except Exception:  # noqa: BLE001 -- terminal emit must not break cancel
-                logger.debug(
-                    "[OrgCmd] emit_command_done on cancel failed", exc_info=True
-                )
+        await self._publish_terminal_events(command_id)
         return {
             "ok": True,
             "command_id": command_id,
@@ -1309,6 +1374,10 @@ class OrgCommandService:
                     cid,
                     exc_info=True,
                 )
+        await asyncio.gather(
+            *(self._publish_terminal_events(cid) for cid in cids),
+            return_exceptions=True,
+        )
         return cids
 
     # ------------------------------------------------------------------
@@ -1668,15 +1737,21 @@ class OrgCommandService:
             raise OrgCommandConflict(
                 "组织当前已暂停，请先恢复组织后再下发指令。",
                 command_id="",
+                error_code="org_not_runnable",
+                org_status=status_value,
             )
         if status_value == "archived":
             raise OrgCommandConflict(
                 "组织已归档，无法下发指令。",
                 command_id="",
+                error_code="org_not_runnable",
+                org_status=status_value,
             )
         raise OrgCommandConflict(
             f"组织尚未启动。当前状态: {status_value}",
             command_id="",
+            error_code="org_not_runnable",
+            org_status=status_value,
         )
 
     def _resolve_command_root_id(self, org, target_node_id: str | None) -> str:  # noqa: ANN001
@@ -2076,6 +2151,7 @@ class OrgCommandService:
                     supervisor_n_replans=cancel_n_replans,
                     supervisor_last_checkpoint_id=cancel_cp,
                 )
+                await asyncio.shield(self._publish_terminal_events(command_id))
                 raise
             except TimeoutError:
                 # test16 clobber fix: the hard ceiling fired.
@@ -2099,6 +2175,7 @@ class OrgCommandService:
                         error="supervisor hard ceiling exceeded",
                         finished_at=time.time(),
                     )
+                    await self._publish_terminal_events(command_id)
             except Exception as exc:  # noqa: BLE001 -- last-resort guardrail
                 logger.exception(
                     "[OrgCmd] supervisor.run raised for cid=%s", command_id
@@ -2115,7 +2192,10 @@ class OrgCommandService:
                     str(cmd_for_bridge.get("org_id") or request.org_id),
                     cmd_for_bridge.get("target_node_id") or request.target_node_id,
                     {"error": str(exc)},
+                    source=cmd_for_bridge.get("source"),
+                    origin_surface=cmd_for_bridge.get("origin_surface"),
                 )
+                await self._publish_terminal_events(command_id)
             finally:
                 self._active_supervisors.pop(command_id, None)
                 root_key = (request.org_id, root_node_id)
@@ -2857,36 +2937,18 @@ class OrgCommandService:
         except Exception:  # noqa: BLE001
             pass
 
-        # Item 2: route the terminal state through the event bus so a
-        # ``command_done`` event is persisted (events.jsonl) + streamed (SSE) +
-        # WS-broadcast, instead of only being discoverable by polling. Best
-        # effort + idempotent (the runtime dedupes per command_id). We schedule
-        # it because ``_reflect_supervisor_outcome`` is sync but always runs
-        # inside the supervisor task's event loop.
+        # Route the terminal state to both consumers: the runtime event bus
+        # powers the organization workspace, while the summary queue powers
+        # desktop chat and IM request streams. These are intentionally separate
+        # transports, so completing only the runtime side leaves chat waiting
+        # forever on ``subscribe_summary``.
         try:
-            emit_done = getattr(self._runtime, "emit_command_done", None)
-            if callable(emit_done) and oid_for_done:
-                cmd_final = self._commands.get(command_id) or {}
-                done_result = cmd_final.get("result")
-                done_error = cmd_final.get("error")
-                done_status = cmd_final.get("status") or status
-                import asyncio as _asyncio
-
-                try:
-                    loop = _asyncio.get_running_loop()
-                    loop.create_task(
-                        emit_done(
-                            oid_for_done,
-                            command_id,
-                            status=done_status,
-                            result=done_result,
-                            error=done_error,
-                        )
-                    )
-                except RuntimeError:
-                    # No running loop (sync test context): skip live emit; the
-                    # polling fallback still surfaces the terminal state.
-                    pass
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._publish_terminal_events(command_id))
+        except RuntimeError:
+            # No running loop (sync test context): polling and late-subscriber
+            # replay still expose the terminal command state.
+            pass
         except Exception:  # noqa: BLE001
             pass
 
@@ -2898,6 +2960,8 @@ class OrgCommandService:
                 "result": deliverable or final_msg,
                 "error": error,
             },
+            source=cmd_for_bridge.get("source"),
+            origin_surface=cmd_for_bridge.get("origin_surface"),
         )
 
     # ------------------------------------------------------------------
@@ -2937,11 +3001,19 @@ class OrgCommandService:
         org_id: str,
         target_node_id: str | None,
         result: dict[str, Any],
+        *,
+        source: dict[str, Any] | None = None,
+        origin_surface: str | None = None,
     ) -> None:
         sm = self._session_manager
         if not sm or not org_id:
             return
-        chat_id = self.bridge_session_chat_id(org_id, target_node_id)
+        source = source if isinstance(source, dict) else {}
+        source_chat_id = str(source.get("chat_id") or "").strip()
+        if origin_surface == "desktop_chat" and source_chat_id:
+            chat_id = source_chat_id
+        else:
+            chat_id = self.bridge_session_chat_id(org_id, target_node_id)
         try:
             session = sm.get_session(
                 channel="desktop",
@@ -2958,7 +3030,11 @@ class OrgCommandService:
                 if isinstance(text, dict):
                     text = text.get("result") or text.get("error") or str(text)
                 session.add_message("assistant", str(text))
-            sm.mark_dirty()
+            persist = getattr(sm, "persist", None)
+            if callable(persist):
+                persist()
+            else:
+                sm.mark_dirty()
         except Exception as exc:
             logger.warning("[OrgCmd] failed to persist result to session: %s", exc)
 
@@ -3017,6 +3093,57 @@ class OrgCommandService:
     # ------------------------------------------------------------------
     # Fan-out / observability
     # ------------------------------------------------------------------
+
+    async def _publish_terminal_events(self, command_id: str) -> None:
+        """Publish one command terminal to runtime and waiting summary streams."""
+        cmd = self._commands.get(command_id)
+        if not cmd:
+            return
+        status = str(cmd.get("status") or "")
+        if status not in {"done", "partial", "error", "cancelled"}:
+            return
+
+        org_id = str(cmd.get("org_id") or "")
+        emit_done = getattr(self._runtime, "emit_command_done", None)
+        if callable(emit_done) and org_id:
+            try:
+                await emit_done(
+                    org_id,
+                    command_id,
+                    status=status,
+                    result=cmd.get("result"),
+                    error=cmd.get("error"),
+                )
+            except Exception:  # noqa: BLE001 -- one transport must not block the other
+                logger.debug(
+                    "[OrgCmd] runtime terminal emit failed for cid=%s",
+                    command_id,
+                    exc_info=True,
+                )
+
+        if command_id in self._summary_terminal_published:
+            return
+        self._summary_terminal_published.add(command_id)
+        event: dict[str, Any] = {
+            "type": "org_command_done",
+            "org_id": org_id,
+            "command_id": command_id,
+        }
+        if status in {"done", "partial"}:
+            event["result"] = cmd.get("result")
+        else:
+            if status == "cancelled":
+                cancelled_by = (self._command_outcomes.get(command_id) or {}).get(
+                    "cancelled_by"
+                )
+                event["error"] = (
+                    "组织已停止，当前任务已取消。"
+                    if cancelled_by == "stop_org"
+                    else "组织命令已取消。"
+                )
+            else:
+                event["error"] = cmd.get("error") or "Command failed"
+        await self.publish_summary(command_id, event)
 
     def subscribe_summary(
         self,

--- a/src/openakita/orgs/runtime.py
+++ b/src/openakita/orgs/runtime.py
@@ -1564,6 +1564,7 @@ class OrgRuntime:
         # 图3 final-PDF: schedule the render of the FINAL root deliverable (only
         # on a successful convergence) before the project-store guard below, so
         # the pdf is produced even in setups without a project store wired.
+        rec = None
         if command_id:
             store = getattr(self, "_root_final_artifact", None)
             # Always pop (cleanup) so a cancelled/errored command can't leak the
@@ -1607,14 +1608,25 @@ class OrgRuntime:
                 return
             from .project_models import TaskStatus
 
-            ps.update_task(
-                pid,
-                tid,
-                {
-                    "status": TaskStatus.DELIVERED if ok else TaskStatus.REJECTED,
-                    "progress_pct": 100 if ok else 0,
-                },
-            )
+            updates: dict[str, Any] = {
+                "status": TaskStatus.DELIVERED if ok else TaskStatus.REJECTED,
+                "progress_pct": 100 if ok else 0,
+            }
+            if ok and rec:
+                _, final_path = rec
+                final_file = Path(str(final_path))
+                try:
+                    final_size = final_file.stat().st_size
+                except OSError:
+                    final_size = 0
+                updates["file_attachments"] = [
+                    {
+                        "filename": final_file.name,
+                        "file_path": str(final_file),
+                        "file_size": final_size,
+                    }
+                ]
+            ps.update_task(pid, tid, updates)
         except Exception:  # noqa: BLE001
             _LOGGER.debug("contract: finalize_command_project failed", exc_info=True)
 
@@ -1876,6 +1888,7 @@ class OrgRuntime:
         # to the flat node-based mapping below.
         chain_id = payload.get("chain_id") or None
         parent_chain_id = payload.get("parent_chain_id") or None
+        command_id = str(payload.get("command_id") or "")
         ev_depth = int(payload.get("depth") or 0)
         try:
             # P3 (黑板=全组织实时分级日志): publish a live, tier-aware process
@@ -1993,6 +2006,15 @@ class OrgRuntime:
                                 t
                                 for t in ps.all_tasks(assignee=node_id)
                                 if t.get("status") == "in_progress"
+                                # The submit-time command task is closed only by
+                                # finalize_command_project(). A root node can
+                                # finish several supervisor turns before the
+                                # command converges, so node-based fallback must
+                                # not mistake a stage result for final delivery.
+                                and (
+                                    not command_id
+                                    or str(t.get("chain_id") or "") != command_id
+                                )
                             ]
                         if open_tasks:
                             t = open_tasks[-1]

--- a/tests/api/contracts/test_orgs_v2_contracts_dispatch.py
+++ b/tests/api/contracts/test_orgs_v2_contracts_dispatch.py
@@ -17,9 +17,7 @@ from unittest.mock import MagicMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-
-from tests.api.contracts.conftest import _async_return, _async_raise
-
+from tests.api.contracts.conftest import _async_raise, _async_return
 
 # ---------------------------------------------------------------------------
 # B34-B37: lifecycle verbs
@@ -141,6 +139,28 @@ def test_b38_submit_command_409_on_conflict(mint_app: FastAPI, mint_client: Test
     assert resp.status_code == 409
     detail = resp.json()["detail"]
     assert detail["code"] == "org_command_conflict"
+
+
+def test_b38_submit_command_preserves_non_runnable_status(
+    mint_app: FastAPI, mint_client: TestClient
+) -> None:
+    from openakita.orgs import OrgCommandConflict
+
+    err = OrgCommandConflict(
+        "not started",
+        command_id="",
+        error_code="org_not_runnable",
+        org_status="dormant",
+    )
+    mint_app.state.org_command_service.submit = _async_raise(err)
+    resp = mint_client.post("/api/v2/orgs/o1/command", json={"content": "hi"})
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == {
+        "code": "org_not_runnable",
+        "message": "not started",
+        "command_id": "",
+        "org_status": "dormant",
+    }
 
 
 def test_b38_submit_command_400_on_command_error(

--- a/tests/runtime/orgs/test_cancel_propagation.py
+++ b/tests/runtime/orgs/test_cancel_propagation.py
@@ -624,6 +624,9 @@ async def test_cancel_emits_terminal_command_done_event() -> None:
     svc = OrgCommandService(rt, supervisor_factory=_factory)
     res = await svc.submit(OrgCommandRequest(org_id="o1", content="cancel done"))
     cid = res["command_id"]
+    summary_queue = svc.subscribe_summary(
+        cid, surface="desktop_chat", target="conversation-1"
+    )
     await asyncio.wait_for(deliver.entered.wait(), timeout=2.0)
 
     cancel_res = await svc.cancel(org_id="o1", command_id=cid, reason="user_cancel")
@@ -635,6 +638,9 @@ async def test_cancel_emits_terminal_command_done_event() -> None:
     assert call.args[0] == "o1"
     assert call.args[1] == cid
     assert call.kwargs.get("status") == "cancelled"
+    terminal = await asyncio.wait_for(summary_queue.get(), timeout=0.5)
+    assert terminal["type"] == "org_command_done"
+    assert terminal["error"] == "组织命令已取消。"
 
     task = svc._inflight_tasks.get(cid)
     if task is not None:

--- a/tests/runtime/orgs/test_command_project_progress.py
+++ b/tests/runtime/orgs/test_command_project_progress.py
@@ -1,0 +1,138 @@
+"""Regression coverage for command-level project task completion."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from openakita.orgs.runtime import OrgRuntime
+
+
+class _ProjectStore:
+    def __init__(self, tasks: list[dict[str, Any]]) -> None:
+        self.tasks = tasks
+
+    def all_tasks(
+        self, *, chain_id: str | None = None, assignee: str | None = None
+    ) -> list[dict[str, Any]]:
+        return [
+            task
+            for task in self.tasks
+            if (chain_id is None or task.get("chain_id") == chain_id)
+            and (assignee is None or task.get("assignee_node_id") == assignee)
+        ]
+
+    def update_task(self, project_id: str, task_id: str, updates: dict[str, Any]) -> None:
+        task = next(task for task in self.tasks if task["id"] == task_id)
+        task.update(updates)
+
+    def find_task_by_chain(self, chain_id: str) -> dict[str, Any] | None:
+        return next(
+            (task for task in self.tasks if task.get("chain_id") == chain_id),
+            None,
+        )
+
+
+class _ProjectRegistry:
+    def __init__(self, store: _ProjectStore) -> None:
+        self.store = store
+
+    def for_org(self, org_id: str) -> _ProjectStore:
+        return self.store
+
+
+@pytest.mark.asyncio
+async def test_stage_finish_does_not_close_command_level_root_task() -> None:
+    command_task = {
+        "id": "task-command",
+        "project_id": "project-1",
+        "chain_id": "cmd-1",
+        "assignee_node_id": "root-1",
+        "status": "in_progress",
+        "progress_pct": 0,
+    }
+    store = _ProjectStore([command_task])
+    runtime = object.__new__(OrgRuntime)
+    runtime._contract_project_store = _ProjectRegistry(store)
+    runtime._contract_blackboard = None
+
+    await runtime._contract_event_tap(
+        "agent_run_finished",
+        {
+            "org_id": "org-1",
+            "command_id": "cmd-1",
+            "node_id": "root-1",
+            "chain_id": "turn-chain-1",
+            "output_len": 100,
+        },
+    )
+
+    assert command_task["status"] == "in_progress"
+    assert command_task["progress_pct"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stage_finish_still_closes_matching_non_command_task() -> None:
+    child_task = {
+        "id": "task-child",
+        "project_id": "project-1",
+        "chain_id": "child-chain",
+        "assignee_node_id": "child-1",
+        "status": "in_progress",
+        "progress_pct": 0,
+    }
+    store = _ProjectStore([child_task])
+    runtime = object.__new__(OrgRuntime)
+    runtime._contract_project_store = _ProjectRegistry(store)
+    runtime._contract_blackboard = None
+
+    await runtime._contract_event_tap(
+        "agent_run_finished",
+        {
+            "org_id": "org-1",
+            "command_id": "cmd-1",
+            "node_id": "child-1",
+            "output_len": 100,
+        },
+    )
+
+    assert str(child_task["status"]) == "delivered"
+    assert child_task["progress_pct"] == 100
+
+
+@pytest.mark.asyncio
+async def test_command_terminal_closes_root_task_with_final_artifact(tmp_path) -> None:
+    final_file = tmp_path / "final.md"
+    final_file.write_text("final result", encoding="utf-8")
+    command_task = {
+        "id": "task-command",
+        "project_id": "project-1",
+        "chain_id": "cmd-1",
+        "assignee_node_id": "root-1",
+        "status": "in_progress",
+        "progress_pct": 0,
+    }
+    store = _ProjectStore([command_task])
+    runtime = object.__new__(OrgRuntime)
+    runtime._contract_project_store = _ProjectRegistry(store)
+    runtime._root_final_artifact = {"cmd-1": ("root-1", str(final_file))}
+
+    async def _render(**kwargs: Any) -> None:
+        return None
+
+    runtime._maybe_render_root_pdf = _render
+
+    runtime.finalize_command_project("org-1", "cmd-1", ok=True)
+    await asyncio.sleep(0)
+
+    assert str(command_task["status"]) == "delivered"
+    assert command_task["progress_pct"] == 100
+    assert command_task["file_attachments"] == [
+        {
+            "filename": "final.md",
+            "file_path": str(final_file),
+            "file_size": len("final result"),
+        }
+    ]

--- a/tests/runtime/orgs/test_command_service_contract.py
+++ b/tests/runtime/orgs/test_command_service_contract.py
@@ -41,6 +41,7 @@ from openakita.orgs.command_models import (
     OrgCommandConflict,
     OrgCommandError,
     OrgCommandRequest,
+    OrgCommandSource,
     OrgCommandSurface,
     OrgOutputScope,
 )
@@ -163,11 +164,16 @@ async def test_submit_rejects_missing_target_node() -> None:
         await svc.submit(OrgCommandRequest(org_id="o1", content="x", target_node_id="nope"))
 
 
+@pytest.mark.parametrize(
+    "status", ["dormant", "created", "paused", "stopped", "archived", "deleted"]
+)
 @pytest.mark.asyncio
-async def test_submit_rejects_paused_org() -> None:
-    svc = _make_service(_make_runtime(org=_Org(status="paused")))
-    with pytest.raises(OrgCommandConflict):
+async def test_submit_rejects_non_runnable_org_with_structured_status(status: str) -> None:
+    svc = _make_service(_make_runtime(org=_Org(status=status)))
+    with pytest.raises(OrgCommandConflict) as exc_info:
         await svc.submit(OrgCommandRequest(org_id="o1", content="x"))
+    assert exc_info.value.error_code == "org_not_runnable"
+    assert exc_info.value.org_status == status
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +311,98 @@ async def test_subscribe_then_publish_delivers_event_and_records_target() -> Non
         "event": "org_progress",
         "ts": delivered[-1]["ts"],
     }
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_publish_progress_to_waiting_chat_subscriber() -> None:
+    subscriptions: dict[str, list[Any]] = {}
+    event_bus = MagicMock()
+    event_bus.subscribe.side_effect = (
+        lambda name, handler: subscriptions.setdefault(name, []).append(handler)
+    )
+    svc = _make_service(_make_runtime(send_hang=True), event_bus=event_bus)
+    res = await svc.submit(
+        OrgCommandRequest(
+            org_id="o1",
+            content="x",
+            source=OrgCommandSource(chat_id="conversation_1"),
+            origin_surface=OrgCommandSurface.DESKTOP_CHAT,
+            output_scope=OrgOutputScope.CHAT_SUMMARY,
+        )
+    )
+    q = svc.subscribe_summary(
+        res["command_id"], surface="desktop_chat", target="conversation_1"
+    )
+
+    handler = subscriptions["subtask_assigned"][0]
+    await handler(
+        {
+            "org_id": "o1",
+            "command_id": res["command_id"],
+            "parent_node_id": "root1",
+            "child_node_id": "child1",
+        }
+    )
+
+    event = await asyncio.wait_for(q.get(), timeout=0.1)
+    assert event["type"] == "org_progress"
+    assert event["node_id"] == "child1"
+    assert event["category"] == "subtask_assigned"
+    assert event["summary"] == "root1 已将任务分派给 child1"
+
+
+@pytest.mark.asyncio
+async def test_terminal_publish_reaches_waiting_desktop_chat_subscriber() -> None:
+    rt = _make_runtime(send_hang=True)
+    svc = _make_service(rt)
+    res = await svc.submit(
+        OrgCommandRequest(
+            org_id="o1",
+            content="x",
+            source=OrgCommandSource(chat_id="conversation_1"),
+            origin_surface=OrgCommandSurface.DESKTOP_CHAT,
+            output_scope=OrgOutputScope.CHAT_SUMMARY,
+        )
+    )
+    q = svc.subscribe_summary(
+        res["command_id"], surface="desktop_chat", target="conversation_1"
+    )
+    svc._update_command_state(
+        res["command_id"],
+        status="done",
+        phase="done",
+        result={"deliverable": "final answer"},
+    )
+
+    await svc._publish_terminal_events(res["command_id"])
+
+    event = await asyncio.wait_for(q.get(), timeout=0.1)
+    assert event == {
+        "type": "org_command_done",
+        "org_id": "o1",
+        "command_id": res["command_id"],
+        "result": {"deliverable": "final answer"},
+    }
+
+
+def test_desktop_chat_result_persists_to_source_conversation() -> None:
+    session = MagicMock()
+    manager = MagicMock()
+    manager.get_session.return_value = session
+    manager.persist = MagicMock()
+    svc = _make_service(session_manager=manager)
+
+    svc._bridge_persist_result(
+        "o1",
+        None,
+        {"result": "final answer"},
+        source={"channel": "desktop", "chat_id": "conversation_1"},
+        origin_surface="desktop_chat",
+    )
+
+    assert manager.get_session.call_args.kwargs["chat_id"] == "conversation_1"
+    session.add_message.assert_called_once_with("assistant", "final answer")
+    manager.persist.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/orgs/test_supervisor_hard_ceiling.py
+++ b/tests/runtime/orgs/test_supervisor_hard_ceiling.py
@@ -232,13 +232,20 @@ async def test_hard_ceiling_disabled_when_setting_is_zero(monkeypatch) -> None:
     svc = OrgCommandService(_make_runtime(), supervisor_factory=_factory)
     res = await svc.submit(OrgCommandRequest(org_id="o1", content="hi"))
     cid = res["command_id"]
+    summary_queue = svc.subscribe_summary(
+        cid, surface="desktop_chat", target="conversation_1"
+    )
     task = svc._inflight_tasks.get(cid)
     assert task is not None
     await asyncio.wait_for(task, timeout=2.0)
+    terminal = await asyncio.wait_for(summary_queue.get(), timeout=0.5)
 
     status = svc.get_status("o1", cid)
     assert status is not None
     assert status["status"] == "done"
+    assert terminal["type"] == "org_command_done"
+    assert terminal["command_id"] == cid
+    assert terminal["result"]["final_message"] == "ok"
     # The cancel token must NOT have been touched on the happy path.
     assert not quick.cancel_token.is_cancelled()
 

--- a/tests/runtime/orgs/test_supervisor_http_takeover.py
+++ b/tests/runtime/orgs/test_supervisor_http_takeover.py
@@ -45,7 +45,6 @@ from openakita.orgs.command_service import OrgCommandService
 from openakita.runtime.cancel_token import CancellationToken
 from openakita.runtime.supervisor import FinalOutcome, SupervisorOutcome
 
-
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
@@ -123,7 +122,7 @@ class _FakeSupervisor:
             reason="",
         )
 
-    async def resume_from_checkpoint(self, checkpoint_id: str) -> "_FakeSupervisor":
+    async def resume_from_checkpoint(self, checkpoint_id: str) -> _FakeSupervisor:
         self.resume_calls.append(checkpoint_id)
         return self
 
@@ -315,6 +314,10 @@ async def test_cancel_all_for_org_cancels_every_supervisor() -> None:
     await asyncio.sleep(0.05)
     cid1, cid2 = r1["command_id"], r2["command_id"]
     assert {cid1, cid2} <= set(svc._inflight_by_org.get("o1", set()))
+    queues = {
+        cid: svc.subscribe_summary(cid, surface="desktop_chat", target=f"chat-{cid}")
+        for cid in (cid1, cid2)
+    }
 
     cancelled = await svc.cancel_all_for_org("o1", reason="stop_org")
     assert set(cancelled) == {cid1, cid2}
@@ -333,3 +336,6 @@ async def test_cancel_all_for_org_cancels_every_supervisor() -> None:
     for cid in (cid1, cid2):
         outcome = svc._command_outcomes.get(cid) or {}
         assert outcome.get("cancelled_by") == "stop_org"
+        terminal = await asyncio.wait_for(queues[cid].get(), timeout=0.5)
+        assert terminal["type"] == "org_command_done"
+        assert terminal["error"] == "组织已停止，当前任务已取消。"

--- a/tests/unit/test_chat_org_command_stream.py
+++ b/tests/unit/test_chat_org_command_stream.py
@@ -1,0 +1,197 @@
+"""Regression coverage for organization commands sent from desktop chat."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from openakita.api.routes.chat import _stream_org_command_chat
+from openakita.api.routes.sessions import _history_entry
+from openakita.api.schemas import AttachmentInfo, ChatRequest
+from openakita.orgs.command_models import OrgCommandConflict
+
+
+def _decode_sse(raw: str) -> dict[str, Any]:
+    assert raw.startswith("data: ")
+    return json.loads(raw.removeprefix("data: ").strip())
+
+
+class _CommandService:
+    def __init__(self, *, submit_error: Exception | None = None) -> None:
+        self.request = None
+        self.submit_error = submit_error
+
+    async def submit(self, request):
+        self.request = request
+        if self.submit_error is not None:
+            raise self.submit_error
+        return {"command_id": "cmd_1", "status": "running", "root_node_id": "root_1"}
+
+    def subscribe_summary(self, command_id: str, *, surface: str, target: str):
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "command_id": command_id,
+                "result": {"deliverable": "组织任务完成"},
+            }
+        )
+        return queue
+
+    def unsubscribe_summary(self, command_id: str, queue) -> None:
+        return None
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, dict[str, Any]]] = []
+        self.last_active = datetime.now()
+
+    def add_message(self, role: str, content: str, **metadata) -> None:
+        self.messages.append((role, content, metadata))
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        return None
+
+
+class _SessionManager:
+    def __init__(self) -> None:
+        self.session = _Session()
+        self.dirty = False
+        self.persisted = False
+
+    def get_session(self, **kwargs):
+        return self.session
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    def persist(self) -> None:
+        self.persisted = True
+
+
+async def _collect(
+    service: _CommandService,
+    body: ChatRequest,
+    *,
+    session_manager: _SessionManager | None = None,
+) -> list[dict[str, Any]]:
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                org_command_service=service,
+                session_manager=session_manager,
+            )
+        )
+    )
+    return [
+        _decode_sse(event)
+        async for event in _stream_org_command_chat(
+            body,
+            request=request,
+            conversation_id="conversation_1",
+            client_id="",
+            busy_generation=0,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_org_chat_awaits_submit_and_forwards_input_attachments() -> None:
+    service = _CommandService()
+    body = ChatRequest(
+        message="开始创作",
+        org_mode=True,
+        org_id="org_1",
+        attachments=[AttachmentInfo(type="file", name="brief.txt", local_path="C:\\brief.txt")],
+    )
+
+    events = await _collect(service, body)
+
+    assert service.request is not None
+    assert service.request.org_id == "org_1"
+    assert service.request.content == "开始创作"
+    assert service.request.input_attachments == [
+        {
+            "type": "file",
+            "name": "brief.txt",
+            "localPath": "C:\\brief.txt",
+            "uploadStatus": "uploaded",
+        }
+    ]
+    assert [event["type"] for event in events] == [
+        "org_command_started",
+        "org_command_done",
+        "text_replace",
+        "done",
+    ]
+    assert events[2]["content"] == "组织任务完成"
+
+
+@pytest.mark.asyncio
+async def test_org_chat_surfaces_unexpected_submit_errors() -> None:
+    service = _CommandService(submit_error=TypeError("request contract drift"))
+    body = ChatRequest(message="开始创作", org_mode=True, org_id="org_1")
+
+    session_manager = _SessionManager()
+    events = await _collect(service, body, session_manager=session_manager)
+
+    assert [event["type"] for event in events] == ["error", "done"]
+    assert events[0]["message"] == "组织命令提交失败，请重试。"
+    assert session_manager.persisted is True
+    assert session_manager.session.messages[-1][2]["error_info"]["error_code"] == (
+        "org_command_submit_failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_org_chat_exposes_non_runnable_status_for_localization() -> None:
+    error = OrgCommandConflict(
+        "组织尚未启动。当前状态: dormant",
+        command_id="",
+        error_code="org_not_runnable",
+        org_status="dormant",
+    )
+    service = _CommandService(submit_error=error)
+    body = ChatRequest(message="开始创作", org_mode=True, org_id="org_1")
+
+    session_manager = _SessionManager()
+    events = await _collect(service, body, session_manager=session_manager)
+
+    assert events[0]["type"] == "error"
+    assert events[0]["error_code"] == "org_not_runnable"
+    assert events[0]["org_status"] == "dormant"
+    assert session_manager.persisted is True
+    role, content, metadata = session_manager.session.messages[-1]
+    assert role == "assistant"
+    assert content == ""
+    assert metadata["error_info"] == {
+        "message": "组织尚未启动。当前状态: dormant",
+        "raw": "组织尚未启动。当前状态: dormant",
+        "error_code": "org_not_runnable",
+        "org_status": "dormant",
+    }
+
+
+def test_session_history_serializes_persisted_org_error() -> None:
+    session = _Session()
+    error_info = {
+        "message": "组织尚未启动。当前状态: dormant",
+        "raw": "组织尚未启动。当前状态: dormant",
+        "error_code": "org_not_runnable",
+        "org_status": "dormant",
+    }
+
+    entry = _history_entry(
+        session,
+        "conversation_1",
+        1,
+        {"role": "assistant", "content": "", "error_info": error_info},
+    )
+
+    assert entry["error_info"] == error_info

--- a/tests/unit/test_chat_view_session_isolation.py
+++ b/tests/unit/test_chat_view_session_isolation.py
@@ -102,7 +102,9 @@ def test_hydration_treats_attachments_as_structured_history():
     chat_source = CHAT_VIEW.read_text(encoding="utf-8")
     helper_source = CHAT_HELPERS.read_text(encoding="utf-8")
 
-    assert "msg.attachments?.length ? 20 + msg.attachments.length : 0" in chat_source
+    assert "export function messageHistoryRichness" in helper_source
+    assert "msg.attachments?.length ? 20 + msg.attachments.length : 0" in helper_source
+    assert "messageHistoryRichness(candidate) > messageHistoryRichness(best)" in chat_source
     assert "function attachmentSignature" in helper_source
     assert "attachmentSignature(msg.attachments)" in helper_source
     assert "attachmentSignature(prev.attachments) === attachmentSignature(msg.attachments)" in helper_source


### PR DESCRIPTION
## Summary

- deliver organization command progress, terminal results, errors, and cancellations reliably to desktop chat
- persist organization replies to the originating conversation and prevent stage completion from prematurely finishing command-level project tasks
- localize organization statuses and synchronize lifecycle changes between orchestration and chat views

## Tests

- `uv run --no-sync pytest tests/runtime/orgs/test_cancel_propagation.py tests/runtime/orgs/test_supervisor_http_takeover.py tests/runtime/orgs/test_command_service_contract.py tests/runtime/orgs/test_command_project_progress.py tests/runtime/orgs/test_command_done_event.py tests/runtime/orgs/test_supervisor_hard_ceiling.py tests/unit/test_chat_org_command_stream.py tests/integration/test_gateway_org_control.py -q`
- `uv run --no-sync ruff check ...`
- `npx vitest run src/utils/__tests__/orgStructureEvents.test.ts src/utils/__tests__/orgStatus.test.ts src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts`
- `npx tsc -b --pretty false`

Fixes #748
