### PR TITLE
prevent same-version release artifacts from replacing packaged fixes

### DIFF
--- a/.github/actions/desktop-build-prepare/action.yml
+++ b/.github/actions/desktop-build-prepare/action.yml
@@ -131,7 +131,10 @@ runs:
 
     - name: Package Python backend (PyInstaller)
       shell: bash
-      run: python build/build_backend.py
+      run: |
+        set -euo pipefail
+        export OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"
+        python build/build_backend.py
 
     - name: Read bootstrap pins (PBS / uv version)
       id: bootstrap_pins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,11 +430,14 @@ jobs:
           cp -r dist/openakita-server "$RESOURCE_DIR/openakita-server"
 
       - name: Verify bundled Python contract (seed packaged)
-        run: >
-          python build/verify_bundled_python_contract.py
-          --backend-dir apps/setup-center/src-tauri/resources/openakita-server
-          --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json
-          --require-seed-packaged
+        shell: bash
+        run: |
+          python build/verify_bundled_python_contract.py \
+            --backend-dir apps/setup-center/src-tauri/resources/openakita-server \
+            --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json \
+            --require-seed-packaged \
+            --expected-git-hash "$(git rev-parse HEAD)" \
+            --check-chat-api
 
       - name: Create gitignored placeholders
         run: |

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -14,10 +14,43 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   RELEASE_TAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
+  CHECKOUT_REF: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
+
+concurrency:
+  group: mobile-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  release_contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Verify immutable mobile assets and tag provenance
+        if: startsWith(env.RELEASE_TAG, 'v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          python scripts/release_contract.py
+          --repo "${{ github.repository }}"
+          --tag "${{ env.RELEASE_TAG }}"
+          --expected-commit "$(git rev-parse HEAD)"
+          --asset-name "OpenAkita-${{ env.RELEASE_TAG }}-android.apk"
+          --asset-name "OpenAkita-${{ env.RELEASE_TAG }}-ios.ipa"
+          --require-release
+          --wait-seconds 180
+
   # ── Android APK ──
   android:
+    needs: [release_contract]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,6 +59,8 @@ jobs:
         working-directory: apps/setup-center
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - uses: actions/setup-node@v6
         with:
@@ -113,10 +148,11 @@ jobs:
           APK="${{ steps.find_apk.outputs.apk_path }}"
           BASENAME="OpenAkita-${{ env.RELEASE_TAG }}-android.apk"
           cp "$APK" "$BASENAME"
-          gh release upload "${{ env.RELEASE_TAG }}" "$BASENAME" --clobber || true
+          gh release upload "${{ env.RELEASE_TAG }}" "$BASENAME"
 
   # ── iOS IPA ──
   ios:
+    needs: [release_contract]
     runs-on: macos-15
     permissions:
       contents: write
@@ -125,6 +161,8 @@ jobs:
         working-directory: apps/setup-center
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - uses: actions/setup-node@v6
         with:
@@ -305,10 +343,8 @@ jobs:
           IPA=$(find $RUNNER_TEMP/ipa -name '*.ipa' | head -1)
           BASENAME="OpenAkita-${{ env.RELEASE_TAG }}-ios.ipa"
           cp "$IPA" "$BASENAME"
-          gh release upload "${{ env.RELEASE_TAG }}" "$BASENAME" --clobber || true
+          gh release upload "${{ env.RELEASE_TAG }}" "$BASENAME"
 
       - name: Clean up keychain
         if: always()
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
-
-

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -202,11 +202,14 @@ jobs:
           du -sh "$RESOURCE_DIR"/*
 
       - name: Verify bundled Python contract (seed packaged)
-        run: >
-          python build/verify_bundled_python_contract.py
-          --backend-dir apps/setup-center/src-tauri/resources/openakita-server
-          --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json
-          --require-seed-packaged
+        shell: bash
+        run: |
+          python build/verify_bundled_python_contract.py \
+            --backend-dir apps/setup-center/src-tauri/resources/openakita-server \
+            --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json \
+            --require-seed-packaged \
+            --expected-git-hash "$(git rev-parse HEAD)" \
+            --check-chat-api
 
       - name: Codesign embedded binaries for macOS notarization
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ env:
   RELEASE_TAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
   CHECKOUT_REF: ${{ (github.event_name == 'workflow_dispatch' && inputs.ref != '' && inputs.ref) || (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
 
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   # ── Job 0: Bootstrap contract 预检（廉价 HEAD 检查 + 版本一致性） ──
   # 在任何下载/打包之前先确保 PBS / uv 远端 URL + pyproject.toml 与 PBS pin
@@ -33,6 +37,8 @@ jobs:
   bootstrap_contract:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,11 +49,25 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Verify immutable release and tag provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          python scripts/release_contract.py
+          --repo "${{ github.repository }}"
+          --tag "${{ env.RELEASE_TAG }}"
+          --expected-commit "$(git rev-parse HEAD)"
+
+      - name: Verify version matches release tag
+        shell: bash
+        run: python scripts/version.py check --expected "${RELEASE_TAG#v}"
+
       - name: Verify remote bootstrap asset URLs + version pins
         run: python build/prepare_bootstrap_resources.py --verify-remote-assets
 
   # ── Job 1: 确保 Draft Release 存在（仅首次创建，重新打包时跳过） ──
   create_release:
+    needs: [bootstrap_contract]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -66,7 +86,7 @@ jobs:
         run: |
           if gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Release ${{ env.RELEASE_TAG }} already exists — will upload new artifacts to it"
+            echo "Release ${{ env.RELEASE_TAG }} already exists and passed the empty-asset contract"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "📦 Release ${{ env.RELEASE_TAG }} does not exist — will create draft"
@@ -144,8 +164,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ env.RELEASE_TAG }}" dist/* --clobber
-          gh release upload "${{ env.RELEASE_TAG }}" dist-sdk/* --clobber
+          gh release upload "${{ env.RELEASE_TAG }}" dist/*
+          gh release upload "${{ env.RELEASE_TAG }}" dist-sdk/*
 
       # 必须先发 Plugin SDK 再发 main package：
       # main 的 [plugins]/[all] extras 依赖 openakita-plugin-sdk>=X，
@@ -362,11 +382,14 @@ jobs:
           du -sh "$RESOURCE_DIR"/*
 
       - name: Verify bundled Python contract (seed packaged)
-        run: >
-          python build/verify_bundled_python_contract.py
-          --backend-dir apps/setup-center/src-tauri/resources/openakita-server
-          --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json
-          --require-seed-packaged
+        shell: bash
+        run: |
+          python build/verify_bundled_python_contract.py \
+            --backend-dir apps/setup-center/src-tauri/resources/openakita-server \
+            --bootstrap-manifest apps/setup-center/src-tauri/resources/bootstrap/manifest.json \
+            --require-seed-packaged \
+            --expected-git-hash "$(git rev-parse HEAD)" \
+            --check-chat-api
 
       - name: Codesign embedded binaries for macOS notarization
         if: runner.os == 'macOS'
@@ -1367,7 +1390,7 @@ jobs:
           fi
           OUT_DIR="${BUNDLE_DIR}/_upload"
           ls -la "${OUT_DIR}"
-          gh release upload "${RELEASE_TAG}" "${OUT_DIR}"/* --clobber
+          gh release upload "${RELEASE_TAG}" "${OUT_DIR}"/*
 
       - name: Upload signature files as artifacts
         if: always()

--- a/build/openakita.spec
+++ b/build/openakita.spec
@@ -7,9 +7,11 @@ Usage:
 """
 
 import os
-import sys
 import shutil
+import sys
 from pathlib import Path
+
+from PyInstaller.building.datastruct import Tree
 from PyInstaller.utils.hooks import collect_submodules
 
 # Project root directory
@@ -530,8 +532,7 @@ else:
 # in _internal/openakita/
 _openakita_src = SRC_DIR / "openakita"
 if _openakita_src.exists():
-    datas.append((str(_openakita_src), "openakita"))
-    print(f"[spec] Bundling openakita source: {_openakita_src}")
+    print(f"[spec] Will bundle openakita source without build-owned version metadata: {_openakita_src}")
 
 # Provider list (single source of truth, shared by frontend and backend)
 # Must be bundled to openakita/llm/registries/ directory, Python reads via Path(__file__).parent
@@ -737,6 +738,17 @@ a = Analysis(
     excludes=excludes,
     noarchive=False,
 )
+
+# Add importable source for bridge subprocesses, but keep the build-owned
+# VERSION+commit file as the sole _bundled_version.txt provider. Supplying the
+# source directory and generated file to the same destination made PyInstaller's
+# winner platform-dependent and allowed Linux artifacts to lose the commit hash.
+if _openakita_src.exists():
+    a.datas += Tree(
+        str(_openakita_src),
+        prefix="openakita",
+        excludes=["_bundled_version.txt"],
+    )
 
 pyz = PYZ(a.pure)
 

--- a/build/verify_bundled_python_contract.py
+++ b/build/verify_bundled_python_contract.py
@@ -15,14 +15,21 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 def _bundled_python_env(internal_dir: Path) -> dict:
     """Build environment dict for invoking standalone _internal/python.exe."""
     env = dict(os.environ)
-    for key in ("PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP",
-                "VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV"):
+    for key in (
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+        "VIRTUAL_ENV",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
+    ):
         env.pop(key, None)
 
     # NOTE: When python3XX._pth exists (created by build_backend.py), Python
@@ -59,6 +66,53 @@ def _major_minor(version: str) -> str:
     return f"{match.group(1)}.{match.group(2)}"
 
 
+def _verify_build_identity(version_file: Path, expected_git_hash: str) -> str:
+    if not version_file.is_file():
+        raise RuntimeError(f"bundled version file missing: {version_file}")
+    version = version_file.read_text(encoding="utf-8").strip()
+    if "+" not in version:
+        raise RuntimeError(f"bundled version does not include a git hash: {version!r}")
+    _, bundled_hash = version.rsplit("+", 1)
+    expected = expected_git_hash.strip().lower()[:7]
+    if not expected or bundled_hash.lower() != expected:
+        raise RuntimeError(
+            f"bundled git hash {bundled_hash!r} does not match build commit {expected!r}"
+        )
+    return version
+
+
+def _run_bundled_chat_smoke(internal_dir: Path) -> None:
+    smoke_script = Path(__file__).parents[1] / "scripts" / "package_chat_smoke.py"
+    if not smoke_script.is_file():
+        raise RuntimeError(f"bundled chat smoke script missing: {smoke_script}")
+    with tempfile.TemporaryDirectory(prefix="openakita-package-smoke-") as temp_root:
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENAKITA_ROOT": temp_root,
+                "OPENAKITA_USER_WORKSPACE": temp_root,
+                "LOG_FORMAT": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                "FEISHU_ENABLED": "false",
+                "QQBOT_ENABLED": "false",
+                "TELEGRAM_ENABLED": "false",
+                "DINGTALK_ENABLED": "false",
+                "WEWORK_ENABLED": "false",
+            }
+        )
+        result = subprocess.run(
+            [sys.executable, str(smoke_script), "--internal-dir", str(internal_dir)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            cwd=temp_root,
+        )
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(f"bundled /api/chat smoke failed: {details[:2000]}")
+    print((result.stdout or "").strip())
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Verify bundled Python contract")
     parser.add_argument(
@@ -81,6 +135,16 @@ def main() -> int:
             "Use in CI/release packaging path."
         ),
     )
+    parser.add_argument(
+        "--expected-git-hash",
+        default="",
+        help="Require openakita/_bundled_version.txt to contain this build commit hash",
+    )
+    parser.add_argument(
+        "--check-chat-api",
+        action="store_true",
+        help="Run a minimal POST /api/chat against the Python source copied into the bundle",
+    )
     args = parser.parse_args()
 
     backend_dir = Path(args.backend_dir).resolve()
@@ -95,6 +159,24 @@ def main() -> int:
     print(f"[OK] backend executable: {exe}")
 
     internal = backend_dir / "_internal"
+    if args.expected_git_hash:
+        try:
+            bundled_identity = _verify_build_identity(
+                internal / "openakita" / "_bundled_version.txt",
+                args.expected_git_hash,
+            )
+        except RuntimeError as exc:
+            print(f"[ERROR] {exc}")
+            return 1
+        print(f"[OK] bundled build identity: {bundled_identity}")
+
+    if args.check_chat_api:
+        try:
+            _run_bundled_chat_smoke(internal)
+        except RuntimeError as exc:
+            print(f"[ERROR] {exc}")
+            return 1
+
     if sys.platform == "win32":
         candidates = [internal / "python.exe"]
     else:
@@ -131,7 +213,11 @@ def main() -> int:
     print(f"[OK] bundled pip check passed (pip {pip_ver})")
 
     version_check = subprocess.run(
-        [str(py), "-c", "import platform,sysconfig; print(platform.python_version()); print(sysconfig.get_config_var('SOABI') or '')"],
+        [
+            str(py),
+            "-c",
+            "import platform,sysconfig; print(platform.python_version()); print(sysconfig.get_config_var('SOABI') or '')",
+        ],
         capture_output=True,
         text=True,
         timeout=20,
@@ -251,12 +337,16 @@ def main() -> int:
                 print(f"[OK] Linux bundled native runtime artifacts: {len(hits)} {rel} matches")
                 break
         else:
-            print("[WARN] Linux libpython artifact not found under _internal; verify PyInstaller bundle manually")
+            print(
+                "[WARN] Linux libpython artifact not found under _internal; verify PyInstaller bundle manually"
+            )
 
     if sys.platform == "darwin":
         framework = internal / "Python.framework"
         if not framework.exists():
-            print("[WARN] macOS Python.framework not found under _internal; notarization may still pass for non-framework builds")
+            print(
+                "[WARN] macOS Python.framework not found under _internal; notarization may still pass for non-framework builds"
+            )
         else:
             print(f"[OK] macOS Python.framework present: {framework}")
     return 0

--- a/scripts/package_chat_smoke.py
+++ b/scripts/package_chat_smoke.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run a minimal /api/chat request against source copied into a backend bundle."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+async def _run(internal_dir: Path) -> None:
+    sys.path.insert(0, str(internal_dir))
+
+    from httpx import ASGITransport, AsyncClient
+
+    import openakita
+    from openakita.api.routes import chat as chat_routes
+    from openakita.api.server import create_app
+
+    imported_from = Path(openakita.__file__).resolve()
+    if not imported_from.is_relative_to(internal_dir):
+        raise RuntimeError(f"openakita imported from {imported_from}, not bundle {internal_dir}")
+
+    agent = MagicMock()
+    agent.initialized = True
+    agent._initialized = True
+    agent.state.has_active_task = False
+    agent.state.is_task_cancelled = False
+    agent.brain.model = "package-smoke-model"
+    agent.settings.max_iterations = 1
+    agent.session_manager = None
+    agent.insert_user_message = AsyncMock(return_value=True)
+
+    async def fake_stream(*args, **kwargs):
+        yield {"type": "text_delta", "content": "package smoke ok"}
+        yield {"type": "done"}
+
+    agent.chat_with_session_stream = fake_stream
+    agent.chat_with_session = AsyncMock(return_value="package smoke ok")
+    chat_routes._chat_endpoint_names = lambda: {"package-smoke"}
+    chat_routes._resolve_agent = lambda value: value
+
+    app = create_app(agent=agent, shutdown_event=asyncio.Event())
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://127.0.0.1",
+    ) as client:
+        response = await client.post(
+            "/api/chat",
+            json={"message": "package smoke", "conversation_id": "package-smoke"},
+        )
+
+    if response.status_code != 200:
+        raise RuntimeError(f"POST /api/chat returned {response.status_code}: {response.text[:500]}")
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" not in content_type:
+        raise RuntimeError(f"POST /api/chat returned unexpected content type {content_type!r}")
+    if "package smoke ok" not in response.text:
+        raise RuntimeError("POST /api/chat SSE response did not contain the mock agent output")
+    print(f"[OK] bundled POST /api/chat smoke passed ({response.status_code})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--internal-dir", required=True)
+    args = parser.parse_args()
+    asyncio.run(_run(Path(args.internal_dir).resolve()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_contract.py
+++ b/scripts/release_contract.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Reject mutable or commit-mismatched GitHub releases before packaging."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from typing import Any
+from urllib.parse import quote
+
+JsonFetcher = Callable[[str, bool], dict[str, Any] | None]
+
+
+def _gh_json(endpoint: str, allow_not_found: bool = False) -> dict[str, Any] | None:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    error = (result.stderr or result.stdout).strip()
+    if allow_not_found and ("HTTP 404" in error or "Not Found" in error):
+        return None
+    raise RuntimeError(f"GitHub API request failed for {endpoint}: {error[:500]}")
+
+
+def _resolve_tag_commit(repo: str, tag: str, fetch_json: JsonFetcher) -> str:
+    encoded_tag = quote(tag, safe="")
+    ref = fetch_json(f"repos/{repo}/git/ref/tags/{encoded_tag}", False)
+    if ref is None:
+        raise RuntimeError(f"tag {tag!r} does not exist")
+    obj = ref.get("object") or {}
+    for _ in range(5):
+        obj_type = str(obj.get("type") or "")
+        sha = str(obj.get("sha") or "")
+        if obj_type == "commit" and sha:
+            return sha
+        if obj_type != "tag" or not sha:
+            break
+        tag_obj = fetch_json(f"repos/{repo}/git/tags/{sha}", False)
+        if tag_obj is None:
+            break
+        obj = tag_obj.get("object") or {}
+    raise RuntimeError(f"tag {tag!r} does not resolve to a commit")
+
+
+def check_release_contract(
+    *,
+    repo: str,
+    tag: str,
+    expected_commit: str,
+    asset_names: Sequence[str] = (),
+    require_release: bool = False,
+    wait_seconds: int = 0,
+    fetch_json: JsonFetcher = _gh_json,
+) -> None:
+    """Validate tag provenance and reject any release asset collision."""
+    if not tag.startswith("v"):
+        raise RuntimeError(f"release tag must start with 'v', got {tag!r}")
+    tag_commit = _resolve_tag_commit(repo, tag, fetch_json)
+    if tag_commit.lower() != expected_commit.lower():
+        raise RuntimeError(
+            f"tag {tag!r} points to {tag_commit}, but the build checkout is {expected_commit}"
+        )
+
+    encoded_tag = quote(tag, safe="")
+    deadline = time.monotonic() + max(0, wait_seconds)
+    release: dict[str, Any] | None
+    while True:
+        release = fetch_json(f"repos/{repo}/releases/tags/{encoded_tag}", True)
+        if release is not None or not require_release or time.monotonic() >= deadline:
+            break
+        time.sleep(2)
+
+    if release is None:
+        if require_release:
+            raise RuntimeError(f"release {tag!r} does not exist after waiting {wait_seconds}s")
+        return
+
+    existing = {str(asset.get("name") or "") for asset in release.get("assets") or []}
+    conflicts = sorted(existing.intersection(asset_names) if asset_names else existing)
+    if conflicts:
+        joined = ", ".join(conflicts)
+        raise RuntimeError(
+            f"release {tag!r} already contains immutable assets: {joined}. "
+            "Publish a new version instead of replacing them."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--tag", required=True, help="Release tag to validate")
+    parser.add_argument("--expected-commit", required=True, help="Full checkout commit SHA")
+    parser.add_argument(
+        "--asset-name",
+        action="append",
+        default=[],
+        help="Reject only this existing asset name; omit to reject every existing asset",
+    )
+    parser.add_argument("--require-release", action="store_true")
+    parser.add_argument("--wait-seconds", type=int, default=0)
+    args = parser.parse_args()
+
+    try:
+        check_release_contract(
+            repo=args.repo,
+            tag=args.tag,
+            expected_commit=args.expected_commit,
+            asset_names=args.asset_name,
+            require_release=args.require_release,
+            wait_seconds=args.wait_seconds,
+        )
+    except Exception as exc:
+        print(f"[ERROR] release contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"[OK] release contract passed for {args.tag} at {args.expected_commit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_bundled_python_contract.py
+++ b/tests/unit/test_bundled_python_contract.py
@@ -32,3 +32,10 @@ def test_verify_build_identity_rejects_missing_or_wrong_hash(tmp_path: Path, val
 
 def test_bundled_chat_smoke_exercises_request_without_mode() -> None:
     _run_bundled_chat_smoke(Path("src").resolve())
+
+
+def test_pyinstaller_source_tree_excludes_build_owned_version_file() -> None:
+    spec_source = (Path("build") / "openakita.spec").read_text(encoding="utf-8")
+
+    assert 'excludes=["_bundled_version.txt"]' in spec_source
+    assert 'datas.append((str(_openakita_src), "openakita"))' not in spec_source

--- a/tests/unit/test_bundled_python_contract.py
+++ b/tests/unit/test_bundled_python_contract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[2] / "build" / "verify_bundled_python_contract.py"
+_SPEC = importlib.util.spec_from_file_location("verify_bundled_python_contract", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+_run_bundled_chat_smoke = _MODULE._run_bundled_chat_smoke
+_verify_build_identity = _MODULE._verify_build_identity
+
+
+def test_verify_build_identity_accepts_full_expected_commit(tmp_path: Path) -> None:
+    version_file = tmp_path / "_bundled_version.txt"
+    version_file.write_text("1.2.3+abcdef0", encoding="utf-8")
+
+    assert _verify_build_identity(version_file, "abcdef0123456789") == "1.2.3+abcdef0"
+
+
+@pytest.mark.parametrize("value", ["1.2.3", "1.2.3+7654321"])
+def test_verify_build_identity_rejects_missing_or_wrong_hash(tmp_path: Path, value: str) -> None:
+    version_file = tmp_path / "_bundled_version.txt"
+    version_file.write_text(value, encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        _verify_build_identity(version_file, "abcdef0123456789")
+
+
+def test_bundled_chat_smoke_exercises_request_without_mode() -> None:
+    _run_bundled_chat_smoke(Path("src").resolve())

--- a/tests/unit/test_release_contract.py
+++ b/tests/unit/test_release_contract.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.release_contract import check_release_contract
+
+
+class _Fetcher:
+    def __init__(self, responses: dict[str, dict[str, Any] | None]) -> None:
+        self.responses = responses
+
+    def __call__(self, endpoint: str, allow_not_found: bool) -> dict[str, Any] | None:
+        assert endpoint in self.responses
+        return self.responses[endpoint]
+
+
+def test_release_contract_accepts_new_release_for_matching_lightweight_tag() -> None:
+    commit = "a" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/tags/v1.2.3": None,
+        }
+    )
+
+    check_release_contract(
+        repo="openakita/openakita",
+        tag="v1.2.3",
+        expected_commit=commit,
+        fetch_json=fetcher,
+    )
+
+
+def test_release_contract_resolves_annotated_tag() -> None:
+    commit = "b" * 40
+    tag_object = "c" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "tag", "sha": tag_object}
+            },
+            f"repos/openakita/openakita/git/tags/{tag_object}": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/tags/v1.2.3": {"assets": []},
+        }
+    )
+
+    check_release_contract(
+        repo="openakita/openakita",
+        tag="v1.2.3",
+        expected_commit=commit,
+        fetch_json=fetcher,
+    )
+
+
+def test_release_contract_rejects_commit_mismatch() -> None:
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": "a" * 40}
+            }
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="build checkout"):
+        check_release_contract(
+            repo="openakita/openakita",
+            tag="v1.2.3",
+            expected_commit="b" * 40,
+            fetch_json=fetcher,
+        )
+
+
+def test_release_contract_rejects_existing_assets() -> None:
+    commit = "a" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/tags/v1.2.3": {
+                "assets": [{"name": "OpenAkita-v1.2.3.dmg"}]
+            },
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="immutable assets"):
+        check_release_contract(
+            repo="openakita/openakita",
+            tag="v1.2.3",
+            expected_commit=commit,
+            fetch_json=fetcher,
+        )
+
+
+def test_release_contract_can_scope_collision_check_to_mobile_assets() -> None:
+    commit = "a" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/tags/v1.2.3": {
+                "assets": [{"name": "openakita-1.2.3-py3-none-any.whl"}]
+            },
+        }
+    )
+
+    check_release_contract(
+        repo="openakita/openakita",
+        tag="v1.2.3",
+        expected_commit=commit,
+        asset_names=["OpenAkita-v1.2.3-android.apk"],
+        require_release=True,
+        fetch_json=fetcher,
+    )

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[2]
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+MOBILE = ROOT / ".github" / "workflows" / "mobile.yml"
+PREPARE = ROOT / ".github" / "actions" / "desktop-build-prepare" / "action.yml"
+
+
+def test_release_workflows_never_clobber_existing_assets() -> None:
+    for path in (RELEASE, MOBILE):
+        source = path.read_text(encoding="utf-8")
+        assert "gh release upload" in source
+        assert "--clobber" not in source
+
+
+def test_release_workflows_enforce_release_contract() -> None:
+    release_source = RELEASE.read_text(encoding="utf-8")
+    mobile_source = MOBILE.read_text(encoding="utf-8")
+
+    assert "scripts/release_contract.py" in release_source
+    assert "scripts/release_contract.py" in mobile_source
+    assert "--require-release" in mobile_source
+    assert "--expected-commit" in release_source
+    assert "--expected-commit" in mobile_source
+
+
+def test_packaging_verifies_checkout_identity_and_chat_api() -> None:
+    workflow_sources = [
+        path.read_text(encoding="utf-8")
+        for path in (
+            RELEASE,
+            ROOT / ".github" / "workflows" / "release-dryrun.yml",
+            ROOT / ".github" / "workflows" / "ci.yml",
+        )
+    ]
+    prepare_source = PREPARE.read_text(encoding="utf-8")
+
+    for source in workflow_sources:
+        assert "--expected-git-hash" in source
+        assert "--check-chat-api" in source
+    assert 'OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"' in prepare_source
+
+
+def test_changed_workflow_yaml_is_valid() -> None:
+    paths = (
+        RELEASE,
+        MOBILE,
+        ROOT / ".github" / "workflows" / "release-dryrun.yml",
+        ROOT / ".github" / "workflows" / "ci.yml",
+        PREPARE,
+    )
+    for path in paths:
+        assert yaml.safe_load(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Reject release builds when the tag does not match the checked-out commit or the release already contains assets.
- Verify packaged build identity and run a minimal `/api/chat` request without `mode` before installers are uploaded.

## Tests

- `uv run --no-sync pytest tests/unit/test_release_contract.py tests/unit/test_bundled_python_contract.py tests/unit/test_release_workflow_contract.py tests/integration/test_api_chat.py -k "release_contract or bundled or workflow or without_mode" -q`
- `uv run --no-sync ruff check scripts/release_contract.py scripts/package_chat_smoke.py build/verify_bundled_python_contract.py tests/unit/test_release_contract.py tests/unit/test_bundled_python_contract.py tests/unit/test_release_workflow_contract.py`
- Bundled backend contract verification, including build identity and `/api/chat` smoke

Fixes #536
