### PR TITLE
persist compacted conversation projections across restarts with workspace-aware continuity records

### DIFF
--- a/docs/architecture/context-continuity.md
+++ b/docs/architecture/context-continuity.md
@@ -1,0 +1,60 @@
+# Context continuity
+
+OpenAkita keeps long-term memory and conversation compaction as separate systems. Long-term
+memory stores reusable facts and experience. Context continuity preserves the exact execution
+projection needed to resume one conversation after compaction or process restart.
+
+## Durable records
+
+SQLite schema version 6 adds four records:
+
+- `compaction_checkpoints`: started, completed, and failed compaction attempts. A completed row
+  contains the anchored summary, recent tail, final model-visible projection, source digests,
+  token counts, context epoch, contributor output, and workspace snapshot reference.
+- `context_epochs`: hashes of the system prompt, effective tool schemas, and model identity.
+- `tool_output_blobs`: zlib-compressed full tool results removed from the active model context.
+  Blob identifiers include the session identity in their digest and reads through
+  `MemoryManager` are restricted to the active session.
+- `workspace_snapshots`: Git HEAD, changed paths, status digest, a bounded compressed patch, and
+  an explicit capture status/error. Git absence, non-repositories, and command failures degrade to
+  inspectable partial snapshots instead of blocking compaction.
+
+The original session messages are never overwritten by a checkpoint. Session JSON contains a
+bounded mirror of recent checkpoints for fast local recovery; SQLite remains the durable source.
+
+## Compaction flow
+
+1. Build the current context epoch and restore the latest valid completed checkpoint.
+2. Verify the raw `SessionContext.messages` prefix digest before applying a restored projection.
+3. Cold-store old large tool results while protecting the newest half-window, capped at 40,000
+   tokens and never below the recent-tail budget.
+4. Select recent tool-interaction groups using a token budget, not only a turn count.
+5. Collect bounded contributions from registered `CompactionContributor` implementations.
+6. Capture a read-only workspace snapshot.
+7. Persist a `started` checkpoint before the summarization request.
+8. Persist `completed` with the sanitized final projection, or `failed` if summarization aborts.
+
+Only completed checkpoints are eligible for recovery. A changed context epoch adds an explicit
+update marker and the current system context always takes precedence over an older summary.
+
+## Recent-tail configuration
+
+- `context_recent_tail_ratio`: portion of the message hard limit reserved for exact recent text.
+- `context_recent_tail_min_tokens`: lower bound for that budget.
+- `context_recent_tail_max_tokens`: upper bound for that budget.
+- `context_recent_tail_max_groups`: maximum number of recent interaction groups considered.
+- `context_min_recent_turns`: compatibility cap retained for existing configurations; token
+  budget is authoritative.
+
+## Extension contract
+
+Components register with `ContextManager.register_compaction_contributor()`. A contributor returns
+one or more `CompactionContribution` values with a name, priority, content, and token ceiling.
+Failures are isolated and do not abort compaction. `MemoryManager` is the first built-in
+contributor and supplies the pre-compaction fact snapshot plus active scratchpad state.
+
+## Episode linkage
+
+Episodes generated at session end copy the latest completed `compaction_checkpoint_id` and
+`workspace_snapshot_id`. This makes recalled task experience traceable to both the conversation
+projection and the code state from which it was learned.

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -930,7 +930,29 @@ class Settings(BaseSettings):
     )
     context_min_recent_turns: int = Field(
         default=12,
-        description="压缩时至少保留的最近对话组数 (4~20)",
+        description="兼容配置：recent-tail 参与选择的对话组上限；token 预算优先 (4~20)",
+    )
+    context_recent_tail_ratio: float = Field(
+        default=0.25,
+        ge=0.05,
+        le=0.5,
+        description="压缩后最近原文可占消息硬预算的比例",
+    )
+    context_recent_tail_min_tokens: int = Field(
+        default=2000,
+        ge=256,
+        description="压缩后最近原文的最小 token 预算",
+    )
+    context_recent_tail_max_tokens: int = Field(
+        default=8000,
+        ge=512,
+        description="压缩后最近原文的最大 token 预算",
+    )
+    context_recent_tail_max_groups: int = Field(
+        default=12,
+        ge=1,
+        le=50,
+        description="参与 recent-tail 选择的最大工具交互组数（同时受兼容配置限制）",
     )
     context_enable_tool_compression: bool = Field(
         default=True,

--- a/src/openakita/core/_agent_legacy.py
+++ b/src/openakita/core/_agent_legacy.py
@@ -3800,6 +3800,9 @@ class Agent:
         max_tokens: int = None,
         system_prompt: str = None,
         conversation_id: str | None = None,
+        session_context: object | None = None,
+        working_directory: str | None = None,
+        persist_checkpoint: bool = False,
     ) -> list[dict]:
         """委托给统一的 context_manager.compress_if_needed()。"""
         _sp = system_prompt or getattr(self._context, "system", "")
@@ -3813,6 +3816,9 @@ class Agent:
             max_tokens=max_tokens,
             memory_manager=self.memory_manager,
             conversation_id=_conv_id,
+            session_context=session_context,
+            working_directory=working_directory,
+            persist_checkpoint=persist_checkpoint,
         )
         if len(result) != _msg_count_before:
             logger.info(
@@ -3830,6 +3836,7 @@ class Agent:
         session_id: str,
         conversation_id: str | None = None,
         system_prompt: str | None = None,
+        session: object | None = None,
     ) -> list[dict]:
         """Compress session history during prepare without reusing stale cancel signals."""
         active_task = None
@@ -3845,6 +3852,9 @@ class Agent:
                 messages,
                 system_prompt=system_prompt,
                 conversation_id=conversation_id,
