### PR TITLE
bound remote LLM stream stalls to improve interactive recovery

### DIFF
--- a/src/openakita/core/_reasoning_engine_legacy.py
+++ b/src/openakita/core/_reasoning_engine_legacy.py
@@ -2065,7 +2065,7 @@ class ReasoningEngine:
                 if retry_result == "retry":
                     _total_r = getattr(state, "_total_llm_retries", 1)
                     await _emit_progress(
-                        f"AI 服务响应异常，正在重试（{_total_r}/{self.MAX_TOTAL_LLM_RETRIES}）..."
+                        self._retry_progress_message(e, _total_r, self.MAX_TOTAL_LLM_RETRIES)
                     )
                     _retry_sleep = min(2 * _total_r, 15)
                     _sleep = asyncio.create_task(asyncio.sleep(_retry_sleep))
@@ -4305,11 +4305,10 @@ class ReasoningEngine:
                         _total_r = getattr(state, "_total_llm_retries", 1)
                         yield {
                             "type": "chain_text",
-                            "content": (
-                                f"AI 服务响应异常，正在重试"
-                                f"（{_total_r}/{self.MAX_TOTAL_LLM_RETRIES}）..."
+                            "content": self._retry_progress_message(
+                                e, _total_r, self.MAX_TOTAL_LLM_RETRIES
                             ),
-                            "icon": "alert",
+                            "icon": "clock" if self._is_llm_timeout_error(e) else "alert",
                         }
                         _retry_sleep = min(2 * _total_r, 15)
                         _sleep = asyncio.create_task(asyncio.sleep(_retry_sleep))
@@ -8650,6 +8649,27 @@ class ReasoningEngine:
             target_tokens,
         )
         return True
