### PR TITLE
fix fin-pulse custom date filters to preserve source-local day boundaries

### DIFF
--- a/plugins/fin-pulse/tests/test_smoke.py
+++ b/plugins/fin-pulse/tests/test_smoke.py
@@ -90,6 +90,16 @@ def test_index_html_exists_and_nonempty() -> None:
     assert len(html) > 1024, "index.html is suspiciously short"
 
 
+def test_custom_time_filter_keeps_source_wall_clock_boundaries() -> None:
+    """datetime-local values must stay aligned with displayed source dates."""
+    html = INDEX_HTML.read_text("utf-8")
+
+    assert "function datetimeLocalToWallClock(value, upperBound)" in html
+    assert "datetimeLocalToWallClock(filters.since, false)" in html
+    assert "datetimeLocalToWallClock(filters.until, true)" in html
+    assert "function datetimeLocalToISO" not in html
+
+
 def test_rate_limited_renders_as_cooldown_not_error() -> None:
     """NewsNow public cooldown is a retryable wait state, not a failure."""
     html = INDEX_HTML.read_text("utf-8")

--- a/plugins/fin-pulse/tests/test_task_manager.py
+++ b/plugins/fin-pulse/tests/test_task_manager.py
@@ -17,7 +17,6 @@ import asyncio
 from pathlib import Path
 
 import pytest
-
 from finpulse_task_manager import DEFAULT_CONFIG, FinpulseTaskManager
 
 
@@ -208,6 +207,37 @@ def test_article_list_window_uses_space_separated_published_at(tm_path: Path) ->
 
             assert total == 0
             assert rows == []
+        finally:
+            await tm.close()
+
+    _run(_body())
+
+
+def test_article_list_custom_day_excludes_previous_local_date(tm_path: Path) -> None:
+    async def _body() -> None:
+        tm = await _init(tm_path)
+        try:
+            for suffix, published_at in (
+                ("previous-evening", "2026-05-11T20:30:00"),
+                ("selected-day", "2026-05-12T00:30:00"),
+            ):
+                await tm.upsert_article(
+                    source_id="yicai",
+                    url=f"https://example.com/{suffix}",
+                    url_hash=f"h_{suffix}",
+                    title=suffix,
+                    fetched_at="2026-05-12T01:00:00Z",
+                    published_at=published_at,
+                )
+
+            rows, total = await tm.list_articles(
+                since="2026-05-12T00:00:00",
+                until="2026-05-12T23:59:59",
+                limit=10,
+            )
+
+            assert total == 1
+            assert [row["title"] for row in rows] == ["selected-day"]
         finally:
             await tm.close()
 

--- a/plugins/fin-pulse/ui/dist/index.html
+++ b/plugins/fin-pulse/ui/dist/index.html
@@ -2165,11 +2165,12 @@ function hoursAgoISO(hours) {
   const d = new Date(Date.now() - hours * 3600 * 1000);
   return d.toISOString().replace(/\.\d+Z$/, "Z");
 }
-function datetimeLocalToISO(value) {
+function datetimeLocalToWallClock(value, upperBound) {
   if (!value) return "";
-  const d = new Date(value);
-  if (isNaN(d.getTime())) return "";
-  return d.toISOString().replace(/\.\d+Z$/, "Z");
+  // Article dates are displayed and queried as source wall clocks; UTC conversion shifts the day.
+  var match = String(value).trim().match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})(?::(\d{2}))?$/);
+  if (!match) return "";
+  return match[1] + ":" + (match[2] || (upperBound ? "59" : "00"));
 }
 function copyText(text) {
   try {
@@ -2810,8 +2811,8 @@ function TodayTab() {
     setLoading(true);
     try {
       const qs = {
-        since: filters.window === "custom" ? datetimeLocalToISO(filters.since) : (filters.window ? hoursAgoISO(filters.window) : undefined),
-        until: filters.window === "custom" ? datetimeLocalToISO(filters.until) : undefined,
+        since: filters.window === "custom" ? datetimeLocalToWallClock(filters.since, false) : (filters.window ? hoursAgoISO(filters.window) : undefined),
+        until: filters.window === "custom" ? datetimeLocalToWallClock(filters.until, true) : undefined,
         sort: filters.sort || "time",
         limit: 1000,
       };


### PR DESCRIPTION
## Summary

- Preserve source-local wall-clock values when applying custom Fin Pulse date filters.
- Expand minute-precision inputs to complete lower and upper second boundaries.
- Add UI contract and task-manager regressions for cross-day filtering.

## Tests

- `uv run --no-sync pytest plugins/fin-pulse/tests/test_smoke.py plugins/fin-pulse/tests/test_task_manager.py -q` (`22 passed`)
- `uv run --no-sync ruff check plugins/fin-pulse/tests/test_smoke.py plugins/fin-pulse/tests/test_task_manager.py` (passed)
- `uv run --no-sync pytest plugins/fin-pulse/tests -q` (`305 passed, 2 skipped, 6 unrelated existing failures`)

Fixes #541