+                session_context=getattr(session, "context", None),
+                working_directory=getattr(session, "working_directory", None),
+                persist_checkpoint=session is not None,
             )
         except _CtxCancelledError:
             active_task = (
@@ -4903,6 +4913,47 @@ class Agent:
         # session_messages 已包含当前轮用户消息（gateway 调用前 add_message），
         # 当前轮由下方 compiled_message 单独追加，需排除最后一条避免重复。
         history_messages = session_messages
+        checkpoint_seed: list[dict] = []
+        if session is not None and not topic_changed and hasattr(session, "context"):
+            try:
+                from openakita.runtime.context.continuity import content_digest
+
+                checkpoint = session.context.latest_compaction_checkpoint()
+                if checkpoint is None:
+                    store = getattr(self.memory_manager, "store", None)
+                    loader = getattr(store, "get_latest_completed_compaction", None)
+                    if callable(loader):
+                        checkpoint = loader(conversation_id or session_id)
+                        if checkpoint:
+                            session.context.append_compaction_checkpoint(checkpoint)
+                source_count = int((checkpoint or {}).get("session_source_message_count", 0) or 0)
+                raw_messages = list(getattr(session.context, "messages", []) or [])
+                profile_matches = (checkpoint or {}).get(
+                    "agent_profile_id", "default"
+                ) == active_agent_profile_id and not bool(
+                    getattr(session.context, "agent_switch_history", [])
+                )
+                source_matches = (
+                    source_count > 0
+                    and source_count <= len(raw_messages)
+                    and content_digest(raw_messages[:source_count])
+                    == (checkpoint or {}).get("session_source_digest")
+                )
+                if checkpoint and profile_matches and source_matches:
+                    history_messages = session_messages[source_count:]
+                    checkpoint_seed = list(checkpoint.get("projected_messages") or [])
+                    if not checkpoint_seed:
+                        checkpoint_seed = self.context_manager._inject_summary_into_recent(
+                            str(checkpoint.get("summary") or ""),
+                            list(checkpoint.get("recent_messages") or []),
+                        )
+                    logger.info(
+                        "[Session:%s] Applied durable compaction checkpoint %s",
+                        session_id,
+                        str(checkpoint.get("id") or "")[:12],
+                    )
+            except Exception as exc:
+                logger.warning("[Session:%s] Checkpoint projection skipped: %s", session_id, exc)
         if history_messages and history_messages[-1].get("role") == "user":
             history_messages = history_messages[:-1]
 
@@ -4942,7 +4993,7 @@ class Agent:
         # 起始符寻找右边界）。新增 marker 时改 ``response_handler.py`` 即可。
         _RE_TIME_PREFIX = re.compile(r"^\[\d{1,2}:\d{2}\]\s")
 
-        messages: list[dict] = []
+        messages: list[dict] = checkpoint_seed
         for msg in history_messages:
             role = msg.get("role", "user")
             content = coerce_text(msg.get("content", ""))
@@ -5491,6 +5542,7 @@ class Agent:
             session_id=session_id,
             conversation_id=conversation_id,
             system_prompt=compression_system_prompt,
+            session=session,
         )
         logger.info(
             "[ChatTiming] stage=context_ready session=%s duration_ms=%.1f "

--- a/src/openakita/core/_context_manager_legacy.py
+++ b/src/openakita/core/_context_manager_legacy.py
@@ -11,12 +11,23 @@
 """
 
 import asyncio
+import copy
+import inspect
 import json
 import logging
 import re
+import uuid
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
+from openakita.runtime.context.continuity import (
+    CompactionCheckpoint,
+    CompactionContribution,
+    ContextEpoch,
+    capture_workspace_snapshot,
+    content_digest,
+)
 from openakita.utils.url_safety import safe_urlparse
 
 from ..tracing.tracer import get_tracer
@@ -74,6 +85,16 @@ class ContextManager:
         self._token_cache: dict[int, int] = {}
         self._tools_tokens_cache: int | None = None
         self._previous_summaries: dict[str, str] = {}
+        self._compaction_contributors: list[Any] = []
+
+    def register_compaction_contributor(self, contributor: Any) -> None:
+        """Register a bounded context provider for future compactions."""
+        if contributor not in self._compaction_contributors:
+            self._compaction_contributors.append(contributor)
+
+    def unregister_compaction_contributor(self, contributor: Any) -> None:
+        if contributor in self._compaction_contributors:
+            self._compaction_contributors.remove(contributor)
 
     def set_cancel_event(self, event: asyncio.Event | None) -> None:
         """更新 cancel_event（每次任务开始时由 Agent 设置）"""
@@ -348,10 +369,7 @@ class ContextManager:
         # Otherwise long-running tasks with many side tools see a large fixed
         # tools_tokens overhead and trip token-anomaly compaction prematurely.
         if tools:
-            effective_tools = [
-                t for t in tools
-                if not (isinstance(t, dict) and t.get("_deferred"))
-            ]
+            effective_tools = [t for t in tools if not (isinstance(t, dict) and t.get("_deferred"))]
         else:
             effective_tools = tools
         tools_tokens = self.estimate_tools_tokens(effective_tools)
@@ -443,6 +461,192 @@ class ContextManager:
             force=True,
         )
 
+    @staticmethod
+    def _continuity_store(memory_manager: object | None) -> Any | None:
+        store = getattr(memory_manager, "store", None)
+        required = (
+            "save_context_epoch",
+            "save_compaction_checkpoint",
+            "get_latest_completed_compaction",
+        )
+        return (
+            store if store is not None and all(hasattr(store, name) for name in required) else None
+        )
+
+    def _context_epoch(self, system_prompt: str, tools: list | None) -> ContextEpoch:
+        model = str(getattr(self._brain, "model", "") or "")
+        return ContextEpoch.build(system_prompt=system_prompt, tools=tools, model=model)
+
+    def _restore_completed_checkpoint(
+        self,
+        messages: list[dict],
+        *,
+        session_id: str,
+        store: Any | None,
+        epoch: ContextEpoch,
+    ) -> tuple[list[dict], dict | None, bool]:
+        if store is None or not session_id:
+            return messages, None, False
+        try:
+            checkpoint = store.get_latest_completed_compaction(session_id)
+        except Exception as exc:
+            logger.warning("[Compress] Checkpoint lookup failed: %s", exc)
+            return messages, None, False
+        if not checkpoint:
+            return messages, None, False
+        source_count = int(checkpoint.get("source_message_count", 0) or 0)
+        if source_count <= 0 or source_count > len(messages):
+            return messages, None, False
+        if content_digest(messages[:source_count]) != checkpoint.get("source_digest"):
+            return messages, None, False
+
+        summary = str(checkpoint.get("summary") or "")
+        recent = copy.deepcopy(checkpoint.get("recent_messages") or [])
+        saved_projection = copy.deepcopy(checkpoint.get("projected_messages") or [])
+        if not saved_projection and (not summary or not recent):
+            return messages, None, False
+        projected = saved_projection or self._inject_summary_into_recent(summary, recent)
+        projected.extend(copy.deepcopy(messages[source_count:]))
+        epoch_changed = checkpoint.get("epoch_digest") != epoch.digest
+        if epoch_changed:
+            projected.insert(
+                1,
+                {
+                    "role": "user",
+                    "content": (
+                        "[context_epoch_update] System instructions, tool schemas, or model "
+                        "configuration changed after the saved compaction. The current system "
+                        "context takes precedence over the anchored summary."
+                    ),
+                },
+            )
+        self._previous_summaries[session_id] = summary
+        logger.info(
+            "[Compress] Restored checkpoint %s for %s (%d source messages, epoch_changed=%s)",
+            checkpoint.get("id", "")[:12],
+            session_id,
+            source_count,
+            epoch_changed,
+        )
+        return projected, checkpoint, epoch_changed
+
+    def _recent_tail_budget(self, hard_limit: int) -> int:
+        from ..config import settings as _settings
+
+        ratio = float(getattr(_settings, "context_recent_tail_ratio", 0.25) or 0.25)
+        minimum = int(getattr(_settings, "context_recent_tail_min_tokens", 2000) or 2000)
+        maximum = int(getattr(_settings, "context_recent_tail_max_tokens", 8000) or 8000)
+        return min(maximum, max(minimum, int(hard_limit * ratio)))
+
+    def _select_recent_groups(
+        self, groups: list[list[dict]], *, hard_limit: int
+    ) -> tuple[list[list[dict]], list[list[dict]]]:
+        """Select a recent tail by token budget while preserving whole groups."""
+        if len(groups) <= 1:
+            return [], groups
+        from ..config import settings as _settings
+
+        legacy_cap = int(getattr(_settings, "context_min_recent_turns", 12) or 12)
+        max_groups = min(
+            legacy_cap,
+            int(getattr(_settings, "context_recent_tail_max_groups", legacy_cap) or legacy_cap),
+        )
+        budget = self._recent_tail_budget(hard_limit)
+        selected = 0
+        used = 0
+        for group in reversed(groups[-max_groups:]):
+            size = self.estimate_messages_tokens(group)
+            if selected and used + size > budget:
+                break
+            selected += 1
+            used += size
+            if used >= budget:
+                break
+        selected = max(1, selected)
+        return groups[:-selected], groups[-selected:]
+
+    async def _gather_compaction_contributions(
+        self,
+        *,
+        session_id: str,
+        messages: list[dict],
+        context_epoch: ContextEpoch,
+    ) -> list[CompactionContribution]:
+        results: list[CompactionContribution] = []
+        for contributor in tuple(self._compaction_contributors):
+            callback = getattr(contributor, "contribute_to_compaction", None)
+            if not callable(callback):
+                continue
+            try:
+                value = callback(
+                    session_id=session_id,
+                    messages=messages,
+                    context_epoch=context_epoch,
+                )
+                if inspect.isawaitable(value):
+                    value = await value
+                values = value if isinstance(value, list) else [value]
+                results.extend(item for item in values if isinstance(item, CompactionContribution))
+            except Exception as exc:
+                logger.warning("[Compress] Contributor %r failed: %s", contributor, exc)
+        results.sort(key=lambda item: (-item.priority, item.name))
+        return results
+
+    def _cold_store_tool_outputs(
+        self,
+        messages: list[dict],
+        *,
+        session_id: str,
+        store: Any | None,
+        protect_tokens: int,
+    ) -> tuple[list[dict], list[str]]:
+        if store is None or not hasattr(store, "save_tool_output_blob"):
+            return messages, []
+        copied = copy.deepcopy(messages)
+        protected_start = len(copied)
+        used = 0
+        for index in range(len(copied) - 1, -1, -1):
+            used += self._estimate_single_message_tokens(copied[index])
+            protected_start = index
+            if used >= protect_tokens:
+                break
+
+        tool_names: dict[str, str] = {}
+        for message in copied:
+            for item in (
+                message.get("content", []) if isinstance(message.get("content"), list) else []
+            ):
+                if isinstance(item, dict) and item.get("type") == "tool_use":
+                    tool_names[str(item.get("id") or "")] = str(item.get("name") or "")
+
+        refs: list[str] = []
+        for message in copied[:protected_start]:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "tool_result":
+                    continue
+                raw = item.get("content", "")
+                if not isinstance(raw, str) or len(raw) <= 8000 or "memory://tool-output/" in raw:
+                    continue
+                tool_name = tool_names.get(str(item.get("tool_use_id") or ""), "")
+                try:
+                    blob_id = store.save_tool_output_blob(session_id, tool_name, raw)
+                except Exception as exc:
+                    logger.warning("[Compress] Tool output cold-store failed: %s", exc)
+                    continue
+                if not blob_id:
+                    continue
+                refs.append(blob_id)
+                item["content"] = (
+                    raw[:2000]
+                    + f"\n\n[full tool output: memory://tool-output/{blob_id}; "
+                    + f"original_chars={len(raw)}]"
+                )
+                item["_cold_output_ref"] = blob_id
+        return copied, refs
+
     async def compress_if_needed(
         self,
         messages: list[dict],
@@ -454,6 +658,9 @@ class ContextManager:
         conversation_id: str | None = None,
         last_real_input_tokens: int | None = None,
         force: bool = False,
+        session_context: object | None = None,
+        working_directory: str | None = None,
+        persist_checkpoint: bool = False,
     ) -> list[dict]:
         """
         如果上下文接近限制，执行压缩 (autocompact)。
@@ -482,6 +689,47 @@ class ContextManager:
             压缩后的消息列表
         """
         from ..config import settings as _settings
+
+        source_messages = copy.deepcopy(messages)
+        session_id = str(
+            conversation_id or getattr(memory_manager, "_current_session_id", "") or ""
+        )
+        continuity_store = self._continuity_store(memory_manager)
+        context_epoch = self._context_epoch(system_prompt, tools)
+        if persist_checkpoint and continuity_store is not None and session_id:
+            try:
+                continuity_store.save_context_epoch(session_id, context_epoch.to_dict())
+            except Exception as exc:
+                logger.warning("[Compress] Context epoch persistence failed: %s", exc)
+            if session_context is not None and hasattr(session_context, "context_epoch"):
+                session_context.context_epoch = context_epoch.to_dict()
+            messages, restored_checkpoint, _epoch_changed = self._restore_completed_checkpoint(
+                messages,
+                session_id=session_id,
+                store=continuity_store,
+                epoch=context_epoch,
+            )
+            mirrored_getter = getattr(session_context, "latest_compaction_checkpoint", None)
+            mirrored = mirrored_getter() if callable(mirrored_getter) else None
+            if (
+                restored_checkpoint is None
+                and mirrored
+                and mirrored.get("epoch_digest") != context_epoch.digest
+                and not any(
+                    "[context_epoch_update]" in str(message.get("content", ""))
+                    for message in messages
+                )
+            ):
+                messages.insert(
+                    1 if messages else 0,
+                    {
+                        "role": "user",
+                        "content": (
+                            "[context_epoch_update] The current system context changed after "
+                            "the saved compaction and takes precedence over its summary."
+                        ),
+                    },
+                )
 
         pressure = self.calculate_context_pressure(
             messages,
@@ -550,6 +798,8 @@ class ContextManager:
             f"soft={soft_limit}, hard={hard_limit}), compressing with LLM..."
         )
 
+        checkpoint_record: dict | None = None
+
         def _end_ctx_span(result_msgs: list[dict]) -> list[dict]:
             """结束 ctx_span，修复 tool 配对，并返回结果"""
             result_msgs = self._sanitize_tool_pairs(result_msgs)
@@ -557,7 +807,36 @@ class ContextManager:
             ctx_span.set_attribute("tokens_after", result_tokens)
             ctx_span.set_attribute("compression_ratio", result_tokens / max(current_tokens, 1))
             tracer.end_span(ctx_span)
+            if checkpoint_record is not None and checkpoint_record.get("summary"):
+                checkpoint_record.update(
+                    status="completed",
+                    tokens_after=result_tokens,
+                    projected_messages=copy.deepcopy(result_msgs),
+                    completed_at=datetime.now().isoformat(),
+                )
+                try:
+                    continuity_store.save_compaction_checkpoint(checkpoint_record)
+                except Exception as exc:
+                    logger.warning("[Compress] Completed checkpoint persistence failed: %s", exc)
+                append_checkpoint = getattr(session_context, "append_compaction_checkpoint", None)
+                if callable(append_checkpoint):
+                    append_checkpoint(checkpoint_record)
             return result_msgs
+
+        # Deterministically move old large tool payloads out of the active prompt.
+        if persist_checkpoint and session_id:
+            messages, cold_refs = self._cold_store_tool_outputs(
+                messages,
+                session_id=session_id,
+                store=continuity_store,
+                protect_tokens=min(
+                    40_000,
+                    max(self._recent_tail_budget(hard_limit), int(hard_limit * 0.5)),
+                ),
+            )
+            if cold_refs:
+                logger.info("[Compress] Cold-stored %d tool outputs", len(cold_refs))
+                current_tokens = self.estimate_messages_tokens(messages)
 
         # Step 1: 对单条过大的 tool_result 独立压缩
         if _settings.context_enable_tool_compression:
@@ -593,9 +872,9 @@ class ContextManager:
                 "[Compress] Merged trailing assistant-question + user-answer into one group"
             )
 
-        recent_group_count = min(_settings.context_min_recent_turns, len(groups))
+        early_groups, recent_groups = self._select_recent_groups(groups, hard_limit=hard_limit)
 
-        if len(groups) <= recent_group_count:
+        if not early_groups:
             messages = await self._compress_large_tool_results(messages, threshold=2000)
             return _end_ctx_span(
                 self._hard_truncate_if_needed(
@@ -605,9 +884,6 @@ class ContextManager:
                     overhead_bytes=_overhead_bytes,
                 )
             )
-
-        early_groups = groups[:-recent_group_count]
-        recent_groups = groups[-recent_group_count:]
 
         early_messages = [msg for group in early_groups for msg in group]
         recent_messages = [msg for group in recent_groups for msg in group]
@@ -620,14 +896,100 @@ class ContextManager:
         early_tokens = self.estimate_messages_tokens(early_messages)
         target_summary_tokens = max(int(early_tokens * _settings.context_compression_ratio), 200)
         _summary_key = conversation_id or "__default__"
-        summary = await self._summarize_messages_chunked(
-            early_messages,
-            target_summary_tokens,
-            previous_summary=self._previous_summaries.get(_summary_key, ""),
-            url_facts=self._extract_urls_from_messages(early_messages),
+        if callable(getattr(memory_manager, "contribute_to_compaction", None)):
+            self.register_compaction_contributor(memory_manager)
+        contributions = await self._gather_compaction_contributions(
+            session_id=session_id,
+            messages=source_messages,
+            context_epoch=context_epoch,
         )
+        if contributions:
+            contribution_lines = ["[Compaction contributors]"]
+            for contribution in contributions:
+                max_chars = max(1, contribution.max_tokens) * CHARS_PER_TOKEN
+                contribution_lines.append(
+                    f"## {contribution.name}\n{contribution.content[:max_chars]}"
+                )
+            early_messages = [
+                *early_messages,
+                {"role": "user", "content": "\n\n".join(contribution_lines)},
+            ]
+
+        workspace_snapshot_id = ""
+        if persist_checkpoint and continuity_store is not None and session_id:
+            workspace_snapshot = await asyncio.to_thread(
+                capture_workspace_snapshot,
+                working_directory,
+                session_id=session_id,
+            )
+            if workspace_snapshot is not None:
+                try:
+                    workspace_snapshot_id = continuity_store.save_workspace_snapshot(
+                        workspace_snapshot.to_dict()
+                    )
+                except Exception as exc:
+                    logger.warning("[Compress] Workspace snapshot persistence failed: %s", exc)
+
+            checkpoint_record = CompactionCheckpoint(
+                id=uuid.uuid4().hex,
+                session_id=session_id,
+                status="started",
+                source_digest=content_digest(source_messages),
+                source_message_count=len(source_messages),
+                session_source_digest=content_digest(
+                    list(getattr(session_context, "messages", []) or [])
+                ),
+                session_source_message_count=len(
+                    list(getattr(session_context, "messages", []) or [])
+                ),
+                summary="",
+                recent_messages=copy.deepcopy(recent_messages),
+                projected_messages=[],
+                tail_start_index=max(0, len(messages) - len(recent_messages)),
+                tokens_before=pressure.messages_tokens,
+                tokens_after=0,
+                epoch_digest=context_epoch.digest,
+                workspace_snapshot_id=workspace_snapshot_id,
+                contributions=[
+                    {
+                        "name": item.name,
+                        "content": item.content,
+                        "priority": item.priority,
+                        "max_tokens": item.max_tokens,
+                    }
+                    for item in contributions
+                ],
+                model=context_epoch.model,
+                agent_profile_id=str(
+                    getattr(session_context, "agent_profile_id", "default") or "default"
+                ),
+            ).to_dict()
+            try:
+                continuity_store.save_compaction_checkpoint(checkpoint_record)
+            except Exception as exc:
+                logger.warning("[Compress] Started checkpoint persistence failed: %s", exc)
+
+        try:
+            summary = await self._summarize_messages_chunked(
+                early_messages,
+                target_summary_tokens,
+                previous_summary=self._previous_summaries.get(_summary_key, ""),
+                url_facts=self._extract_urls_from_messages(early_messages),
+            )
+        except BaseException as exc:
+            if checkpoint_record is not None:
+                checkpoint_record.update(status="failed", error=str(exc)[:1000])
+                try:
+                    continuity_store.save_compaction_checkpoint(checkpoint_record)
+                except Exception as persist_exc:
+                    logger.warning(
+                        "[Compress] Failed checkpoint persistence failed: %s", persist_exc
+                    )
+            raise
         if summary:
             self._previous_summaries[_summary_key] = summary
+            if checkpoint_record is not None:
+                checkpoint_record["summary"] = summary
 
         if summary and memory_manager is not None:
             try:

--- a/src/openakita/memory/manager.py
+++ b/src/openakita/memory/manager.py
@@ -1681,6 +1681,14 @@ class MemoryManager:
                         turns, session_id, source="session_end"
                     )
                     if episode:
+                        checkpoint = None
+                        with contextlib.suppress(Exception):
+                            checkpoint = self.store.get_latest_completed_compaction(session_id)
+                        if checkpoint:
+                            episode.compaction_checkpoint_id = checkpoint.get("id", "")
+                            episode.workspace_snapshot_id = checkpoint.get(
+                                "workspace_snapshot_id", ""
+                            )
                         self.store.save_episode(episode)
                         logger.info("[Memory] Session finalized: episode saved")
                 except Exception as e:
@@ -1953,6 +1961,36 @@ class MemoryManager:
                     )
             except Exception as e:
                 logger.warning(f"[Memory] Relational quick encode failed: {e}")
+
+    def contribute_to_compaction(self, **_kwargs):
+        """Provide bounded durable-memory state to the compaction pipeline."""
+        from openakita.runtime.context.continuity import CompactionContribution
+
+        parts: list[str] = []
+        snapshot = self.get_precompact_snapshot_context(max_chars=1000)
+        if snapshot:
+            parts.append(snapshot)
+        with contextlib.suppress(Exception):
+            scratchpad = self.store.get_scratchpad(self._current_user_id or "default")
+            if scratchpad:
+                rendered = scratchpad.to_markdown().strip()
+                if rendered:
+                    parts.append(rendered[:1000])
+        if not parts:
+            return None
+        return CompactionContribution(
+            name="Durable memory state",
+            content="\n\n".join(parts),
+            priority=90,
+            max_tokens=700,
+        )
+
+    def get_cold_tool_output(self, blob_id: str) -> str | None:
+        """Load a cold tool payload, restricted to the active session."""
+        session_id = self._current_session_id or ""
+        if not session_id:
+            return None
+        return self.store.get_tool_output_blob(blob_id, session_id=session_id)
 
     async def on_summary_generated(self, summary: str) -> None:
         """Called after context compression generates a summary — Layer 2 backfill."""

--- a/src/openakita/memory/storage.py
+++ b/src/openakita/memory/storage.py
@@ -17,12 +17,14 @@ SQLite 为唯一结构化主存储，管理所有记忆数据:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import shutil
 import sqlite3
 import threading
+import zlib
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -32,7 +34,7 @@ from .types import normalize_tags
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 5
+_SCHEMA_VERSION = 6
 
 # Process-level singleton registry: same db_path → same MemoryStorage instance
 _instance_registry: dict[str, MemoryStorage] = {}
@@ -614,7 +616,7 @@ class MemoryStorage:
         """
         c = conn or self._conn
         # FIX-D (post-S2 audit): do NOT swallow ALTER TABLE failures.  If
-        # we silently continue and then ``_set_schema_version(5)`` bumps
+        # we silently continue and then ``_set_schema_version`` bumps
         # the schema marker, the database lands in a "claims v5 but has
         # no metadata column" state, causing every subsequent
         # ``save_turn`` INSERT (11 placeholders against a 10-column
@@ -731,6 +733,10 @@ class MemoryStorage:
         c.execute("CREATE INDEX IF NOT EXISTS idx_episodes_time ON episodes(started_at)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_episodes_outcome ON episodes(outcome)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_memories_episode ON memories(source_episode_id)")
+        episode_columns = {row[1] for row in c.execute("PRAGMA table_info(episodes)").fetchall()}
+        for col in ("compaction_checkpoint_id", "workspace_snapshot_id"):
+            if col not in episode_columns:
+                c.execute(f"ALTER TABLE episodes ADD COLUMN {col} TEXT DEFAULT ''")
 
         c.execute("""
             CREATE TABLE IF NOT EXISTS scratchpad (
@@ -842,6 +848,80 @@ class MemoryStorage:
             )
         """)
 
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS context_epochs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                digest TEXT NOT NULL,
+                system_digest TEXT NOT NULL,
+                tools_digest TEXT NOT NULL,
+                model TEXT DEFAULT '',
+                created_at TEXT NOT NULL,
+                UNIQUE(session_id, digest)
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS workspace_snapshots (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                root TEXT NOT NULL,
+                capture_status TEXT NOT NULL DEFAULT 'unknown',
+                capture_error TEXT DEFAULT '',
+                vcs TEXT DEFAULT '',
+                head TEXT DEFAULT '',
+                status_digest TEXT DEFAULT '',
+                changed_files TEXT DEFAULT '[]',
+                patch_zlib BLOB,
+                patch_truncated INTEGER DEFAULT 0,
+                created_at TEXT NOT NULL
+            )
+        """)
+        workspace_snapshot_columns = {
+            row[1] for row in c.execute("PRAGMA table_info(workspace_snapshots)").fetchall()
+        }
+        if "capture_status" not in workspace_snapshot_columns:
+            c.execute(
+                "ALTER TABLE workspace_snapshots "
+                "ADD COLUMN capture_status TEXT NOT NULL DEFAULT 'unknown'"
+            )
+        if "capture_error" not in workspace_snapshot_columns:
+            c.execute("ALTER TABLE workspace_snapshots ADD COLUMN capture_error TEXT DEFAULT ''")
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS tool_output_blobs (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                tool_name TEXT DEFAULT '',
+                content_zlib BLOB NOT NULL,
+                content_chars INTEGER NOT NULL,
+                created_at TEXT NOT NULL
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS compaction_checkpoints (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                source_digest TEXT NOT NULL,
+                source_message_count INTEGER NOT NULL,
+                session_source_digest TEXT DEFAULT '',
+                session_source_message_count INTEGER DEFAULT 0,
+                summary TEXT DEFAULT '',
+                recent_messages TEXT DEFAULT '[]',
+                projected_messages TEXT DEFAULT '[]',
+                tail_start_index INTEGER DEFAULT 0,
+                tokens_before INTEGER DEFAULT 0,
+                tokens_after INTEGER DEFAULT 0,
+                epoch_digest TEXT DEFAULT '',
+                workspace_snapshot_id TEXT DEFAULT '',
+                contributions TEXT DEFAULT '[]',
+                model TEXT DEFAULT '',
+                agent_profile_id TEXT DEFAULT 'default',
+                created_at TEXT NOT NULL,
+                completed_at TEXT DEFAULT '',
+                error TEXT DEFAULT ''
+            )
+        """)
+
         # ==============================================================
         # Phase 2: CREATE INDEX — all tables already exist at this point
         # ==============================================================
