### PR TITLE
Notify owners through IM for unattended approval requests

### DIFF
--- a/src/openakita/agent/pending_approval_notifications.py
+++ b/src/openakita/agent/pending_approval_notifications.py
@@ -1,0 +1,189 @@
+"""Proactive IM delivery for unattended approval requests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from openakita.scheduler.delivery import is_im_delivery_channel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApprovalNotificationTarget:
+    channel: str
+    chat_id: str
+    user_id: str
+    task_name: str = ""
+
+
+def build_pending_approval_event_hook(
+    *,
+    loop: asyncio.AbstractEventLoop,
+    fire_event: Callable[[str, dict[str, Any]], None],
+    notify_owner: Callable[[dict[str, Any]], Awaitable[None]],
+) -> Callable[[str, dict[str, Any]], None]:
+    """Build the Store's sync hook while keeping async IM work on the API loop."""
+
+    notification_tasks: set[asyncio.Task[None]] = set()
+
+    def _hook(event_type: str, payload: dict[str, Any]) -> None:
+        fire_event(event_type, payload)
+        if event_type != "pending_approval_created":
+            return
+
+        payload_copy = dict(payload)
+
+        def _schedule_notification() -> None:
+            task = asyncio.create_task(notify_owner(payload_copy))
+            notification_tasks.add(task)
+            task.add_done_callback(notification_tasks.discard)
+
+        try:
+            loop.call_soon_threadsafe(_schedule_notification)
+        except RuntimeError:
+            logger.debug("[PendingApprovals] API loop unavailable; skipped IM notification")
+
+    return _hook
+
+
+def resolve_approval_notification_target(
+    payload: dict[str, Any],
+    *,
+    scheduler: Any | None,
+    gateway: Any | None,
+) -> ApprovalNotificationTarget | None:
+    """Resolve only the task owner or the exact originating IM session."""
+
+    task_id = str(payload.get("task_id") or "").strip()
+    if task_id and scheduler is not None and hasattr(scheduler, "get_task"):
+        task = scheduler.get_task(task_id)
+        if task is not None:
+            channel = str(getattr(task, "channel_id", "") or "").strip()
+            chat_id = str(getattr(task, "chat_id", "") or "").strip()
+            if channel and chat_id and is_im_delivery_channel(channel):
+                return ApprovalNotificationTarget(
+                    channel=channel,
+                    chat_id=chat_id,
+                    user_id=str(getattr(task, "user_id", "") or "system"),
+                    task_name=str(getattr(task, "name", "") or ""),
+                )
+            return None
+
+    session_id = str(payload.get("session_id") or "").strip()
+    session_manager = getattr(gateway, "session_manager", None) if gateway else None
+    if session_id and session_manager is not None and hasattr(session_manager, "get_session_by_id"):
+        session = session_manager.get_session_by_id(session_id)
+        if session is not None:
+            channel = str(getattr(session, "channel", "") or "").strip()
+            chat_id = str(getattr(session, "chat_id", "") or "").strip()
+            if channel and chat_id and is_im_delivery_channel(channel):
+                return ApprovalNotificationTarget(
+                    channel=channel,
+                    chat_id=chat_id,
+                    user_id=str(getattr(session, "user_id", "") or "system"),
+                )
+
+    return None
+
+
+def format_pending_approval_notification(
+    payload: dict[str, Any], target: ApprovalNotificationTarget
+) -> str:
+    approval_id = str(payload.get("id") or "").strip()
+    tool_name = str(payload.get("tool_name") or "unknown").strip()
+    reason = str(payload.get("reason") or "owner approval required").strip()
+    task_line = f"后台任务：{target.task_name}\n" if target.task_name else ""
+    return (
+        "⚠️ **需要审批**\n\n"
+        f"{task_line}"
+        "任务已暂停，等待你确认工具调用。\n"
+        f"工具：`{tool_name}`\n"
+        f"原因：{reason}\n"
+        f"审批编号：`{approval_id}`\n\n"
+        "请在 OpenAkita 控制台的「待审批」页面批准或拒绝。"
+    )
+
+
+async def notify_pending_approval_im(
+    payload: dict[str, Any],
+    *,
+    scheduler: Any | None,
+    gateway: Any | None,
+) -> bool:
+    """Deliver one approval notification without affecting approval persistence."""
+
+    if gateway is None:
+        return False
+
+    try:
+        target = resolve_approval_notification_target(
+            payload,
+            scheduler=scheduler,
+            gateway=gateway,
+        )
+    except Exception:
+        logger.warning(
+            "[PendingApprovals] failed to resolve IM target for approval %s",
+            payload.get("id"),
+            exc_info=True,
+        )
+        return False
+    if target is None:
+        logger.info(
+            "[PendingApprovals] no owner-scoped IM target for approval %s",
+            payload.get("id"),
+        )
+        return False
+
+    text = format_pending_approval_notification(payload, target)
+    try:
+        if hasattr(gateway, "send_text_reliably"):
+            delivered = bool(
+                await gateway.send_text_reliably(
+                    channel=target.channel,
+                    chat_id=target.chat_id,
+                    text=text,
+                    user_id=target.user_id,
+                    metadata={
+                        "event": "pending_approval_created",
+                        "approval_id": str(payload.get("id") or ""),
+                    },
+                )
+            )
+        else:
+            delivered = (
+                await gateway.send(
+                    channel=target.channel,
+                    chat_id=target.chat_id,
+                    text=text,
+                    user_id=target.user_id,
+                    metadata={
+                        "event": "pending_approval_created",
+                        "approval_id": str(payload.get("id") or ""),
+                    },
+                )
+                is not None
+            )
+    except Exception:
+        logger.warning(
+            "[PendingApprovals] IM notification failed for approval %s target=%s/%s",
+            payload.get("id"),
+            target.channel,
+            target.chat_id,
+            exc_info=True,
+        )
+        return False
+
+    if not delivered:
+        logger.warning(
+            "[PendingApprovals] IM notification was not delivered for approval %s target=%s/%s",
+            payload.get("id"),
+            target.channel,
+            target.chat_id,
+        )
+    return delivered

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -1288,24 +1288,53 @@ def create_app(
 
     @app.on_event("startup")
     async def _wire_pending_approvals_sse():
-        """C9c-2: bridge PendingApprovalsStore events to WebSocket broadcast.
+        """Bridge PendingApprovalsStore events to WebSocket and owner IM delivery.
 
-        The Store is policy-loop-agnostic; we install a sync hook that does
-        ``asyncio.ensure_future(broadcast_event(...))`` on the API loop. The
-        broadcast helper itself is cross-loop safe (engine_bridge), so this
-        works regardless of which loop the Store mutation happens on.
+        The Store is policy-loop-agnostic and may call its synchronous hook from
+        another thread. WebSocket broadcast is already cross-loop safe; IM
+        delivery is scheduled onto the API loop captured during startup.
         """
         try:
+            from openakita.agent.pending_approval_notifications import (
+                build_pending_approval_event_hook,
+                notify_pending_approval_im,
+            )
             from openakita.api.routes.websocket import fire_event
             from openakita.core.pending_approvals import get_pending_approvals_store
 
-            def _hook(event_type: str, payload: dict) -> None:
-                fire_event(event_type, payload)
+            api_loop = asyncio.get_running_loop()
 
-            get_pending_approvals_store().set_event_hook(_hook)
-            logger.info("[Startup] PendingApprovals SSE hook wired")
+            async def _notify_owner(payload: dict) -> None:
+                try:
+                    from openakita.scheduler import get_active_scheduler
+
+                    active_scheduler = get_active_scheduler()
+                    if active_scheduler is None:
+                        active_scheduler = getattr(
+                            getattr(app.state, "agent", None), "task_scheduler", None
+                        )
+                    await notify_pending_approval_im(
+                        payload,
+                        scheduler=active_scheduler,
+                        gateway=getattr(app.state, "gateway", None),
+                    )
+                except Exception:
+                    logger.warning(
+                        "[PendingApprovals] unexpected IM notification failure for %s",
+                        payload.get("id"),
+                        exc_info=True,
+                    )
+
+            event_hook = build_pending_approval_event_hook(
+                loop=api_loop,
+                fire_event=fire_event,
+                notify_owner=_notify_owner,
+            )
+
+            get_pending_approvals_store().set_event_hook(event_hook)
+            logger.info("[Startup] PendingApprovals WebSocket/IM hook wired")
         except Exception as e:
-            logger.warning("[Startup] PendingApprovals SSE wire failed: %s", e)
+            logger.warning("[Startup] PendingApprovals event wire failed: %s", e)
 
         # C17 Phase B.4：把 UIConfirmBus 的 confirm_initiated /
         # confirm_revoked 广播绑到同一条 fire_event 通道，让多端 UI 共享

--- a/tests/e2e/test_natural_language_org_approval.py
+++ b/tests/e2e/test_natural_language_org_approval.py
@@ -1,0 +1,243 @@
+"""End-to-end coverage for unattended natural-language organization approval."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openakita.api.routes.pending_approvals import _resume_task
+from openakita.config import settings
+from openakita.core.agent import Agent
+from openakita.core.agent_state import AgentState
+from openakita.core.pending_approvals import (
+    get_pending_approvals_store,
+    reset_pending_approvals_store,
+)
+from openakita.core.policy_v2 import (
+    ConfirmationMode,
+    PolicyConfigV2,
+    PolicyContext,
+    ReplayAuthorization,
+    build_engine_from_config,
+    get_config_v2,
+    get_engine_v2,
+    reset_current_context,
+    set_current_context,
+    set_engine_v2,
+)
+from openakita.core.policy_v2.exceptions import DeferredApprovalRequired
+from openakita.core.reasoning_engine import ReasoningEngine
+from openakita.core.tool_executor import ToolExecutor
+from openakita.orgs.manager import OrgManager
+from openakita.orgs.store import get_default_org_manager, set_default_org_manager
+from openakita.scheduler.task import ScheduledTask, TaskStatus, TriggerType
+from openakita.tools.definitions.org_setup import ORG_SETUP_TOOLS
+from openakita.tools.handlers import SystemHandlerRegistry
+from openakita.tools.handlers.org_setup import OrgSetupHandler
+from tests.fixtures.mock_llm import MockResponse
+
+NATURAL_REQUEST = "请创建一个名为星火研发组的组织，由技术负责人带领开发工程师。"
+TASK_ID = "task-natural-language-org"
+SESSION_ID = "session-natural-language-org"
+ORG_PARAMS = {
+    "action": "create",
+    "name": "星火研发组",
+    "description": "通过自然语言请求创建的测试组织",
+    "core_business": "软件研发",
+    "nodes": [
+        {
+            "role_title": "技术负责人",
+            "level": 0,
+            "agent_profile_id": "architect",
+        },
+        {
+            "role_title": "开发工程师",
+            "level": 1,
+            "agent_profile_id": "code-assistant",
+            "parent_role_title": "技术负责人",
+        },
+    ],
+}
+
+
+def _make_agent(registry: SystemHandlerRegistry, responses: list[MockResponse]) -> Agent:
+    """Build a real Agent loop while scripting only its LLM boundary."""
+    agent = Agent.__new__(Agent)
+    agent._initialized = True
+    agent._current_session_id = None
+    agent._context = SimpleNamespace(system="")
+    agent._tools = ORG_SETUP_TOOLS
+    agent._is_sub_agent_call = False
+    agent._agent_tool_names = set()
+    agent._suppress_desktop_task_notification = True
+    agent.brain = SimpleNamespace(
+        model="test-model",
+        max_tokens=1000,
+        get_fallback_model=lambda _session_id=None: None,
+        restore_default_model=lambda **_kwargs: None,
+    )
+    agent.agent_state = AgentState()
+    agent.agent_state.begin_task(session_id=SESSION_ID, task_id=TASK_ID)
+    agent.reasoning_engine = SimpleNamespace(
+        _drain_steer_before_finish=ReasoningEngine._drain_steer_before_finish
+    )
+    agent.tool_executor = ToolExecutor(registry)
+    agent.tool_executor._agent_ref = agent
+
+    async def _passthrough_compress(messages, system_prompt=""):
+        return messages
+
+    agent._compress_context = _passthrough_compress
+    queued = iter(responses)
+
+    async def _scripted_llm(cancel_event, **kwargs):
+        response = next(queued)
+        if response.tool_calls:
+            messages = kwargs["messages"]
+            tools = kwargs["tools"]
+            assert NATURAL_REQUEST in str(messages[0]["content"])
+            assert any(tool["name"] == "setup_organization" for tool in tools)
+        return response.to_llm_response()
+
+    agent._cancellable_llm_call = _scripted_llm
+    return agent
+
+
+class _Scheduler:
+    def __init__(self, task: ScheduledTask) -> None:
+        self._tasks = {task.id: task}
+        self._lock = asyncio.Lock()
+
+    def _save_tasks(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_natural_language_org_creation_defers_then_replays_after_owner_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise request -> tool orchestration -> approval -> replay -> persistence."""
+    monkeypatch.setattr(settings, "project_root", tmp_path)
+    data_dir = settings.data_dir
+    previous_engine = get_engine_v2()
+    previous_config = get_config_v2()
+    previous_org_manager = get_default_org_manager()
+    reset_pending_approvals_store()
+    set_default_org_manager(None)
+
+    registry = SystemHandlerRegistry()
+    handler_owner = SimpleNamespace()
+    org_handler = OrgSetupHandler(handler_owner)
+    registry.register("organization", org_handler.handle)
+    config = PolicyConfigV2()
+    engine = build_engine_from_config(config, explicit_lookup=registry.get_tool_class)
+    set_engine_v2(engine, config)
+
+    unattended_context = PolicyContext(
+        session_id=SESSION_ID,
+        workspace=data_dir,
+        channel="scheduler",
+        is_owner=True,
+        is_unattended=True,
+        unattended_strategy="defer_to_owner",
+        confirmation_mode=ConfirmationMode.DEFAULT,
+        user_message=NATURAL_REQUEST,
+    )
+    token = set_current_context(unattended_context)
+
+    try:
+        first_agent = _make_agent(
+            registry,
+            [
+                MockResponse(
+                    tool_calls=[
+                        {
+                            "id": "toolu_org_create_first",
+                            "name": "setup_organization",
+                            "input": ORG_PARAMS,
+                        }
+                    ]
+                )
+            ],
+        )
+        with pytest.raises(DeferredApprovalRequired):
+            await first_agent.execute_task_from_message(NATURAL_REQUEST)
+
+        store = get_pending_approvals_store()
+        pending = store.list_active()
+        assert len(pending) == 1
+        approval = pending[0]
+        assert approval.task_id == TASK_ID
+        assert approval.tool_name == "setup_organization"
+        assert approval.params == ORG_PARAMS
+        assert approval.user_message == NATURAL_REQUEST
+        assert OrgManager(data_dir).list_orgs(include_archived=True) == []
+
+        task = ScheduledTask(
+            id=TASK_ID,
+            name="自然语言创建组织",
+            description=NATURAL_REQUEST,
+            trigger_type=TriggerType.ONCE,
+            trigger_config={"run_at": datetime.now().isoformat()},
+            prompt=NATURAL_REQUEST,
+            status=TaskStatus.AWAITING_APPROVAL,
+        )
+        scheduler = _Scheduler(task)
+        resolved = store.resolve(approval.id, decision="allow", resolved_by="owner")
+        assert resolved is not None
+        resume_result = await _resume_task(scheduler, resolved)
+        assert resume_result["task_resumed"] is True
+        assert task.status is TaskStatus.SCHEDULED
+
+        replay_payload = task.metadata["replay_authorizations"][0]
+        replay = ReplayAuthorization(**replay_payload)
+        reset_current_context(token)
+        token = set_current_context(
+            PolicyContext(
+                session_id=SESSION_ID,
+                workspace=data_dir,
+                channel="scheduler",
+                is_owner=True,
+                is_unattended=True,
+                unattended_strategy="defer_to_owner",
+                confirmation_mode=ConfirmationMode.DEFAULT,
+                user_message=NATURAL_REQUEST,
+                replay_authorizations=[replay],
+            )
+        )
+
+        replay_agent = _make_agent(
+            registry,
+            [
+                MockResponse(
+                    tool_calls=[
+                        {
+                            "id": "toolu_org_create_replay",
+                            "name": "setup_organization",
+                            "input": ORG_PARAMS,
+                        }
+                    ]
+                ),
+                MockResponse(content="## 创建结果\n\n- 星火研发组已创建完成\n- 组织包含两个角色。"),
+            ],
+        )
+        result = await replay_agent.execute_task_from_message(NATURAL_REQUEST)
+
+        assert result.success is True
+        organizations = OrgManager(data_dir).list_orgs(include_archived=True)
+        assert len(organizations) == 1
+        created = OrgManager(data_dir).get(organizations[0]["id"])
+        assert created is not None
+        assert created.name == "星火研发组"
+        assert {node.role_title for node in created.nodes} == {"技术负责人", "开发工程师"}
+        assert store.list_active() == []
+    finally:
+        reset_current_context(token)
+        reset_pending_approvals_store()
+        set_default_org_manager(previous_org_manager)
+        set_engine_v2(previous_engine, previous_config)

--- a/tests/unit/test_pending_approval_notifications.py
+++ b/tests/unit/test_pending_approval_notifications.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openakita.agent.pending_approval_notifications import (
+    build_pending_approval_event_hook,
+    notify_pending_approval_im,
+    resolve_approval_notification_target,
+)
+
+
+def _payload(**overrides):
+    payload = {
+        "id": "pa_123",
+        "task_id": "task_123",
+        "session_id": "session_123",
+        "tool_name": "setup_organization",
+        "reason": "owner approval required",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class _Scheduler:
+    def __init__(self, task=None):
+        self.task = task
+
+    def get_task(self, task_id):
+        return self.task if task_id == "task_123" else None
+
+
+class _Loop:
+    def __init__(self):
+        self.callbacks = []
+
+    def call_soon_threadsafe(self, callback):
+        self.callbacks.append(callback)
+
+
+@pytest.mark.asyncio
+async def test_event_hook_notifies_only_for_created_events():
+    loop = _Loop()
+    fired = []
+    notify_owner = AsyncMock()
+    hook = build_pending_approval_event_hook(
+        loop=loop,
+        fire_event=lambda event, payload: fired.append((event, payload)),
+        notify_owner=notify_owner,
+    )
+
+    hook("pending_approval_resolved", {"id": "pa_resolved"})
+    hook("pending_approval_created", {"id": "pa_created"})
+
+    assert [event for event, _payload in fired] == [
+        "pending_approval_resolved",
+        "pending_approval_created",
+    ]
+    assert len(loop.callbacks) == 1
+    loop.callbacks[0]()
+    await asyncio.sleep(0)
+    notify_owner.assert_awaited_once_with({"id": "pa_created"})
+
+
+def test_resolve_target_prefers_scheduled_task_owner_route():
+    task = SimpleNamespace(
+        channel_id="feishu:owner",
+        chat_id="chat-owner",
+        user_id="user-owner",
+        name="Daily research",
+    )
+    unrelated_session = SimpleNamespace(
+        channel="telegram:other",
+        chat_id="chat-other",
+        user_id="user-other",
+    )
+    gateway = SimpleNamespace(
+        session_manager=SimpleNamespace(get_session_by_id=lambda _id: unrelated_session)
+    )
+
+    target = resolve_approval_notification_target(
+        _payload(), scheduler=_Scheduler(task), gateway=gateway
+    )
+
+    assert target is not None
+    assert (target.channel, target.chat_id, target.user_id) == (
+        "feishu:owner",
+        "chat-owner",
+        "user-owner",
+    )
+    assert target.task_name == "Daily research"
+
+
+def test_resolve_target_uses_exact_origin_session_without_global_fallback():
+    session = SimpleNamespace(
+        channel="telegram:owner",
+        chat_id="chat-owner",
+        user_id="user-owner",
+    )
+    session_manager = SimpleNamespace(
+        get_session_by_id=lambda session_id: session if session_id == "session_123" else None
+    )
+    gateway = SimpleNamespace(session_manager=session_manager)
+
+    target = resolve_approval_notification_target(
+        _payload(task_id=None), scheduler=_Scheduler(), gateway=gateway
+    )
+
+    assert target is not None
+    assert (target.channel, target.chat_id) == ("telegram:owner", "chat-owner")
+
+
+def test_resolve_target_rejects_desktop_and_missing_owner_routes():
+    task = SimpleNamespace(
+        channel_id="desktop",
+        chat_id="conversation-1",
+        user_id="user-owner",
+        name="Desktop task",
+    )
+    unrelated_session = SimpleNamespace(
+        channel="telegram:other",
+        chat_id="chat-other",
+        user_id="user-other",
+    )
+    gateway = SimpleNamespace(
+        session_manager=SimpleNamespace(get_session_by_id=lambda _id: unrelated_session)
+    )
+
+    target = resolve_approval_notification_target(
+        _payload(), scheduler=_Scheduler(task), gateway=gateway
+    )
+
+    assert target is None
+
+
+@pytest.mark.asyncio
+async def test_notify_sends_redacted_message_to_owner_route():
+    task = SimpleNamespace(
+        channel_id="feishu:owner",
+        chat_id="chat-owner",
+        user_id="user-owner",
+        name="Daily research",
+    )
+    gateway = SimpleNamespace(
+        session_manager=None,
+        send_text_reliably=AsyncMock(return_value=True),
+    )
+    payload = _payload(params={"secret": "must-not-leak"})
+
+    delivered = await notify_pending_approval_im(
+        payload, scheduler=_Scheduler(task), gateway=gateway
+    )
+
+    assert delivered is True
+    kwargs = gateway.send_text_reliably.await_args.kwargs
+    assert kwargs["channel"] == "feishu:owner"
+    assert kwargs["chat_id"] == "chat-owner"
+    assert kwargs["user_id"] == "user-owner"
+    assert "Daily research" in kwargs["text"]
+    assert "setup_organization" in kwargs["text"]
+    assert "pa_123" in kwargs["text"]
+    assert "must-not-leak" not in kwargs["text"]
+    assert kwargs["metadata"]["approval_id"] == "pa_123"
+
+
+@pytest.mark.asyncio
+async def test_notify_failure_isolated_from_approval_creation():
+    task = SimpleNamespace(
+        channel_id="telegram:owner",
+        chat_id="chat-owner",
+        user_id="user-owner",
+        name="Task",
+    )
+    gateway = SimpleNamespace(
+        session_manager=None,
+        send_text_reliably=AsyncMock(side_effect=RuntimeError("offline")),
+    )
+
+    delivered = await notify_pending_approval_im(
+        _payload(), scheduler=_Scheduler(task), gateway=gateway
+    )
+
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_notify_target_resolution_failure_isolated_from_approval_creation():
+    def fail_get_task(_task_id):
+        raise RuntimeError("bad")
+
+    scheduler = SimpleNamespace(get_task=fail_get_task)
+    gateway = SimpleNamespace(
+        session_manager=None,
+        send_text_reliably=AsyncMock(return_value=True),
+    )
+
+    delivered = await notify_pending_approval_im(_payload(), scheduler=scheduler, gateway=gateway)
+
+    assert delivered is False
+    gateway.send_text_reliably.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Proactively notify the exact scheduled-task owner or originating IM session when an unattended tool call is waiting for approval.
- Keep approval persistence independent from IM delivery failures and avoid exposing tool parameters in notifications.
- Cover the natural-language organization request, RiskGate deferral, owner approval, replay authorization, and real organization creation flow end to end.

## Tests

- `uv run --no-sync ruff check tests/e2e/test_natural_language_org_approval.py`
- `uv run --no-sync ruff format --check tests/e2e/test_natural_language_org_approval.py`
- `uv run --no-sync pytest -q tests/e2e/test_natural_language_org_approval.py tests/unit/test_pending_approvals_store.py tests/unit/test_org_setup_tool.py tests/unit/test_classifier_completeness.py tests/unit/test_pending_approval_notifications.py` (`117 passed`)

Closes #460
