### PR TITLE
prevent inline image payloads from exhausting chat context and replaying stale answers

### DIFF
--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -389,10 +389,19 @@ _PREVIOUS_ANSWER_REPLAY_HINT = (
 )
 
 
-def _looks_like_previous_answer_replay_request(message: str, history_messages: list[dict]) -> bool:
+def _looks_like_previous_answer_replay_request(
+    message: str,
+    history_messages: list[dict],
+    *,
+    has_new_objects: bool = False,
+) -> bool:
     """Whether a follow-up asks to show the previous answer fully, not redo the task."""
     text = (message or "").strip()
-    if not text or not any(msg.get("role") == "assistant" for msg in history_messages):
+    if (
+        not text
+        or has_new_objects
+        or not any(msg.get("role") == "assistant" for msg in history_messages)
+    ):
         return False
 
     normalized = re.sub(r"\s+", "", text).lower()
@@ -5431,15 +5440,6 @@ class Agent:
             f"{len(messages)} history msgs, has_history={_has_history}"
         )
 
-        if isinstance(compiled_message, str) and _looks_like_previous_answer_replay_request(
-            message, messages
-        ):
-            compiled_message = _apply_previous_answer_replay_hint(compiled_message)
-            logger.info(
-                "[Session:%s] Previous-answer replay hint applied for follow-up request",
-                session_id,
-            )
-
         # 当前用户消息（支持多模态）
         pending_images = session.get_metadata("pending_images") if session else None
         pending_videos = session.get_metadata("pending_videos") if session else None
@@ -5453,6 +5453,18 @@ class Agent:
             attachments=attachments,
         )
         self._current_turn_has_media_attachments = turn_has_media