@@ -870,6 +950,22 @@ class MemoryStorage:
 
         # extraction_queue
         c.execute("CREATE INDEX IF NOT EXISTS idx_eq_status ON extraction_queue(status)")
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_context_epochs_session "
+            "ON context_epochs(session_id, id DESC)"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_workspace_snapshots_session "
+            "ON workspace_snapshots(session_id, created_at DESC)"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tool_output_session "
+            "ON tool_output_blobs(session_id, created_at DESC)"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_compaction_session_status "
+            "ON compaction_checkpoints(session_id, status, completed_at DESC)"
+        )
         try:
             c.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_eq_session_turn ON extraction_queue(session_id, turn_index)"
@@ -1516,8 +1612,9 @@ class MemoryStorage:
                     INSERT OR REPLACE INTO episodes
                     (id, session_id, summary, goal, outcome, started_at, ended_at,
                      action_nodes, entities, tools_used, linked_memory_ids, tags,
-                     importance_score, access_count, source)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     importance_score, access_count, source, compaction_checkpoint_id,
+                     workspace_snapshot_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         episode.get("id", ""),
@@ -1535,6 +1632,8 @@ class MemoryStorage:
                         episode.get("importance_score", 0.5),
                         episode.get("access_count", 0),
                         episode.get("source", "session_end"),
