### PR TITLE
fix serve shutdown lifecycle so Ctrl+C runs complete teardown

### DIFF
--- a/src/openakita/main.py
+++ b/src/openakita/main.py
@@ -2103,6 +2103,7 @@ def serve(
     async def _serve():
         nonlocal shutdown_event, agent_or_master, shutdown_triggered
         nonlocal _heartbeat_phase, _heartbeat_http_ready, _heartbeat_im_ready, _heartbeat_ready
+        shutdown_cleanup_started = False
         _install_windows_asyncio_pipe_filter()
         shutdown_event = asyncio.Event()
         shutdown_triggered = False
@@ -2376,8 +2377,12 @@ def serve(
         finally:
             if _watch_task and not _watch_task.done():
                 _watch_task.cancel()
-            if not shutdown_triggered:
-                shutdown_triggered = True
+            # ``shutdown_triggered`` records that SIGINT/SIGTERM was received;
+            # it must not gate cleanup.  The signal handler sets it before
+            # waking ``shutdown_event``, so using it as the old guard skipped
+            # this entire teardown specifically for Ctrl+C shutdowns.
+            if not shutdown_cleanup_started:
+                shutdown_cleanup_started = True
                 is_restart = cfg._restart_requested
                 # 更新心跳状态为重启/停止中
                 _heartbeat_phase = "restarting" if is_restart else "stopping"

--- a/src/openakita/orgs/runtime.py
+++ b/src/openakita/orgs/runtime.py
@@ -516,6 +516,7 @@ class OrgRuntime:
         # workspace / memory isolation is reserved for Sprint-7+
         # (see ``_runtime_agent_host`` module docstring).
         self._node_tool_host: NodeToolHost | None = None
+        self._shutdown = False
 
         # H4 fix (audit ``_orgs_business_capability_audit_v1.md`` §3.2):
         # bridge the in-process dispatch event-bus to two long-lived
@@ -711,6 +712,43 @@ class OrgRuntime:
         """Return the currently-bound :class:`NodeToolHost`, if any."""
 
         return self._node_tool_host
+
+    async def shutdown(self) -> None:
+        """Release resources owned by this runtime.
+
+        The API lifespan still treats ``OrgRuntime`` as a composed resource
+        owner even though the old global ``start()`` entrypoint was removed.
+        Keep teardown idempotent so repeated lifespan/cancellation paths are
+        harmless.
+        """
+
+        if self._shutdown:
+            return
+        self._shutdown = True
+
+        tasks = list(self._idle_probe_tasks.values())
+        self._idle_probe_tasks.clear()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        self.set_node_tool_host(None)
+
+        remove_tap = getattr(self._event_bus, "remove_tap", None)
+        if callable(remove_tap):
+            for tap in (
+                self._persist_event_tap,
+                self._stream_event_tap,
+                self._ws_event_tap,
+                self._contract_event_tap,
+            ):
+                remove_tap(tap)
+
+        self._event_stores.clear()
+        self._inboxes.clear()
+        self._contract_project_by_org.clear()
 
     def set_on_stop_org(self, callback: Any) -> None:
         """Sprint-5 P0-2 passthrough: late-bind the stop-org callback.

--- a/tests/runtime/orgs/test_runtime_contract.py
+++ b/tests/runtime/orgs/test_runtime_contract.py
@@ -539,3 +539,49 @@ def test_contract_start_then_stop_org_lifecycle() -> None:
     stopped = asyncio.run(rt.stop_org("o-cycle"))
     assert stopped["ok"] is True
     assert stopped["status"].upper() == "STOPPED"
+
+
+def test_contract_shutdown_releases_owned_resources_idempotently() -> None:
+    """API lifespan teardown can safely close the composed v2 runtime."""
+
+    rt, _cs, bus = _make_runtime()
+
+    class _Host:
+        def __init__(self) -> None:
+            self.dispose_count = 0
+
+        def dispose(self) -> None:
+            self.dispose_count += 1
+
+    host = _Host()
+    rt.set_node_tool_host(host)  # type: ignore[arg-type]
+    rt._event_stores["o1"] = object()
+    rt._inboxes["o1"] = object()
+    rt._contract_project_by_org["o1"] = "p1"
+
+    async def exercise() -> None:
+        stopped = asyncio.Event()
+
+        async def idle_probe() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                stopped.set()
+
+        rt._idle_probe_tasks["o1"] = asyncio.create_task(idle_probe())
+        await asyncio.sleep(0)
+
+        await rt.shutdown()
+        await rt.shutdown()
+
+        assert stopped.is_set()
+
+    asyncio.run(exercise())
+
+    assert host.dispose_count == 1
+    assert rt.get_node_tool_host() is None
+    assert rt._idle_probe_tasks == {}
+    assert rt._event_stores == {}
+    assert rt._inboxes == {}
+    assert rt._contract_project_by_org == {}
+    assert bus._taps == []


### PR DESCRIPTION
## Summary

- Ensure SIGINT and SIGTERM always run the complete serve-mode teardown instead of treating signal receipt as completed cleanup.
- Restore an idempotent `OrgRuntime.shutdown()` lifecycle surface that cancels owned tasks, disposes the node tool host, detaches event taps, and clears runtime caches.
- Add regression coverage for repeated runtime shutdown and owned-resource cleanup.

## Tests

- `uv run --no-sync ruff check src/openakita/main.py src/openakita/orgs/runtime.py tests/runtime/orgs/test_runtime_contract.py`
- `uv run --no-sync pytest tests/runtime/orgs/test_runtime_contract.py tests/api/test_server_app_wiring.py tests/api/test_lifespan_closes_aiosqlite.py -q` (33 passed)
- `uv run --no-sync pytest tests/api/test_shutdown_endpoint_bounded.py tests/api/test_force_exit_watchdog_threading.py tests/api/test_lifespan_im_drain_under_3s.py -q` (14 passed)
