### PR TITLE
Grant reusable mobile builds permission to upload release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,8 @@ jobs:
   mobile_release:
     needs: [create_release]
     if: github.event_name == 'push' || inputs.include_mobile
+    permissions:
+      contents: write
     uses: ./.github/workflows/mobile.yml
     with:
       tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -37,6 +37,7 @@ def test_mobile_release_waits_for_draft_creation_without_an_independent_tag_trig
 
     mobile_job = release_workflow["jobs"]["mobile_release"]
     assert mobile_job["needs"] == ["create_release"]
+    assert mobile_job["permissions"] == {"contents": "write"}
     assert mobile_job["uses"] == "./.github/workflows/mobile.yml"
     assert mobile_job["secrets"] == "inherit"
     assert "github.event_name == 'push'" in mobile_job["if"]


### PR DESCRIPTION
## Summary

- grant the reusable mobile workflow permission to upload Android and iOS release assets
- test the caller permission contract to prevent another workflow startup failure

## Tests

- `uv run --no-sync pytest tests/unit/test_release_workflow_contract.py tests/unit/test_release_contract.py -q`
- `uv run --no-sync ruff check tests/unit/test_release_workflow_contract.py`
- parsed `release.yml` and `mobile.yml` with PyYAML