+                        episode.get("compaction_checkpoint_id", ""),
+                        episode.get("workspace_snapshot_id", ""),
                     ),
                 )
                 self._conn.commit()
@@ -1649,6 +1748,8 @@ class MemoryStorage:
             "tags",
             "entities",
             "tools_used",
+            "compaction_checkpoint_id",
+            "workspace_snapshot_id",
         }
         filtered = {k: v for k, v in updates.items() if k in allowed}
         if not filtered:
@@ -2571,6 +2672,174 @@ class MemoryStorage:
         except Exception as e:
             logger.error(f"Failed to get session attachments: {e}")
             return []
+
+    # ======================================================================
+    # Durable context continuity
+    # ======================================================================
+
+    def save_context_epoch(self, session_id: str, epoch: dict) -> str:
+        if not self._conn or not session_id or not epoch.get("digest"):
+            return ""
+        with self._lock:
+            self._conn.execute(
+                """INSERT OR IGNORE INTO context_epochs
+                   (session_id, digest, system_digest, tools_digest, model, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    epoch["digest"],
+                    epoch.get("system_digest", ""),
+                    epoch.get("tools_digest", ""),
+                    epoch.get("model", ""),
+                    epoch.get("created_at") or datetime.now().isoformat(),
+                ),
+            )
+            self._conn.commit()
+        return str(epoch["digest"])
+
+    def get_latest_context_epoch(self, session_id: str) -> dict | None:
+        if not self._conn or not session_id:
+            return None
+        cursor = self._conn.execute(
+            "SELECT * FROM context_epochs WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+            (session_id,),
+        )
+        rows = self._rows_to_dicts(cursor)
+        return rows[0] if rows else None
+
+    def save_workspace_snapshot(self, snapshot: dict) -> str:
+        if not self._conn or not snapshot.get("id"):
+            return ""
+        patch = str(snapshot.get("patch") or "")
+        with self._lock:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO workspace_snapshots
+                   (id, session_id, root, capture_status, capture_error, vcs, head,
+                    status_digest, changed_files, patch_zlib, patch_truncated, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    snapshot["id"],
+                    snapshot.get("session_id", ""),
+                    snapshot.get("root", ""),
+                    snapshot.get("capture_status", "unknown"),
+                    str(snapshot.get("capture_error") or "")[:1000],
+                    snapshot.get("vcs", ""),
+                    snapshot.get("head", ""),
+                    snapshot.get("status_digest", ""),
+                    json.dumps(snapshot.get("changed_files", []), ensure_ascii=False),
+                    zlib.compress(patch.encode("utf-8")) if patch else b"",
+                    int(bool(snapshot.get("patch_truncated"))),
+                    snapshot.get("created_at") or datetime.now().isoformat(),
+                ),
+            )
+            self._conn.commit()
+        return str(snapshot["id"])
+
+    def get_workspace_snapshot(self, snapshot_id: str) -> dict | None:
+        if not self._conn or not snapshot_id:
+            return None
+        cursor = self._conn.execute(
+            "SELECT * FROM workspace_snapshots WHERE id = ?", (snapshot_id,)
+        )
+        rows = self._rows_to_dicts(cursor, json_fields=["changed_files"])
+        if not rows:
+            return None
+        result = rows[0]
+        compressed = result.pop("patch_zlib", b"") or b""
+        result["patch"] = zlib.decompress(compressed).decode("utf-8") if compressed else ""
+        result["patch_truncated"] = bool(result.get("patch_truncated"))
+        return result
+
+    def save_tool_output_blob(self, session_id: str, tool_name: str, content: str) -> str:
+        if not self._conn or not content:
+            return ""
+        digest = hashlib.sha256(f"{session_id}\0{content}".encode()).hexdigest()
+        with self._lock:
+            self._conn.execute(
+                """INSERT OR IGNORE INTO tool_output_blobs
+                   (id, session_id, tool_name, content_zlib, content_chars, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    digest,
+                    session_id,
+                    tool_name,
+                    zlib.compress(content.encode("utf-8")),
+                    len(content),
+                    datetime.now().isoformat(),
+                ),
+            )
+            self._conn.commit()
+        return digest
+
+    def get_tool_output_blob(self, blob_id: str, session_id: str = "") -> str | None:
+        if not self._conn or not blob_id:
+            return None
+        if session_id:
+            row = self._conn.execute(
+                "SELECT content_zlib FROM tool_output_blobs WHERE id = ? AND session_id = ?",
+                (blob_id, session_id),
+            ).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT content_zlib FROM tool_output_blobs WHERE id = ?", (blob_id,)
+            ).fetchone()
+        if not row:
+            return None
+        return zlib.decompress(row[0]).decode("utf-8")
+
+    def save_compaction_checkpoint(self, checkpoint: dict) -> str:
+        if not self._conn or not checkpoint.get("id") or not checkpoint.get("session_id"):
+            return ""
+        with self._lock:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO compaction_checkpoints
+                   (id, session_id, status, source_digest, source_message_count,
+                    session_source_digest, session_source_message_count,
+                    summary, recent_messages, projected_messages, tail_start_index, tokens_before,
+                    tokens_after, epoch_digest, workspace_snapshot_id, contributions,
+                    model, agent_profile_id, created_at, completed_at, error)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    checkpoint["id"],
+                    checkpoint["session_id"],
+                    checkpoint.get("status", "started"),
+                    checkpoint.get("source_digest", ""),
+                    int(checkpoint.get("source_message_count", 0)),
+                    checkpoint.get("session_source_digest", ""),
+                    int(checkpoint.get("session_source_message_count", 0)),
+                    checkpoint.get("summary", ""),
+                    json.dumps(checkpoint.get("recent_messages", []), ensure_ascii=False),
+                    json.dumps(checkpoint.get("projected_messages", []), ensure_ascii=False),
+                    int(checkpoint.get("tail_start_index", 0)),
+                    int(checkpoint.get("tokens_before", 0)),
+                    int(checkpoint.get("tokens_after", 0)),
+                    checkpoint.get("epoch_digest", ""),
+                    checkpoint.get("workspace_snapshot_id", ""),
+                    json.dumps(checkpoint.get("contributions", []), ensure_ascii=False),
+                    checkpoint.get("model", ""),
+                    checkpoint.get("agent_profile_id", "default"),
+                    checkpoint.get("created_at") or datetime.now().isoformat(),
+                    checkpoint.get("completed_at", ""),
+                    checkpoint.get("error", ""),
+                ),
+            )
+            self._conn.commit()
+        return str(checkpoint["id"])
+
+    def get_latest_completed_compaction(self, session_id: str) -> dict | None:
+        if not self._conn or not session_id:
+            return None
+        cursor = self._conn.execute(
+            """SELECT * FROM compaction_checkpoints
+               WHERE session_id = ? AND status = 'completed'
+               ORDER BY completed_at DESC, created_at DESC LIMIT 1""",
+            (session_id,),
+        )
+        rows = self._rows_to_dicts(
+            cursor,
+            json_fields=["recent_messages", "projected_messages", "contributions"],
+        )
+        return rows[0] if rows else None
 
     # ======================================================================
     # Export / Import / Cleanup