+
+    @staticmethod
+    def _is_llm_timeout_error(error: Exception) -> bool:
+        error_text = str(error).lower()
+        return any(
+            marker in error_text
+            for marker in (
+                "timeout",
+                "timed out",
+                "readtimeout",
+                "first-byte",
+                "stream stalled",
+            )
+        )
+
+    @classmethod
+    def _retry_progress_message(cls, error: Exception, attempt: int, max_attempts: int) -> str:
+        progress = f"（{attempt}/{max_attempts}）"
+        if cls._is_llm_timeout_error(error):
+            return f"AI 服务响应较慢，正在尝试恢复连接{progress}..."
+        return f"AI 服务暂时不可用，正在重试{progress}..."
 
     async def _handle_llm_error(
         self,

--- a/src/openakita/llm/providers/openai.py
+++ b/src/openakita/llm/providers/openai.py
@@ -58,6 +58,12 @@ from .proxy_utils import (
 logger = logging.getLogger(__name__)
 
 
+# Remote streaming requests should fail over promptly when the upstream sends no
+# data. Non-streaming calls retain their configured/dynamic timeout, while local
+# inference keeps its longer timeout because slow first tokens are expected.
+REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS = 90.0
+
+
 def _safe_dig(data: object, *keys: str) -> object:
     """Walk nested dicts safely; returns ``None`` if any key is missing."""
     cur = data
@@ -337,6 +343,37 @@ class OpenAIProvider(LLMProvider):
             pool=min(30.0, new_read),
         )
 
+    def _estimate_stream_timeout(self, body: dict) -> httpx.Timeout | None:
+        """Bound remote time-to-first-data and inter-chunk stalls.
+
+        The generic request timeout grows with prompt size, which is useful for
+        non-streaming responses but can leave an interactive stream apparently
+        frozen for several minutes before endpoint failover starts.
+        """
+        if self._is_local_endpoint():
+            return self._estimate_request_timeout(body)
+
+        dynamic_timeout = self._estimate_request_timeout(body)
+        configured_read = float(self.config.timeout or 180)
+        if dynamic_timeout is not None:
+            configured_read = float(dynamic_timeout.read or configured_read)
+
+        read_timeout = min(configured_read, REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS)
+        if configured_read > read_timeout:
+            logger.info(
+                "[OpenAI] '%s': capping remote stream read timeout %.0fs -> %.0fs",
+                self.name,
+                configured_read,
+                read_timeout,
+            )
+
+        return httpx.Timeout(
+            connect=min(10.0, read_timeout),
+            read=read_timeout,
+            write=min(30.0, read_timeout),
+            pool=min(30.0, read_timeout),
+        )
+
     async def chat(self, request: LLMRequest) -> LLMResponse:
         """发送聊天请求（统一的非流式 → 流式自动回退）
 
@@ -517,7 +554,8 @@ class OpenAIProvider(LLMProvider):
         子类可覆写以适配不同 SSE 格式（如 Responses API 的 named events）。
         """
         client = await self._get_client()
-        req_timeout = self._estimate_request_timeout(body)
+        req_timeout = self._estimate_stream_timeout(body)
+        has_content = False
 
         try:
             async with client.stream(
@@ -559,7 +597,6 @@ class OpenAIProvider(LLMProvider):
                         raw_body=error_text,
                     )
 
-                has_content = False
                 first_line_raw = None
                 async for line in response.aiter_lines():
                     if not line.strip():
@@ -616,7 +653,8 @@ class OpenAIProvider(LLMProvider):
         except httpx.TimeoutException as e:
             detail = f"{type(e).__name__}: {e}"
             self.mark_unhealthy(f"Timeout: {detail}", is_local=self._is_local_endpoint())
-            raise LLMError(f"Stream timeout: {detail}")
+            timeout_phase = "stalled" if has_content else "first-byte timeout"
+            raise LLMError(f"Stream {timeout_phase}: {detail}")
         except httpx.RequestError as e:
             detail = f"{type(e).__name__}: {e}" if str(e) else f"{type(e).__name__}({repr(e)})"
             self.mark_unhealthy(

--- a/src/openakita/llm/providers/openai_responses.py
+++ b/src/openakita/llm/providers/openai_responses.py
@@ -468,7 +468,8 @@ class OpenAIResponsesProvider(OpenAIProvider):
         并处理 Responses API 特有的流式错误事件。
         """
         client = await self._get_client()
-        req_timeout = self._estimate_request_timeout(body)
+        req_timeout = self._estimate_stream_timeout(body)
+        has_content = False
 
         try:
             import httpx
@@ -504,7 +505,6 @@ class OpenAIResponsesProvider(OpenAIProvider):
                         status_code=response.status_code,
                     )
 
-                has_content = False
                 async for line in response.aiter_lines():
                     if not line.strip():
                         continue
@@ -567,7 +567,8 @@ class OpenAIResponsesProvider(OpenAIProvider):
             if isinstance(e, httpx.TimeoutException):
                 detail = f"{type(e).__name__}: {e}"
                 self.mark_unhealthy(f"Timeout: {detail}", is_local=self._is_local_endpoint())
-                raise LLMError(f"Stream timeout: {detail}")
+                timeout_phase = "stalled" if has_content else "first-byte timeout"
+                raise LLMError(f"Stream {timeout_phase}: {detail}")
             if isinstance(e, httpx.RequestError):
                 detail = f"{type(e).__name__}: {e}" if str(e) else f"{type(e).__name__}({repr(e)})"
                 self.mark_unhealthy(

--- a/src/openakita/scheduler/executor.py
+++ b/src/openakita/scheduler/executor.py
@@ -1192,6 +1192,19 @@ class TaskExecutor:
             if not settings.memory_nudge_enabled or settings.memory_nudge_interval <= 0:
                 return True, "Memory nudge disabled, skipping"
 
+            # Interactive work takes priority over opportunistic memory review.
+            # This task creates its own Brain/LLMClient, so without this guard it
+            # can compete with the user's request for the same upstream endpoint.
+            from ..llm.client import LLMClient
+
+            inflight = LLMClient.get_concurrency_stats()["inflight"]
+            if inflight > 0:
+                logger.info(
+                    "[memory_nudge] Deferring review while %d LLM request(s) are active",
+                    inflight,
+                )
+                return True, "Active LLM request in progress, deferring memory nudge"
+
             mm = self.memory_manager
             if not mm:
                 return True, "No MemoryManager available, skipping nudge"

--- a/tests/unit/test_openai_stream_timeout.py
+++ b/tests/unit/test_openai_stream_timeout.py
@@ -1,0 +1,99 @@
+import pytest
+
+from openakita.core._reasoning_engine_legacy import ReasoningEngine
+from openakita.llm.providers.openai import (
+    REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS,
+    OpenAIProvider,
+)
+from openakita.llm.providers.openai_responses import OpenAIResponsesProvider
+from openakita.llm.types import EndpointConfig, LLMError
+
+
+def _provider(
+    *,
+    base_url: str = "https://api.example.com/v1",
+    timeout: int = 180,
+) -> OpenAIProvider:
+    return OpenAIProvider(
+        EndpointConfig(
+            name="test",
+            provider="custom",
+            api_type="openai",
+            base_url=base_url,
+            api_key="sk-test",
+            model="test-model",
+            timeout=timeout,
+        )
+    )
+
+
+def test_remote_stream_timeout_is_capped_for_large_context() -> None:
+    provider = _provider()
+    body = {"messages": [{"content": "x" * 120_000}], "tools": []}
+
+    request_timeout = provider._estimate_request_timeout(body)
+    stream_timeout = provider._estimate_stream_timeout(body)
+
+    assert request_timeout is not None
+    assert request_timeout.read > REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS
+    assert stream_timeout is not None
+    assert stream_timeout.read == REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS
+
+
+def test_remote_stream_timeout_preserves_shorter_user_setting() -> None:
+    provider = _provider(timeout=30)
+
+    stream_timeout = provider._estimate_stream_timeout({"messages": [], "tools": []})
+
+    assert stream_timeout is not None
+    assert stream_timeout.read == 30
+
+
+def test_local_stream_timeout_is_not_capped() -> None:
+    provider = _provider(base_url="http://127.0.0.1:11434/v1")
+    body = {"messages": [{"content": "x" * 120_000}], "tools": []}
+
+    stream_timeout = provider._estimate_stream_timeout(body)
+
+    assert stream_timeout is not None
+    assert stream_timeout.read > REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS
+
+
+def test_responses_stream_timeout_uses_same_remote_cap() -> None:
+    provider = OpenAIResponsesProvider(
+        EndpointConfig(
+            name="responses-test",
+            provider="openai",
+            api_type="openai_responses",
+            base_url="https://api.openai.com/v1",
+            api_key="sk-test",
+            model="test-model",
+            timeout=180,
+        )
+    )
+    body = {"input": [{"content": "x" * 180_000}], "tools": []}
+
+    stream_timeout = provider._estimate_stream_timeout(body)
+
+    assert stream_timeout is not None
+    assert stream_timeout.read == REMOTE_STREAM_READ_TIMEOUT_CAP_SECONDS
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (
+            LLMError("Stream first-byte timeout: ReadTimeout"),
+            "AI 服务响应较慢，正在尝试恢复连接（2/3）...",
+        ),
+        (LLMError("HTTP 500"), "AI 服务暂时不可用，正在重试（2/3）..."),
+    ],
+)
+def test_retry_progress_describes_action_and_attempt_count(
+    error: Exception,
+    expected: str,
+) -> None:
+    message = ReasoningEngine._retry_progress_message(error, 2, 3)
+
+    assert message == expected
+    assert "2/3" in message

--- a/tests/unit/test_scheduler_fix7.py
+++ b/tests/unit/test_scheduler_fix7.py
@@ -2,24 +2,20 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import re
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
 from openakita.scheduler.scheduler import TaskScheduler
 from openakita.scheduler.task import (
     ScheduledTask,
-    TaskStatus,
     TaskType,
     TriggerType,
 )
-
 
 # ---------------------------------------------------------------------------
 # missed_count 上限保护
@@ -110,3 +106,23 @@ def test_memory_nudge_json_completely_invalid_returns_skip_marker():
 
     # 仅做模块加载冒烟，确保 import 路径与正则常量没回归。
     assert hasattr(ex_mod, "TaskExecutor")
+
+
+@pytest.mark.asyncio
+async def test_memory_nudge_defers_while_an_llm_request_is_active(monkeypatch):
+    from openakita.config import settings
+    from openakita.llm.client import LLMClient
+    from openakita.scheduler.executor import TaskExecutor
+
+    monkeypatch.setattr(settings, "memory_nudge_enabled", True)
+    monkeypatch.setattr(settings, "memory_nudge_interval", 10)
+    monkeypatch.setattr(
+        LLMClient,
+        "get_concurrency_stats",
+        classmethod(lambda cls: {"inflight": 1, "max_concurrent": 20, "tracked_loops": 1}),
+    )
+
+    success, message = await TaskExecutor()._system_memory_nudge_review()
+
+    assert success is True
+    assert message == "Active LLM request in progress, deferring memory nudge"


### PR DESCRIPTION
## Summary

- Cap remote OpenAI-compatible stream stalls at 90 seconds so endpoint failover starts promptly while preserving shorter user settings and longer local inference waits.
- Keep retry attempt counts visible with clearer timeout-specific progress text.
- Defer background memory review while another LLM request is active to prioritize interactive work.

## Tests

- `uv run --no-sync pytest tests/unit/test_openai_stream_timeout.py tests/unit/test_openai_content_recovery.py tests/unit/test_openai_thinking_depth.py tests/unit/test_llm_quota_error_classification.py tests/unit/test_llm_output_token_budget.py tests/unit/test_scheduler_fix7.py tests/unit/test_scheduler_tasks.py tests/unit/test_scheduler_executor_status.py tests/unit/test_scheduler_trigger_background.py tests/unit/test_task_monitor.py -q`
- `uv run --no-sync ruff check src/openakita/llm/providers/openai.py src/openakita/llm/providers/openai_responses.py src/openakita/core/_reasoning_engine_legacy.py src/openakita/scheduler/executor.py tests/unit/test_openai_stream_timeout.py tests/unit/test_scheduler_fix7.py`

Fixes #554