+
+        if isinstance(compiled_message, str) and _looks_like_previous_answer_replay_request(
+            message,
+            messages,
+            has_new_objects=turn_has_media,
+        ):
+            compiled_message = _apply_previous_answer_replay_hint(compiled_message)
+            logger.info(
+                "[Session:%s] Previous-answer replay hint applied for follow-up request",
+                session_id,
+            )
+
         from .current_turn import CurrentTurnInput, SessionObjectRegistry
 
         current_turn = CurrentTurnInput.from_inputs(

--- a/src/openakita/core/current_turn.py
+++ b/src/openakita/core/current_turn.py
@@ -111,10 +111,11 @@ class SessionObjectRegistry:
 
         self.turn_index += 1
         for obj in turn.iter_current_objects():
+            value = _registry_value(obj)
             stamped = TurnObject(
                 kind=obj.kind,
-                value=obj.value,
-                label=obj.label,
+                value=value,
+                label=obj.label or value,
                 mime_type=obj.mime_type,
                 source_turn=self.turn_index,
             )
@@ -136,8 +137,8 @@ class SessionObjectRegistry:
             "objects": [
                 {
                     "kind": obj.kind,
-                    "value": obj.value,
-                    "label": obj.label,
+                    "value": _registry_value(obj),
+                    "label": obj.label or _registry_value(obj),
                     "mime_type": obj.mime_type,
                     "source_turn": obj.source_turn,
                 }
@@ -161,11 +162,14 @@ class SessionObjectRegistry:
             kind = str(raw.get("kind") or "")
             if not value or not kind:
                 continue
+            label = str(raw.get("label") or "")
+            if _is_data_uri(value):
+                value = label or f"inline {kind}"
             objects.append(
                 TurnObject(
                     kind=kind,
                     value=value,
-                    label=str(raw.get("label") or ""),
+                    label=label or value,
                     mime_type=str(raw.get("mime_type") or ""),
                     source_turn=_safe_int(raw.get("source_turn")),
                 )
@@ -652,6 +656,8 @@ def _normalize_url(url: str) -> str:
 
 def _normalize_ref(value: str) -> str:
     raw = (value or "").strip()
+    if _is_data_uri(raw):
+        return raw
     if raw.startswith(("http://", "https://")):
         return _normalize_url(raw)
     try:
@@ -661,9 +667,22 @@ def _normalize_ref(value: str) -> str:
 
 
 def _display_obj(obj: TurnObject) -> str:
+    if _is_data_uri(obj.value):
+        return obj.label or f"inline {obj.kind}"
     if obj.label and obj.label != obj.value:
         return f"{obj.label} ({obj.value})"
     return obj.value
+
+
+def _registry_value(obj: TurnObject) -> str:
+    """Keep inline payloads out of session metadata and follow-up prompts."""
+    if _is_data_uri(obj.value):
+        return obj.label or f"inline {obj.kind}"
+    return obj.value
+
+
+def _is_data_uri(value: str) -> bool:
+    return (value or "").lstrip().lower().startswith("data:")
 
 
 def _is_error_result(result: Any) -> bool:

--- a/tests/unit/test_current_turn_grounding.py
+++ b/tests/unit/test_current_turn_grounding.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from openakita.core.current_turn import CurrentTurnInput, SessionObjectRegistry
 from openakita.agent.tools import ToolExecutor
+from openakita.core.current_turn import CurrentTurnInput, SessionObjectRegistry
 from openakita.tools.handlers import SystemHandlerRegistry
 
 
@@ -160,6 +160,73 @@ def test_prompt_block_lists_current_objects(tmp_path: Path):
     assert "当前轮输入对象" in prompt
     assert "https://example.com/a" in prompt
     assert "current.png" in prompt
+
+
+def test_prompt_block_omits_inline_image_data_uri():
+    encoded = "a" * 100_000
+    data_uri = f"data:image/png;base64,{encoded}"
+    turn = CurrentTurnInput.from_inputs(
+        "分析这张图",
+        pending_images=[
+            {
+                "url": data_uri,
+                "filename": "current.png",
+                "mime_type": "image/png",
+            }
+        ],
+    )
+
+    prompt = turn.prompt_block()
+
+    assert turn.images[0].value == data_uri
+    assert "current.png" in prompt
+    assert "data:image" not in prompt
+    assert encoded not in prompt
+    assert len(prompt) < 1_000
+
+
+def test_registry_does_not_serialize_inline_image_data_uri():
+    encoded = "a" * 100_000
+    registry = SessionObjectRegistry()
+    registry.register_turn(
+        CurrentTurnInput.from_inputs(
+            "分析这张图",
+            pending_images=[
+                {
+                    "url": f"data:image/png;base64,{encoded}",
+                    "filename": "current.png",
+                    "mime_type": "image/png",
+                }
+            ],
+        )
+    )
+
+    state = registry.to_dict()
+
+    assert state["objects"][0]["value"] == "current.png"
+    assert "data:image" not in str(state)
+    assert encoded not in str(state)
+
+
+def test_registry_sanitizes_legacy_inline_image_data_uri_on_restore():
+    encoded = "a" * 100_000
+
+    registry = SessionObjectRegistry.from_dict(
+        {
+            "objects": [
+                {
+                    "kind": "image",
+                    "value": f"data:image/png;base64,{encoded}",
+                    "label": "legacy.png",
+                    "mime_type": "image/png",
+                }
+            ]
+        }
+    )
+
+    assert registry.objects[0].value == "legacy.png"
+    assert "data:image" not in str(registry.to_dict())
+    assert encoded not in str(registry.to_dict())
 
 
 def test_inject_preserves_latest_message_marker():

--- a/tests/unit/test_intent_prompt_contract.py
+++ b/tests/unit/test_intent_prompt_contract.py
@@ -306,6 +306,19 @@ def test_previous_answer_replay_request_does_not_match_reanalysis_requests():
     assert not _looks_like_previous_answer_replay_request("你的完整报告并没有展示完全", [])
 
 
+def test_previous_answer_replay_request_does_not_match_turn_with_new_attachments():
+    history = [
+        {"role": "user", "content": "分析上一批图片"},
+        {"role": "assistant", "content": "上一批图片的分析结果"},
+    ]
+
+    assert not _looks_like_previous_answer_replay_request(
+        "请读取我新上传的图片并输出完整内容",
+        history,
+        has_new_objects=True,
+    )
+
+
 def test_previous_answer_replay_hint_preserves_original_user_request():
     prompted = _apply_previous_answer_replay_hint("你的完整报告并没有展示完全")
 


### PR DESCRIPTION
## Summary

- Keep inline attachment data URIs out of current-turn prompts and persisted session object registries.
- Skip previous-answer replay when the current chat turn contains newly uploaded attachments.

## Tests

- `pytest -q tests/unit/test_current_turn_grounding.py tests/unit/test_intent_prompt_contract.py tests/unit/test_context_manager_media_truncation.py tests/unit/test_desktop_attachment_reference.py tests/unit/test_reasoning_engine_user_handoff.py -k "not action_completion_claim_without_tools"`
- `ruff check src/openakita/core/current_turn.py src/openakita/core/_agent_legacy.py tests/unit/test_current_turn_grounding.py tests/unit/test_intent_prompt_contract.py`

Fixes #548