--- a/src/openakita/memory/types.py
+++ b/src/openakita/memory/types.py
@@ -439,6 +439,8 @@ class Episode:
     importance_score: float = 0.5
     access_count: int = 0
     source: str = "session_end"  # session_end / context_compress / daily_consolidation
+    compaction_checkpoint_id: str = ""
+    workspace_snapshot_id: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -457,6 +459,8 @@ class Episode:
             "importance_score": self.importance_score,
             "access_count": self.access_count,
             "source": self.source,
+            "compaction_checkpoint_id": self.compaction_checkpoint_id,
+            "workspace_snapshot_id": self.workspace_snapshot_id,
         }
 
     @classmethod
@@ -483,6 +487,8 @@ class Episode:
             importance_score=data.get("importance_score", 0.5),
             access_count=data.get("access_count", 0),
             source=data.get("source", "session_end"),
+            compaction_checkpoint_id=data.get("compaction_checkpoint_id", ""),
+            workspace_snapshot_id=data.get("workspace_snapshot_id", ""),
         )
 
     def to_markdown(self) -> str:

--- a/src/openakita/memory/unified_store.py
+++ b/src/openakita/memory/unified_store.py
@@ -689,6 +689,34 @@ class UnifiedStore:
         return [Attachment.from_dict(r) for r in rows]
 
     # ======================================================================
