### PR TITLE
remove implicit text cancellation from organization node routing

### DIFF
--- a/src/openakita/orgs/__init__.py
+++ b/src/openakita/orgs/__init__.py
@@ -97,19 +97,19 @@
   ``llm_usage`` events through the bus.
 - P9.6g ships :class:`NodeStatusController` +
   :class:`NodeMessageRouter` + ``format_incoming_message``
-  + ``is_stop_intent`` in ``_runtime_node_lifecycle.py``
+  in ``_runtime_node_lifecycle.py``
   (~330 LOC). Lifts v1 ``_on_node_message`` (175 LOC) +
   ``_format_incoming_message`` (96 LOC) +
   ``_drain_node_pending`` (86 LOC) + ``_post_task_hook``
   (81 LOC) + ``_set_node_status`` / ``set_node_status`` /
   ``_mark_effective_action`` / ``_try_route_to_clone`` /
   ``_make_message_handler`` / ``_register_clone_in_messenger``
-  / ``_on_inbound_for_node`` / ``_is_stop_intent``
+  / ``_on_inbound_for_node``
   / ``evict_node_agent`` / ``_connect_node_mcp_servers``
-  (~600 v1 LOC) into two focused classes + 4
+  (~600 v1 LOC) into two focused classes + 3
   ``STATUS_*`` constants. Routes inbound messages through
