### PR TITLE
Fix Fin Pulse IM channel discovery with ChainMap host references

### DIFF
--- a/plugins/fin-pulse/finpulse_dispatch.py
+++ b/plugins/fin-pulse/finpulse_dispatch.py
@@ -373,7 +373,7 @@ class DispatchService:
 
     def _get_adapter(self, channel: str) -> Any | None:
         host = getattr(self._api, "_host", {}) or {}
-        gateway = host.get("gateway") if isinstance(host, dict) else None
+        gateway = host.get("gateway")
         if gateway is None or not hasattr(gateway, "get_adapter"):
             return None
         try:

--- a/plugins/fin-pulse/plugin.py
+++ b/plugins/fin-pulse/plugin.py
@@ -2196,7 +2196,7 @@ class Plugin(PluginBase):
             in-process (no extra HTTP round-trip).
             """
             host = getattr(self._api, "_host", None) or {}
-            api_app = host.get("api_app") if isinstance(host, dict) else None
+            api_app = host.get("api_app")
             if api_app is None:
                 return {"ok": True, "channels": []}
             try:
@@ -2223,7 +2223,7 @@ class Plugin(PluginBase):
             to a probe list when the gateway hides ``_adapters``.
             """
             host = getattr(self._api, "_host", None) or {}
-            gateway = host.get("gateway") if isinstance(host, dict) else None
+            gateway = host.get("gateway")
             if gateway is None:
                 return {"ok": True, "channels": []}
             names: list[str] = []

--- a/plugins/fin-pulse/tests/test_dispatch.py
+++ b/plugins/fin-pulse/tests/test_dispatch.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import ChainMap
 from pathlib import Path
 
 from finpulse_dispatch import DispatchResult, DispatchService
@@ -316,7 +317,7 @@ class _StubGateway:
 class _StubAPIWithAdapter(_StubAPI):
     def __init__(self, adapter: _StubAdapter, **kw) -> None:
         super().__init__(**kw)
-        self._host = {"gateway": _StubGateway(adapter)}
+        self._host = ChainMap({}, {"gateway": _StubGateway(adapter)})
 
 
 async def _stub_render(self, html: str, out_path: Path) -> None:  # noqa: ARG001

--- a/plugins/fin-pulse/tests/test_sources_route.py
+++ b/plugins/fin-pulse/tests/test_sources_route.py
@@ -7,12 +7,19 @@ drifted and that every entry carries the fields the dynamic UI relies on.
 
 from __future__ import annotations
 
+import asyncio
 import sys
+from collections import ChainMap
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+from fastapi import APIRouter
 
 PLUGIN_DIR = Path(__file__).resolve().parent.parent
 if str(PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(PLUGIN_DIR))
+
+from plugin import Plugin  # noqa: E402
 
 
 def _load_source_defs() -> dict[str, dict[str, object]]:
@@ -97,3 +104,33 @@ def test_plugin_exposes_sources_route() -> None:
     assert '@router.get("/scheduler/channels")' in plugin_src, (
         "GET /scheduler/channels proxy missing from plugin.py"
     )
+
+
+def _route_endpoint(router: APIRouter, path: str):
+    return next(route.endpoint for route in router.routes if route.path == path)
+
+
+def test_channel_routes_accept_chainmap_host_refs(monkeypatch) -> None:
+    """Late-bound PluginAPI host refs use ChainMap rather than dict."""
+    api_app = object()
+    gateway = SimpleNamespace(_adapters={"wechat:bot-1": object()})
+    plugin = Plugin()
+    plugin._api = SimpleNamespace(_host=ChainMap({}, {"api_app": api_app, "gateway": gateway}))
+    router = APIRouter()
+    plugin._register_routes(router)
+
+    expected_channels = [{"channel_id": "wechat:bot-1", "chat_id": "user-1"}]
+
+    async def fake_list_channels(request):
+        assert request.app is api_app
+        return {"channels": expected_channels}
+
+    scheduler_module = ModuleType("openakita.api.routes.scheduler")
+    scheduler_module.list_channels = fake_list_channels
+    monkeypatch.setitem(sys.modules, "openakita.api.routes.scheduler", scheduler_module)
+
+    scheduler_payload = asyncio.run(_route_endpoint(router, "/scheduler/channels")())
+    fallback_payload = asyncio.run(_route_endpoint(router, "/available-channels")())
+
+    assert scheduler_payload == {"ok": True, "channels": expected_channels}
+    assert fallback_payload == {"ok": True, "channels": ["wechat:bot-1"]}


### PR DESCRIPTION
## Summary

- Fix Fin Pulse IM channel discovery when `PluginAPI` exposes live host references through `ChainMap`.
- Restore adapter lookup for PDF report delivery and add regression coverage for channel routes and dispatch.
- Fixes #542.

## Tests

- `uv run --no-sync pytest plugins/fin-pulse/tests/test_sources_route.py plugins/fin-pulse/tests/test_dispatch.py -q` (`19 passed`)
- Targeted Ruff checks passed for all changed files.
- Full Fin Pulse suite: `304 passed, 2 skipped, 6 failed`; the remaining failures are pre-existing dedupe, fetcher-registry, and HTML-render expectation drift unrelated to this change.

Fixed #542