+    # Durable context continuity
+    # ======================================================================
+
+    def save_context_epoch(self, session_id: str, epoch: dict) -> str:
+        return self.db.save_context_epoch(session_id, epoch)
+
+    def get_latest_context_epoch(self, session_id: str) -> dict | None:
+        return self.db.get_latest_context_epoch(session_id)
+
+    def save_workspace_snapshot(self, snapshot: dict) -> str:
+        return self.db.save_workspace_snapshot(snapshot)
+
+    def get_workspace_snapshot(self, snapshot_id: str) -> dict | None:
+        return self.db.get_workspace_snapshot(snapshot_id)
+
+    def save_tool_output_blob(self, session_id: str, tool_name: str, content: str) -> str:
+        return self.db.save_tool_output_blob(session_id, tool_name, content)
+
+    def get_tool_output_blob(self, blob_id: str, session_id: str = "") -> str | None:
+        return self.db.get_tool_output_blob(blob_id, session_id=session_id)
+
+    def save_compaction_checkpoint(self, checkpoint: dict) -> str:
+        return self.db.save_compaction_checkpoint(checkpoint)
+
+    def get_latest_completed_compaction(self, session_id: str) -> dict | None:
+        return self.db.get_latest_completed_compaction(session_id)
+
+    # ======================================================================
     # Utilities
     # ======================================================================
 

--- a/src/openakita/runtime/context/__init__.py
+++ b/src/openakita/runtime/context/__init__.py
@@ -19,14 +19,30 @@ from .budget_trace import (
     payload_size_bytes,
 )
 from .compress import pre_request_cleanup, sanitize_tool_pairs
+from .continuity import (
+    CompactionCheckpoint,
+    CompactionContribution,
+    CompactionContributor,
+    ContextEpoch,
+    WorkspaceSnapshot,
+    capture_workspace_snapshot,
+    content_digest,
+)
 from .grouping import group_messages
 
 __all__ = [
     "DEFAULT_MAX_CONTEXT_TOKENS",
     "calc_context_budget",
+    "capture_workspace_snapshot",
+    "CompactionCheckpoint",
+    "CompactionContribution",
+    "CompactionContributor",
+    "content_digest",
+    "ContextEpoch",
     "estimate_tokens",
     "group_messages",
     "payload_size_bytes",
     "pre_request_cleanup",
     "sanitize_tool_pairs",
+    "WorkspaceSnapshot",
 ]