-  stop-intent detection, busy-queueing, agent pipeline
-  delivery, and post-task hook orchestration.
+  busy-queueing, agent pipeline delivery, and post-task hook
+  orchestration. Cancellation uses the explicit command API.
 - P9.6h1 ships :class:`PluginAssetRecorder` +
   :class:`ToolHandlerBridge` + :class:`PluginAsset`
   dataclass + helpers (``safe_asset_filename`` /
@@ -187,11 +187,9 @@ from ._runtime_node_lifecycle import (
     STATUS_BUSY,
     STATUS_ERROR,
     STATUS_IDLE,
-    STATUS_STOPPED,
     NodeMessageRouter,
     NodeStatusController,
     format_incoming_message,
-    is_stop_intent,
 )
 from ._runtime_plugin_assets import (
     FileOutput,
@@ -403,7 +401,6 @@ __all__ = [
     "STATUS_BUSY",
     "STATUS_ERROR",
     "STATUS_IDLE",
-    "STATUS_STOPPED",
     "ScheduleStore",
     "ScheduleType",
     "SchedulerRuntimeProbe",
@@ -441,7 +438,6 @@ __all__ = [
     "get_runtime",
     "infer_agent_profile_id_for_node",
     "is_plugin_tool",
-    "is_stop_intent",
     "list_avatar_presets",
     "new_command_id",
     "new_org_id",

--- a/src/openakita/orgs/_runtime_node_lifecycle.py
+++ b/src/openakita/orgs/_runtime_node_lifecycle.py
@@ -12,7 +12,7 @@ routing / status machine / pending-drain plumbing out of v1
   post-task hook orchestration.
 * :class:`NodeMessageRouter` -- inbound message routing
   (clone, format, deliver to the agent pipeline) +
-  per-channel inbox handlers + stop-intent detection.
+  per-channel inbox handlers.
 
 Both compose against :class:`AgentPipelineExecutor` (P9.6f)
 + :class:`CommandDispatchManager` (P9.6e) + the
@@ -40,28 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 # pipeline + the cancel paths.
 STATUS_IDLE = "idle"
 STATUS_BUSY = "busy"
-STATUS_STOPPED = "stopped"
 STATUS_ERROR = "error"
-
-# Stop-intent phrases v1 ``_is_stop_intent`` checked.
-_STOP_PHRASES: tuple[str, ...] = (
-    "/stop",
-    "/cancel",
-    "stop",
-    "cancel",
-    "abort",
-    "停止",  # zh: tingzhi (stop)
-    "取消",  # zh: quxiao (cancel)
-)
-
-
-def is_stop_intent(content: str) -> bool:
-    """v1 ``_is_stop_intent`` parity -- best-effort phrase match."""
-
-    if not content:
-        return False
-    lowered = content.strip().lower()
-    return any(p in lowered for p in _STOP_PHRASES)
 
 
 def format_incoming_message(
@@ -265,15 +244,12 @@ class NodeMessageRouter:
         """v1 ``_on_inbound_for_node`` + ``_on_node_message`` happy path.
 
         Returns a v1-shaped dict:
-            {"status": "queued" | "delivered" | "stop_intent",
+            {"status": "queued" | "delivered",
              "node_id": str,
              "depth": int,
              "result": dict | None}
         """
 
-        if is_stop_intent(content):
-            self._status.set_status(org_id, node_id, STATUS_STOPPED)
-            return {"status": "stop_intent", "node_id": node_id, "depth": 0, "result": None}
         framed = format_incoming_message(
             source=source, sender=sender, content=content, metadata=metadata
         )
@@ -323,9 +299,7 @@ __all__ = [
     "STATUS_BUSY",
     "STATUS_ERROR",
     "STATUS_IDLE",
-    "STATUS_STOPPED",
     "NodeMessageRouter",
     "NodeStatusController",
     "format_incoming_message",
-    "is_stop_intent",
 ]

--- a/tests/parity/orgs/test_runtime_parity.py
+++ b/tests/parity/orgs/test_runtime_parity.py
@@ -1,7 +1,7 @@
 """Parity fixtures for v2 OrgRuntime (P-RC-9 P9.6gamma).
 
-20 parametrised cases pinning the v1 ``OrgRuntime`` observable
-contract on the v2 rewrite (``runtime/orgs/runtime.py`` +
+20 contract cases pinning retained v1 ``OrgRuntime`` behavior and deliberate
+v2 safety changes (``runtime/orgs/runtime.py`` +
 the seven sibling managers shipped across P9.6alpha-beta).
 
 Per P-RC-9-PLAN section 5.2 OrgRuntime contract: *assert
@@ -26,7 +26,7 @@ Case axes per the P9.6gamma brief:
 * 5 agent pipeline (activate_and_run happy / missing /
   paused / quota -> pause / other-error)
 * 5 node lifecycle (on_inbound delivered / queued /
-  stop_intent / format_incoming_message / drain replay)
+  control text delivery / format_incoming_message / drain replay)
 * 5 plugin assets (record_url for plugin / record_file
   digest / file_output_registered event / react_trace stats
   / TaskDeliverySynthesizer default summary)
@@ -58,7 +58,6 @@ from openakita.orgs._runtime_dispatch import (
 from openakita.orgs._runtime_node_lifecycle import (
     STATUS_BUSY,
     STATUS_IDLE,
-    STATUS_STOPPED,
     NodeMessageRouter,
     NodeStatusController,
     format_incoming_message,
@@ -365,17 +364,21 @@ def test_parity_node_on_inbound_queued_when_busy() -> None:
     assert status.pending_depth("o1", "n1") == 1
 
 
-def test_parity_node_stop_intent_short_circuits() -> None:
-    """fixture id: node.on_inbound.stop_intent"""
+def test_node_control_text_is_delivered_as_regular_content() -> None:
+    """Text cannot cancel work; callers must use the explicit command cancel API."""
     router, status, calls = _make_router()
-    out = asyncio.run(router.on_inbound(org_id="o1", node_id="n1", source="im", content="/stop"))
-    assert out == {"status": "stop_intent", "node_id": "n1", "depth": 0, "result": None}
-    # v1 parity: stop intent transitions the node to STOPPED, no delivery.
-    assert status.get_status("o1", "n1") == STATUS_STOPPED
-    assert calls == []
-    # CN parity: ``停止`` (zh: stop) also short-circuits.
-    out2 = asyncio.run(router.on_inbound(org_id="o1", node_id="n2", source="im", content="请停止"))
-    assert out2["status"] == "stop_intent"
+    first = asyncio.run(
+        router.on_inbound(org_id="o1", node_id="n1", source="im", content="/stop")
+    )
+    second = asyncio.run(
+        router.on_inbound(org_id="o1", node_id="n2", source="im", content="请停止当前任务")
+    )
+
+    assert first["status"] == "delivered"
+    assert second["status"] == "delivered"
+    assert status.get_status("o1", "n1") == STATUS_IDLE
+    assert status.get_status("o1", "n2") == STATUS_IDLE
+    assert [call[2] for call in calls] == ["[im]/stop", "[im]请停止当前任务"]
 
 
 def test_parity_node_format_incoming_message_shape() -> None:


### PR DESCRIPTION
## Summary

- Remove implicit stop-intent keyword handling from organization node routing.
- Route all text messages to the agent and reserve cancellation for the explicit command API.

## Tests

- `uv run --no-sync pytest tests/runtime/orgs/ -q` (`460 passed`)
- `uv run --no-sync pytest tests/parity/orgs/test_runtime_parity.py -q` (`20 passed`)
- `uv run --no-sync ruff check src/openakita/orgs/__init__.py src/openakita/orgs/_runtime_node_lifecycle.py tests/parity/orgs/test_runtime_parity.py`

Fixes #539
