### PR TITLE
Fix isolated agents to rebind all memory consumers

### DIFF
--- a/src/openakita/agents/factory.py
+++ b/src/openakita/agents/factory.py
@@ -541,7 +541,13 @@ class AgentFactory:
                 _GlobalStoreSource(global_store, isolated_mm._current_owner)
             )
 
-        agent.memory_manager = isolated_mm
+        rebind_memory_manager = getattr(agent, "rebind_memory_manager", None)
+        if callable(rebind_memory_manager):
+            rebind_memory_manager(isolated_mm)
+        else:
+            # Compatibility for third-party Agent implementations that have
+            # not adopted the unified rebinding hook yet.
+            agent.memory_manager = isolated_mm
 
         logger.info(
             f"Memory isolation applied: profile={profile.id}, "

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -1240,6 +1240,66 @@ class Agent:
 
         logger.info(f"Agent '{self.name}' created (with refactored sub-modules)")
 
+    def rebind_memory_manager(self, memory_manager: Any) -> None:
+        """Replace the memory manager across every long-lived Agent subsystem.
+
+        AgentFactory applies profile memory isolation after ``initialize()``.
+        Several subsystems retain the manager they received during ``__init__``,
+        so assigning only ``agent.memory_manager`` leaves prompt retrieval and
+        reasoning on the old shared store.
+        """
+        if memory_manager is None:
+            raise ValueError("memory_manager must not be None")
+
+        self.memory_manager = memory_manager
+
+        profile_manager = getattr(self, "profile_manager", None)
+        if profile_manager is not None:
+            memory_manager.profile_manager = profile_manager
+
+        memory_backends = getattr(self, "_memory_backends", None)
+        if memory_backends is not None and hasattr(memory_manager, "set_plugin_backends"):
+            memory_manager.set_plugin_backends(memory_backends)
+
+        plugin_manager = getattr(self, "_plugin_manager", None)
+        hook_registry = getattr(plugin_manager, "hook_registry", None)
+        retrieval_engine = getattr(memory_manager, "retrieval_engine", None)
+        if retrieval_engine is not None and hook_registry is not None:
+            retrieval_engine._plugin_hooks = hook_registry
+
+        prompt_assembler = getattr(self, "prompt_assembler", None)
+        if prompt_assembler is not None:
+            prompt_assembler._memory_manager = memory_manager
+
+        reasoning_engine = getattr(self, "reasoning_engine", None)
+        if reasoning_engine is not None:
+            reasoning_engine._memory_manager = memory_manager
+
+        response_handler = getattr(self, "response_handler", None)
+        if response_handler is not None:
+            response_handler._memory_manager = memory_manager
+
+        proactive_engine = getattr(self, "proactive_engine", None)
+        if proactive_engine is not None:
+            proactive_engine.memory_manager = memory_manager
+
+        task_executor = getattr(self, "_task_executor", None)
+        if task_executor is not None:
+            task_executor.memory_manager = memory_manager
+
+        plugin_host_refs = getattr(plugin_manager, "_external_host_refs", None)
+        if isinstance(plugin_host_refs, dict):
+            plugin_host_refs["memory_manager"] = memory_manager
+            plugin_host_refs["external_retrieval_sources"] = (
+                retrieval_engine._external_sources if retrieval_engine is not None else []
+            )
+
+        if hasattr(self, "_system_prompt_cache"):
+            self._invalidate_system_prompt_cache("memory manager rebound")
+        context = getattr(self, "_context", None)
+        if context is not None and hasattr(context, "system"):
+            context.system = self._build_system_prompt()
+
     # 永远不会因为 intent-driven defer 被剔除的工具分类。
     #
     # 这两类是 OpenAkita 在每一轮里都需要的"基础能力"：

--- a/tests/unit/test_agent_memory_rebinding.py
+++ b/tests/unit/test_agent_memory_rebinding.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+
+from openakita.agent.core import Agent
+from openakita.agents.factory import AgentFactory
+from openakita.agents.profile import AgentProfile, AgentType
+from openakita.memory.manager import MemoryManager
+from openakita.memory.types import MemoryPriority, MemoryType, SemanticMemory
+
+
+def _memory_manager(data_dir, memory_md_path) -> MemoryManager:
+    return MemoryManager(
+        data_dir=data_dir,
+        memory_md_path=memory_md_path,
+        search_backend="fts5",
+    )
+
+
+def _agent_with_memory_consumers(memory_manager: MemoryManager) -> Agent:
+    agent = Agent.__new__(Agent)
+    agent.brain = None
+    agent.memory_manager = memory_manager
+    agent.profile_manager = object()
+    agent._memory_backends = {}
+    agent.prompt_assembler = SimpleNamespace(_memory_manager=memory_manager)
+    agent.reasoning_engine = SimpleNamespace(_memory_manager=memory_manager)
+    agent.response_handler = SimpleNamespace(_memory_manager=memory_manager)
+    agent.proactive_engine = SimpleNamespace(memory_manager=memory_manager)
+    agent._task_executor = SimpleNamespace(memory_manager=memory_manager)
+    agent._plugin_manager = SimpleNamespace(
+        hook_registry=SimpleNamespace(get_hooks=lambda _hook_name: []),
+        _external_host_refs={
+            "memory_manager": memory_manager,
+            "external_retrieval_sources": memory_manager.retrieval_engine._external_sources,
+        },
+    )
+    agent._system_prompt_cache = {"stale": "prompt"}
+    agent._system_prompt_cache_dirty = False
+    agent._context = SimpleNamespace(system="stale shared prompt")
+    agent._build_system_prompt = lambda: "fresh isolated prompt"
+    return agent
+
+
+def _apply_isolation(tmp_path, monkeypatch, *, profile_id: str):
+    profile_dir = tmp_path / "profiles" / profile_id
+    profile_dir.mkdir(parents=True)
+    profile_store = SimpleNamespace(ensure_profile_dir=lambda _profile_id: profile_dir)
+    monkeypatch.setattr("openakita.agents.profile.get_profile_store", lambda: profile_store)
+
+    shared = _memory_manager(tmp_path / "shared", tmp_path / "GLOBAL_MEMORY.md")
+    agent = _agent_with_memory_consumers(shared)
+    profile = AgentProfile(
+        id=profile_id,
+        name="Isolated Agent",
+        description="",
+        type=AgentType.CUSTOM,
+        created_by="test",
+        memory_mode="isolated",
+        memory_inherit_global=False,
+    )
+    AgentFactory._apply_memory_isolation(agent, profile)
+    return agent, shared
+
+
+def test_isolated_memory_rebinds_full_chain_and_cannot_read_global(tmp_path, monkeypatch):
+    agent, shared = _apply_isolation(tmp_path, monkeypatch, profile_id="strict-isolation")
+    shared.start_session("global-session", user_id="desktop_user", workspace_id="default")
+    shared.add_memory(
+        SemanticMemory(
+            type=MemoryType.FACT,
+            priority=MemoryPriority.LONG_TERM,
+            content="The global launch code is violet-orchid-9472.",
+            importance_score=0.95,
+        ),
+        scope="user",
+    )
+
+    isolated = agent.memory_manager
+    isolated.start_session("isolated-session", user_id="desktop_user", workspace_id="default")
+
+    assert isolated is not shared
+    assert agent.prompt_assembler._memory_manager is isolated
+    assert agent.reasoning_engine._memory_manager is isolated
+    assert agent.response_handler._memory_manager is isolated
+    assert agent.proactive_engine.memory_manager is isolated
+    assert agent._task_executor.memory_manager is isolated
+    assert agent._plugin_manager._external_host_refs["memory_manager"] is isolated
+    assert (
+        agent._plugin_manager._external_host_refs["external_retrieval_sources"]
+        is isolated.retrieval_engine._external_sources
+    )
+    assert isolated._global_store_ref is None
+    assert isolated.retrieval_engine._external_sources == []
+    assert agent._system_prompt_cache == {}
+    assert agent._system_prompt_cache_dirty is True
+    assert agent._context.system == "fresh isolated prompt"
+
+    query = "What is the global launch code violet orchid?"
+    shared_rows = shared.query_visible_semantic(limit=10)
+    assert any("violet-orchid-9472" in memory.content for memory in shared_rows)
+    assert "violet-orchid-9472" not in agent.prompt_assembler._memory_manager.get_injection_context(
+        query
+    )
+
+
+def test_isolated_memory_recalls_long_term_memory_in_a_new_session(tmp_path, monkeypatch):
+    agent, _shared = _apply_isolation(tmp_path, monkeypatch, profile_id="cross-session")
+    isolated = agent.memory_manager
+
+    isolated.start_session("session-a", user_id="desktop_user", workspace_id="default")
+    isolated.add_memory(
+        SemanticMemory(
+            type=MemoryType.PREFERENCE,
+            priority=MemoryPriority.LONG_TERM,
+            content="The user prefers release summaries named silver-pine-5831.",
+            importance_score=0.95,
+        ),
+        scope="user",
+    )
+
+    isolated.start_session("session-b", user_id="desktop_user", workspace_id="default")
+    context = agent.prompt_assembler._memory_manager.get_injection_context(
+        "How should release summaries be named?"
+    )
+
+    assert "silver-pine-5831" in context


### PR DESCRIPTION
## Summary

- Rebind every long-lived Agent subsystem when profile isolation replaces the shared memory manager.
- Refresh prompt state and plugin host references so strict isolation cannot read global memory while profile memory remains available across conversations.
- Add regression coverage for strict no-inheritance isolation and cross-conversation recall.

## Tests

- `uv run --no-sync pytest tests/unit/test_agent_memory_rebinding.py tests/unit/test_memory_v4_migration_and_isolation.py tests/unit/test_memory_scope_isolation.py tests/unit/test_memory_owner_isolation.py tests/unit/test_agent_instance_pool_runtime_config.py tests/unit/test_session.py tests/unit/test_chat_apply_agent_profile.py -q`
- `uv run --no-sync ruff check src/openakita/core/_agent_legacy.py src/openakita/agents/factory.py tests/unit/test_agent_memory_rebinding.py`
- `git diff --check`