--- a/src/openakita/runtime/context/continuity.py
+++ b/src/openakita/runtime/context/continuity.py
@@ -1,0 +1,231 @@
+"""Durable context-continuity primitives used by context compaction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def content_digest(value: Any) -> str:
+    """Return a stable digest for persisted context projections."""
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContextEpoch:
+    """Fingerprint of privileged context used to produce a compaction."""
+
+    digest: str
+    system_digest: str
+    tools_digest: str
+    model: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    @classmethod
+    def build(cls, *, system_prompt: str, tools: list | None, model: str = "") -> ContextEpoch:
+        system_digest = content_digest(system_prompt or "")
+        tools_digest = content_digest(tools or [])
+        return cls(
+            digest=content_digest(
+                {"system": system_digest, "tools": tools_digest, "model": model or ""}
+            ),
+            system_digest=system_digest,
+            tools_digest=tools_digest,
+            model=model or "",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CompactionContribution:
+    """A bounded, named context block supplied before compaction."""
+
+    name: str
+    content: str
+    priority: int = 50
+    max_tokens: int = 500
+
+
+@runtime_checkable
+class CompactionContributor(Protocol):
+    """Extension point for plans, memory, plugins, or domain runtimes."""
+
+    def contribute_to_compaction(
+        self,
+        *,
+        session_id: str,
+        messages: list[dict],
+        context_epoch: ContextEpoch,
+    ) -> CompactionContribution | list[CompactionContribution] | None: ...
+
+
+@dataclass(frozen=True)
+class WorkspaceSnapshot:
+    """Read-only VCS snapshot associated with a compaction checkpoint."""
+
+    id: str
+    session_id: str
+    root: str
+    capture_status: str = "unknown"
+    capture_error: str = ""
+    vcs: str = ""
+    head: str = ""
+    status_digest: str = ""
+    changed_files: list[str] = field(default_factory=list)
+    patch: str = ""
+    patch_truncated: bool = False
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class _GitResult:
+    stdout: str = ""
+    status: str = "success"
+    error: str = ""
+
+
+def _git(root: Path, *args: str, timeout: float = 4.0) -> _GitResult:
+    command = "git " + " ".join(args[:2])
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return _GitResult(
+            status="git_unavailable",
+            error="git executable was not found",
+        )
+    except subprocess.TimeoutExpired:
+        return _GitResult(
+            status="command_failed",
+            error=f"{command} timed out after {timeout:g} seconds",
+        )
+    except OSError as exc:
+        return _GitResult(
+            status="command_failed",
+            error=f"{command} could not start: {exc}"[:1000],
+        )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        status = (
+            "not_a_repository" if "not a git repository" in stderr.lower() else "command_failed"
+        )
+        detail = stderr or "no error output"
+        return _GitResult(
+            status=status,
+            error=f"{command} exited with code {completed.returncode}: {detail}"[:1000],
+        )
+    return _GitResult(stdout=completed.stdout)
+
+
+def capture_workspace_snapshot(
+    root: str | Path | None,
+    *,
+    session_id: str,
+    max_patch_chars: int = 2_000_000,
+) -> WorkspaceSnapshot | None:
+    """Capture Git identity and a bounded patch without modifying the workspace."""
+    if not root:
+        return None
+    path = Path(root).expanduser().resolve()
+    if not path.is_dir():
+        return None
+
+    top_result = _git(path, "rev-parse", "--show-toplevel")
+    top = top_result.stdout.strip()
+    if top_result.status != "success" or not top:
+        return WorkspaceSnapshot(
+            id=uuid.uuid4().hex,
+            session_id=session_id,
+            root=str(path),
+            capture_status=(
+                top_result.status if top_result.status != "success" else "command_failed"
+            ),
+            capture_error=top_result.error or "git rev-parse returned an empty repository root",
+        )
+
+    repo = Path(top).resolve()
+    head_result = _git(repo, "rev-parse", "HEAD")
+    status_result = _git(repo, "status", "--porcelain=v1", "--untracked-files=normal")
+    patch_result = _git(repo, "diff", "--binary", "--no-ext-diff", "HEAD", "--", timeout=8.0)
+    results = (head_result, status_result, patch_result)
+    failed = next((result for result in results if result.status != "success"), None)
+    head = head_result.stdout.strip()
+    status = status_result.stdout
+    changed_files = []
+    for line in status.splitlines():
+        value = line[3:].strip() if len(line) > 3 else ""
+        if " -> " in value:
+            value = value.split(" -> ", 1)[1]
+        if value and value not in changed_files:
+            changed_files.append(value)
+
+    patch = patch_result.stdout
+    truncated = len(patch) > max_patch_chars
+    if truncated:
+        patch = patch[:max_patch_chars]
+    return WorkspaceSnapshot(
+        id=uuid.uuid4().hex,
+        session_id=session_id,
+        root=str(repo),
+        capture_status=failed.status if failed else "success",
+        capture_error=failed.error if failed else "",
+        vcs="git",
+        head=head,
+        status_digest=content_digest(status),
+        changed_files=changed_files,
+        patch=patch,
+        patch_truncated=truncated,
+    )
+
+
+@dataclass(frozen=True)
+class CompactionCheckpoint:
+    """Durable projection of a compacted conversation prefix."""
+
+    id: str
+    session_id: str
+    status: str
+    source_digest: str
+    source_message_count: int
+    session_source_digest: str
+    session_source_message_count: int
+    summary: str
+    recent_messages: list[dict]
+    projected_messages: list[dict]
+    tail_start_index: int
+    tokens_before: int
+    tokens_after: int
+    epoch_digest: str
+    workspace_snapshot_id: str = ""
+    contributions: list[dict] = field(default_factory=list)
+    model: str = ""
+    agent_profile_id: str = "default"
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    completed_at: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -228,6 +228,9 @@ class SessionContext:
     focus_terms: list[str] = field(default_factory=list)
     focus_updated_at: str | None = None
     precompact_snapshot: dict[str, Any] = field(default_factory=dict)
+    compaction_checkpoints: list[dict] = field(default_factory=list)
+    context_epoch: dict[str, Any] = field(default_factory=dict)
+    workspace_snapshot_id: str = ""
     _msg_lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
     def add_message(self, role: str, content: str, **metadata) -> bool:
@@ -481,6 +484,9 @@ class SessionContext:
             self.messages = []
             self.topic_boundaries = []
             self.current_topic_start = 0
+            self.compaction_checkpoints = []
+            self.context_epoch = {}
+            self.workspace_snapshot_id = ""
             self.variables["_context_reset_at"] = datetime.now().isoformat()
 
     def append_task_checkpoint(
@@ -521,6 +527,23 @@ class SessionContext:
                     return ckpt
         return None
 
+    def append_compaction_checkpoint(self, checkpoint: dict, *, max_keep: int = 20) -> dict:
+        """Mirror a durable compaction checkpoint into the session document."""
+        data = deepcopy(checkpoint)
+        with self._msg_lock:
+            self.compaction_checkpoints.append(data)
+            self.compaction_checkpoints = self.compaction_checkpoints[-max_keep:]
+            self.summary = str(data.get("summary") or self.summary or "")
+            self.workspace_snapshot_id = str(data.get("workspace_snapshot_id") or "")
+        return data
+
+    def latest_compaction_checkpoint(self) -> dict | None:
+        with self._msg_lock:
+            for checkpoint in reversed(self.compaction_checkpoints):
+                if checkpoint.get("status") == "completed":
+                    return deepcopy(checkpoint)
+        return None
+
     def to_dict(self) -> dict:
         """序列化"""
         with self._msg_lock:
@@ -544,6 +567,9 @@ class SessionContext:
                     "focus_terms": self.focus_terms,
                     "focus_updated_at": self.focus_updated_at,
                     "precompact_snapshot": self.precompact_snapshot,
+                    "compaction_checkpoints": self.compaction_checkpoints,
+                    "context_epoch": self.context_epoch,
+                    "workspace_snapshot_id": self.workspace_snapshot_id,
                 }
             )
 
@@ -569,6 +595,9 @@ class SessionContext:
             focus_terms=data.get("focus_terms", []),
             focus_updated_at=data.get("focus_updated_at"),
             precompact_snapshot=data.get("precompact_snapshot", {}),
+            compaction_checkpoints=data.get("compaction_checkpoints", []),
+            context_epoch=data.get("context_epoch", {}),
+            workspace_snapshot_id=data.get("workspace_snapshot_id", ""),
         )
 
 

--- a/tests/unit/test_context_continuity.py
+++ b/tests/unit/test_context_continuity.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import openakita.runtime.context.continuity as continuity
+from openakita.agent.context import ContextManager
+from openakita.memory.storage import _SCHEMA_VERSION, MemoryStorage
+from openakita.memory.unified_store import UnifiedStore
+from openakita.runtime.context.continuity import (
+    CompactionContribution,
+    ContextEpoch,
+    capture_workspace_snapshot,
+    content_digest,
+)
+from openakita.sessions.session import SessionContext
+
+
+def _manager() -> ContextManager:
+    return ContextManager(SimpleNamespace(model="test-model"))
+
+
+def test_context_epoch_is_stable_and_tracks_privileged_inputs() -> None:
+    first = ContextEpoch.build(system_prompt="rules", tools=[{"name": "read"}], model="m")
+    same = ContextEpoch.build(system_prompt="rules", tools=[{"name": "read"}], model="m")
+    changed = ContextEpoch.build(system_prompt="new rules", tools=[{"name": "read"}], model="m")
+
+    assert first.digest == same.digest
+    assert first.digest != changed.digest
+
+
+def test_continuity_storage_round_trip(tmp_path) -> None:
+    store = UnifiedStore(tmp_path / "memory.db")
+    epoch = ContextEpoch.build(system_prompt="rules", tools=[], model="m").to_dict()
+    assert store.save_context_epoch("s1", epoch) == epoch["digest"]
+    assert store.get_latest_context_epoch("s1")["digest"] == epoch["digest"]
+
+    blob_id = store.save_tool_output_blob("s1", "shell", "large output" * 1000)
+    assert store.get_tool_output_blob(blob_id) == "large output" * 1000
+    assert store.get_tool_output_blob(blob_id, session_id="other") is None
+
+    snapshot = capture_workspace_snapshot(tmp_path, session_id="s1")
+    assert snapshot is not None
+    snapshot_id = store.save_workspace_snapshot(snapshot.to_dict())
+    loaded_snapshot = store.get_workspace_snapshot(snapshot_id)
+    assert loaded_snapshot["root"] == str(tmp_path.resolve())
+    assert loaded_snapshot["capture_status"] in {"not_a_repository", "git_unavailable"}
+    assert loaded_snapshot["capture_error"]
+
+    checkpoint = {
+        "id": "checkpoint-1",
+        "session_id": "s1",
+        "status": "completed",
+        "source_digest": "abc",
+        "source_message_count": 2,
+        "summary": "anchored summary",
+        "recent_messages": [{"role": "user", "content": "recent"}],
+        "projected_messages": [{"role": "user", "content": "projected"}],
+        "tail_start_index": 1,
+        "tokens_before": 100,
+        "tokens_after": 20,
+        "epoch_digest": epoch["digest"],
+        "workspace_snapshot_id": snapshot_id,
+        "contributions": [{"name": "plan"}],
+        "model": "m",
+        "created_at": "2026-01-01T00:00:00",
+        "completed_at": "2026-01-01T00:00:01",
+        "error": "",
+    }
+    store.save_compaction_checkpoint(checkpoint)
+    loaded = store.get_latest_completed_compaction("s1")
+    assert loaded["summary"] == "anchored summary"
+    assert loaded["recent_messages"][0]["content"] == "recent"
+    assert loaded["projected_messages"][0]["content"] == "projected"
+    assert loaded["workspace_snapshot_id"] == snapshot_id
+
+
+def test_workspace_snapshot_reports_missing_git(tmp_path, monkeypatch) -> None:
+    def missing_git(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(continuity.subprocess, "run", missing_git)
+
+    snapshot = capture_workspace_snapshot(tmp_path, session_id="s1")
+
+    assert snapshot is not None
+    assert snapshot.capture_status == "git_unavailable"
+    assert snapshot.capture_error == "git executable was not found"
+    assert snapshot.vcs == ""
+
+
+def test_workspace_snapshot_reports_non_repository(tmp_path, monkeypatch) -> None:
+    def not_a_repository(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository (or any parent up to mount point)",
+        )
+
+    monkeypatch.setattr(continuity.subprocess, "run", not_a_repository)
+
+    snapshot = capture_workspace_snapshot(tmp_path, session_id="s1")
+
+    assert snapshot is not None
+    assert snapshot.capture_status == "not_a_repository"
+    assert "not a git repository" in snapshot.capture_error
+    assert snapshot.vcs == ""
+
+
+def test_checkpoint_restore_requires_an_exact_source_prefix(tmp_path) -> None:
+    store = UnifiedStore(tmp_path / "memory.db")
+    manager = _manager()
+    source = [
+        {"role": "user", "content": "old request"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    epoch = ContextEpoch.build(system_prompt="rules", tools=[], model="test-model")
+    store.save_compaction_checkpoint(
+        {
+            "id": "checkpoint-1",
+            "session_id": "s1",
+            "status": "completed",
+            "source_digest": content_digest(source),
+            "source_message_count": len(source),
+            "summary": "old work is complete",
+            "recent_messages": [{"role": "assistant", "content": "old answer"}],
+            "projected_messages": [],
+            "tail_start_index": 1,
+            "tokens_before": 100,
+            "tokens_after": 20,
+            "epoch_digest": epoch.digest,
+            "created_at": "2026-01-01T00:00:00",
+            "completed_at": "2026-01-01T00:00:01",
+        }
+    )
+
+    restored, checkpoint, changed = manager._restore_completed_checkpoint(
+        [*source, {"role": "user", "content": "new request"}],
+        session_id="s1",
+        store=store,
+        epoch=epoch,
+    )
+    assert checkpoint["id"] == "checkpoint-1"
+    assert changed is False
+    assert "old work is complete" in restored[0]["content"]
+    assert restored[-1]["content"] == "new request"
+
+    untouched, checkpoint, _ = manager._restore_completed_checkpoint(
+        [{"role": "user", "content": "different"}],
+        session_id="s1",
+        store=store,
+        epoch=epoch,
+    )
+    assert untouched == [{"role": "user", "content": "different"}]
+    assert checkpoint is None
+
+
+def test_checkpoint_lookup_failure_degrades_to_original_messages() -> None:
+    manager = _manager()
+    messages = [{"role": "user", "content": "continue"}]
+
+    class LockedStore:
+        def get_latest_completed_compaction(self, _session_id):
+            raise RuntimeError("database is locked")
+
+    restored, checkpoint, changed = manager._restore_completed_checkpoint(
+        messages,
+        session_id="s1",
+        store=LockedStore(),
+        epoch=ContextEpoch.build(system_prompt="", tools=[]),
+    )
+    assert restored is messages
+    assert checkpoint is None
+    assert changed is False
+
+
+def test_recent_tail_selection_uses_token_budget(monkeypatch) -> None:
+    manager = _manager()
+    monkeypatch.setattr(manager, "_recent_tail_budget", lambda _limit: 700)
+    groups = [[{"role": "user", "content": str(i) * 600}] for i in range(6)]
+
+    early, recent = manager._select_recent_groups(groups, hard_limit=10_000)
+
+    assert early
+    assert 1 <= len(recent) < len(groups)
+    assert recent[-1][0]["content"].startswith("5")
+
+
+def test_old_tool_output_is_cold_stored_without_mutating_source(tmp_path) -> None:
+    store = UnifiedStore(tmp_path / "memory.db")
+    manager = _manager()
+    raw = "x" * 12_000
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "call-1", "name": "shell", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": raw}],
+        },
+        {"role": "user", "content": "z" * 1000},
+    ]
+
+    projected, refs = manager._cold_store_tool_outputs(
+        messages, session_id="s1", store=store, protect_tokens=100
+    )
+
+    assert refs
+    assert messages[1]["content"][0]["content"] == raw
+    assert "memory://tool-output/" in projected[1]["content"][0]["content"]
+    assert store.get_tool_output_blob(refs[0]) == raw
+
+
+@pytest.mark.asyncio
+async def test_contributors_are_ordered_and_bounded_by_contract() -> None:
+    manager = _manager()
+
+    class Contributor:
+        async def contribute_to_compaction(self, **_kwargs):
+            return CompactionContribution("plan", "next step", priority=80, max_tokens=20)
+
+    manager.register_compaction_contributor(Contributor())
+    epoch = ContextEpoch.build(system_prompt="", tools=[])
+    values = await manager._gather_compaction_contributions(
+        session_id="s1", messages=[], context_epoch=epoch
+    )
+    assert values == [CompactionContribution("plan", "next step", priority=80, max_tokens=20)]
+
+
+@pytest.mark.asyncio
+async def test_force_compaction_persists_completed_checkpoint(tmp_path, monkeypatch) -> None:
+    store = UnifiedStore(tmp_path / "memory.db")
+    manager = _manager()
+    memory_manager = SimpleNamespace(store=store, _current_session_id="s1")
+    session_context = SessionContext()
+    messages = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": str(i) * 5000} for i in range(8)
+    ]
+
+    async def summarize(*_args, **_kwargs):
+        return "## Objective\n- persist continuity"
+
+    monkeypatch.setattr(manager, "_summarize_messages_chunked", summarize)
+    result = await manager.compress_if_needed(
+        messages,
+        system_prompt="rules",
+        tools=[],
+        max_tokens=6000,
+        memory_manager=memory_manager,
+        conversation_id="s1",
+        force=True,
+        session_context=session_context,
+        working_directory=str(tmp_path),
+        persist_checkpoint=True,
+    )
+
+    checkpoint = store.get_latest_completed_compaction("s1")
+    assert checkpoint is not None
+    assert checkpoint["summary"].startswith("## Objective")
+    assert checkpoint["projected_messages"] == result
+    assert session_context.latest_compaction_checkpoint()["id"] == checkpoint["id"]
+    assert len(result) < len(messages)
+
+
+def test_session_context_serializes_compaction_state() -> None:
+    context = SessionContext()
+    context.context_epoch = {"digest": "epoch"}
+    context.append_compaction_checkpoint(
+        {"id": "c1", "status": "completed", "summary": "summary", "workspace_snapshot_id": "w1"}
+    )
+
+    loaded = SessionContext.from_dict(context.to_dict())
+    assert loaded.latest_compaction_checkpoint()["id"] == "c1"
+    assert loaded.context_epoch["digest"] == "epoch"
+    assert loaded.workspace_snapshot_id == "w1"
+
+
+def test_schema_v5_migrates_context_continuity_tables(tmp_path) -> None:
+    db_path = tmp_path / "memory.db"
+    storage = MemoryStorage(db_path)
+    storage._conn.execute("DROP TABLE compaction_checkpoints")
+    storage._conn.execute("DROP TABLE context_epochs")
+    storage._conn.execute("DROP TABLE tool_output_blobs")
+    storage._conn.execute("DROP TABLE workspace_snapshots")
+    storage._set_schema_version(5)
+    storage.close()
+
+    migrated = MemoryStorage(db_path)
+    assert migrated._get_schema_version() == _SCHEMA_VERSION
+    names = {
+        row[0]
+        for row in migrated._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    assert {
+        "compaction_checkpoints",
+        "context_epochs",
+        "tool_output_blobs",
+        "workspace_snapshots",
+    } <= names
+    snapshot_columns = {
+        row[1]
+        for row in migrated._conn.execute("PRAGMA table_info(workspace_snapshots)").fetchall()
+    }
+    assert {"capture_status", "capture_error"} <= snapshot_columns


### PR DESCRIPTION
## Summary

- Persist validated compaction checkpoints and restore the exact model-visible projection after process restarts without replacing original session messages.
- Bound the recent tail by tokens, cold-store old large tool outputs, and fingerprint system prompts, effective tools, and model identity with context epochs.
- Add bounded compaction contributors and link checkpoints and episodes to diagnostic Git workspace snapshots that degrade cleanly when Git is unavailable.

## Tests

- `uv run --no-sync pytest -q tests/unit/test_context_continuity.py tests/unit/test_memory_storage_recovery.py tests/unit/test_memory_v4_migration_and_isolation.py` (`57 passed`)
- `uv run --no-sync ruff check src/openakita/runtime/context/continuity.py src/openakita/memory/storage.py tests/unit/test_context_continuity.py`
- `uv run --no-sync ruff format --check src/openakita/runtime/context/continuity.py src/openakita/memory/storage.py tests/unit/test_context_continuity.py`
- `git diff --check`
