### PR TITLE
fix mobile plugin apps to authenticate API requests through the host bridge

### DIFF
--- a/apps/setup-center/src/components/__tests__/PluginBridgeHost.auth.test.ts
+++ b/apps/setup-center/src/components/__tests__/PluginBridgeHost.auth.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  authFetch: vi.fn(),
+  downloadFile: vi.fn(),
+}));
+
+vi.mock("../../platform/auth", () => ({
+  authFetch: mocks.authFetch,
+  isTauriRemoteMode: () => false,
+}));
+
+vi.mock("../../platform", () => ({
+  IS_TAURI: false,
+  copyFileToDownloads: vi.fn(),
+  downloadFile: mocks.downloadFile,
+}));
+
+import { PluginBridgeHost } from "../../lib/plugin-bridge-host";
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("PluginBridgeHost authenticated proxy", () => {
+  let iframe: HTMLIFrameElement;
+  let bridge: PluginBridgeHost;
+  let postMessage: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mocks.authFetch.mockReset();
+    mocks.downloadFile.mockReset();
+    iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    postMessage = vi.spyOn(iframe.contentWindow!, "postMessage");
+    bridge = new PluginBridgeHost({
+      pluginId: "happyhorse-video",
+      iframe,
+      apiBase: "https://akita.example",
+      theme: "light",
+      locale: "zh-CN",
+    });
+  });
+
+  afterEach(() => {
+    bridge.dispose();
+    iframe.remove();
+  });
+
+  function send(type: string, payload: Record<string, unknown>, requestId: string) {
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { __akita_bridge: true, version: 1, type, payload, requestId },
+    }));
+  }
+
+  it("uses the auth-aware transport for plugin API requests", async () => {
+    mocks.authFetch.mockResolvedValueOnce(response({ tasks: [] }));
+
+    send("bridge:api-request", {
+      method: "GET",
+      path: "/api/plugins/happyhorse-video/tasks",
+    }, "api-1");
+
+    await waitFor(() => expect(mocks.authFetch).toHaveBeenCalledTimes(1));
+    expect(mocks.authFetch.mock.calls[0][0]).toBe(
+      "https://akita.example/api/plugins/happyhorse-video/tasks",
+    );
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: "bridge:api-response",
+      requestId: "api-1",
+      payload: expect.objectContaining({ ok: true, status: 200, body: { tasks: [] } }),
+    }), "*"));
+  });
+
+  it("rebuilds multipart form data and uploads through the auth-aware transport", async () => {
+    mocks.authFetch.mockResolvedValueOnce(response({ ok: true, preview_url: "/preview/1" }));
+    const file = new File(["image"], "frame.png", { type: "image/png" });
+
+    send("bridge:upload", {
+      path: "/api/plugins/happyhorse-video/upload",
+      entries: [{ name: "file", value: file, filename: file.name }],
+    }, "upload-1");
+
+    await waitFor(() => expect(mocks.authFetch).toHaveBeenCalledTimes(1));
+    const init = mocks.authFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("file")).toBeInstanceOf(Blob);
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: "bridge:upload-ack",
+      requestId: "upload-1",
+      payload: expect.objectContaining({ ok: true, status: 200 }),
+    }), "*"));
+  });
+
+  it("rejects requests outside the current plugin API", async () => {
+    send("bridge:api-request", {
+      method: "GET",
+      path: "/api/config/workspace-info",
+    }, "api-denied");
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: "bridge:api-response",
+      requestId: "api-denied",
+      payload: expect.objectContaining({ ok: false, status: 0 }),
+    }), "*"));
+    expect(mocks.authFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/setup-center/src/lib/plugin-bridge-host.ts
+++ b/apps/setup-center/src/lib/plugin-bridge-host.ts
@@ -148,6 +148,10 @@ export class PluginBridgeHost {
         this.handleApiRequest(data);
         break;
 
+      case "bridge:upload":
+        this.handleUpload(data);
+        break;
+
       case "bridge:notification":
         if (this.onNotification && data.payload) {
           this.onNotification(data.payload as { title: string; body: string; type?: string });
@@ -247,11 +251,25 @@ export class PluginBridgeHost {
 
     try {
       const platform = await import("../platform");
+      const { isTauriRemoteMode } = await import("../platform/auth");
       const savedPath = localPath
         ? await platform.copyFileToDownloads(localPath, fname)
         : await (async () => {
             const resolvedUrl = rawUrl!.startsWith("http") ? rawUrl! : `${this.apiBase}${rawUrl}`;
-            return platform.downloadFile(resolvedUrl, fname);
+            if (platform.IS_TAURI && !isTauriRemoteMode()) {
+              return platform.downloadFile(resolvedUrl, fname);
+            }
+
+            const resp = this.isBackendUrl(resolvedUrl)
+              ? await this.authenticatedFetch(resolvedUrl)
+              : await fetch(resolvedUrl);
+            if (!resp.ok) throw new Error(`Download failed: HTTP ${resp.status}`);
+            const objectUrl = URL.createObjectURL(await resp.blob());
+            try {
+              return await platform.downloadFile(objectUrl, fname);
+            } finally {
+              setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+            }
           })();
       this.post({
         type: "bridge:download-ack",
@@ -349,8 +367,8 @@ export class PluginBridgeHost {
       return;
     }
 
-    const url = path.startsWith("http") ? path : `${this.apiBase}${path}`;
     try {
+      const url = this.resolvePluginApiUrl(path);
       const fetchOpts: RequestInit = {
         method,
         headers: { "Content-Type": "application/json" },
@@ -358,7 +376,7 @@ export class PluginBridgeHost {
       if (body && method !== "GET" && method !== "HEAD") {
         fetchOpts.body = JSON.stringify(body);
       }
-      const resp = await fetch(url, fetchOpts);
+      const resp = await this.authenticatedFetch(url, fetchOpts);
       let respBody: unknown;
       const ct = resp.headers.get("content-type") || "";
       if (ct.includes("application/json")) {
@@ -379,5 +397,79 @@ export class PluginBridgeHost {
       });
     }
   }
-}
 
+  private async handleUpload(msg: BridgeMessage) {
+    const { path, entries } = (msg.payload || {}) as {
+      path?: string;
+      entries?: Array<{ name?: string; value?: unknown; filename?: string }>;
+    };
+    if (!path || !Array.isArray(entries)) {
+      this.post({
+        type: "bridge:upload-ack",
+        requestId: msg.requestId,
+        payload: { ok: false, status: 400, error: "Missing upload path or entries" },
+      });
+      return;
+    }
+
+    try {
+      const url = this.resolvePluginApiUrl(path);
+      const formData = new FormData();
+      for (const entry of entries) {
+        if (!entry.name) continue;
+        if (entry.value instanceof Blob) {
+          formData.append(entry.name, entry.value, entry.filename);
+        } else {
+          formData.append(entry.name, String(entry.value ?? ""));
+        }
+      }
+      const resp = await this.authenticatedFetch(url, { method: "POST", body: formData });
+      const contentType = resp.headers.get("content-type") || "";
+      const body = contentType.includes("application/json")
+        ? await resp.json()
+        : await resp.text();
+      this.post({
+        type: "bridge:upload-ack",
+        requestId: msg.requestId,
+        payload: { ok: resp.ok, status: resp.status, body },
+      });
+    } catch (e) {
+      this.post({
+        type: "bridge:upload-ack",
+        requestId: msg.requestId,
+        payload: { ok: false, status: 0, error: String(e) },
+      });
+    }
+  }
+
+  private async authenticatedFetch(url: string, init?: RequestInit): Promise<Response> {
+    const { authFetch } = await import("../platform/auth");
+    let authBase = this.apiBase;
+    try {
+      authBase = new URL(this.apiBase || window.location.origin).origin;
+    } catch { /* relative local-web base */ }
+    return authFetch(url, init, authBase);
+  }
+
+  private isBackendUrl(url: string): boolean {
+    try {
+      const backendOrigin = new URL(this.apiBase || window.location.origin).origin;
+      return new URL(url, backendOrigin).origin === backendOrigin;
+    } catch {
+      return false;
+    }
+  }
+
+  private resolvePluginApiUrl(path: string): string {
+    const backendOrigin = new URL(this.apiBase || window.location.origin).origin;
+    const url = new URL(path, backendOrigin);
+    const pluginPrefix = `/api/plugins/${encodeURIComponent(this.pluginId)}`;
+    if (
+      url.origin !== backendOrigin
+      || (url.pathname !== pluginPrefix && !url.pathname.startsWith(`${pluginPrefix}/`))
+    ) {
+      throw new Error("Plugin bridge requests must target the current plugin API");
+    }
+    return url.toString();
+  }
+}

--- a/plugins/happyhorse-video/tests/test_smoke.py
+++ b/plugins/happyhorse-video/tests/test_smoke.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_models_module_imports_clean():
     import happyhorse_models  # noqa: F401
@@ -56,3 +60,20 @@ def test_plugin_module_imports_clean():
 
     mod = load_happyhorse_plugin()
     assert mod.PLUGIN_ID == "happyhorse-video"
+
+
+def test_ui_routes_api_and_uploads_through_host_bridge():
+    html = (PLUGIN_ROOT / "ui" / "dist" / "index.html").read_text(encoding="utf-8")
+
+    assert 'typeof window.OpenAkita.api === "function"' in html
+    assert 'typeof window.OpenAkita.upload === "function"' in html
+    assert "const r = await uploadAsset(file);" in html
+
+
+def test_ui_bootstrap_supports_upload_bridge_messages():
+    bootstrap = (PLUGIN_ROOT / "ui" / "dist" / "_assets" / "bootstrap.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'case "bridge:upload-ack":' in bootstrap
+    assert 'return request("bridge:upload"' in bootstrap

--- a/plugins/happyhorse-video/ui/dist/_assets/bootstrap.js
+++ b/plugins/happyhorse-video/ui/dist/_assets/bootstrap.js
@@ -79,6 +79,7 @@
         break;
       }
       case "bridge:api-response":
+      case "bridge:upload-ack":
       case "bridge:download-ack":
       case "bridge:open-external-ack":
       case "bridge:show-in-folder-ack":
@@ -119,6 +120,20 @@
     get meta() { return Object.assign({}, meta); },
     api: function (method, path, body) {
       return request("bridge:api-request", { method: method, path: path, body: body });
+    },
+    upload: function (path, formData) {
+      var entries = [];
+      if (!formData || typeof formData.forEach !== "function") {
+        return Promise.resolve({ ok: false, error: "formData is required" });
+      }
+      formData.forEach(function (value, name) {
+        entries.push({
+          name: name,
+          value: value,
+          filename: typeof File !== "undefined" && value instanceof File ? value.name : undefined,
+        });
+      });
+      return request("bridge:upload", { path: path, entries: entries });
     },
     notify: function (opts) { send("bridge:notification", opts || {}); },
     navigate: function (viewId) { send("bridge:navigate", { viewId: viewId }); },

--- a/plugins/happyhorse-video/ui/dist/index.html
+++ b/plugins/happyhorse-video/ui/dist/index.html
@@ -84,6 +84,24 @@ class ApiError extends Error {
 }
 
 async function api(method, path, body) {
+  if (window.OpenAkita && typeof window.OpenAkita.api === "function") {
+    const result = await window.OpenAkita.api(
+      method,
+      `/api/plugins/${PLUGIN_ID}${path}`,
+      body,
+    );
+    const responseBody = result?.body;
+    if (!result?.ok) {
+      const detail = responseBody?.detail ?? responseBody ?? result?.error;
+      const message =
+        (detail && typeof detail === "object" && detail.message)
+        || (typeof detail === "string" && detail)
+        || `${result?.status || 0} request failed`;
+      throw new ApiError(result?.status || 0, message, detail);
+    }
+    return responseBody;
+  }
+
   const opts = { method, headers: {} };
   if (body !== undefined) {
     opts.headers["Content-Type"] = "application/json";
@@ -103,6 +121,29 @@ async function api(method, path, body) {
       || `${res.status} ${res.statusText}`;
     throw new ApiError(res.status, message, detail);
   }
+  return res.json();
+}
+
+async function uploadAsset(file) {
+  const fd = new FormData();
+  fd.append("file", file);
+  if (window.OpenAkita && typeof window.OpenAkita.upload === "function") {
+    const result = await window.OpenAkita.upload(
+      `/api/plugins/${PLUGIN_ID}/upload`,
+      fd,
+    );
+    if (!result?.ok) {
+      const detail = result?.body?.detail ?? result?.body ?? result?.error;
+      const message =
+        (detail && typeof detail === "object" && (detail.message || detail.error))
+        || (typeof detail === "string" && detail)
+        || `${result?.status || 0} upload failed`;
+      throw new Error(message);
+    }
+    return result.body;
+  }
+
+  const res = await fetch(apiBase() + "/upload", { method: "POST", body: fd });
   return res.json();
 }
 
@@ -1282,10 +1323,7 @@ function UploadUrlField({ label, value, onChange, accept = "*/*", kind = "image"
     if (!file) return;
     setUploading(true);
     try {
-      const fd = new FormData();
-      fd.append("file", file);
-      const res = await fetch(apiBase() + "/upload", { method: "POST", body: fd });
-      const r = await res.json();
+      const r = await uploadAsset(file);
       if (!r.ok) throw new Error(r.error || "upload failed");
       setAsset(r);
       if (!r.oss_url) {
@@ -1513,10 +1551,7 @@ function FileUploadCard({ accept, kind, value, onUploaded, hint }) {
     if (!file) return;
     setUploading(true);
     try {
-      const fd = new FormData();
-      fd.append("file", file);
-      const res = await fetch(apiBase() + "/upload", { method: "POST", body: fd });
-      const r = await res.json();
+      const r = await uploadAsset(file);
       if (!r.ok) throw new Error(r.error || "upload failed");
       onUploaded(r);
       if (!r.oss_url) {

--- a/src/openakita/api/auth.py
+++ b/src/openakita/api/auth.py
@@ -14,6 +14,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from pathlib import Path
@@ -49,6 +50,7 @@ AUTH_EXEMPT_PATHS = frozenset(
     }
 )
 AUTH_EXEMPT_PREFIXES = ("/web/", "/web", "/ws/", "/docs", "/openapi.json", "/redoc", "/user-docs")
+PLUGIN_UI_ASSET_PATH = re.compile(r"^/api/plugins/[^/]+/ui(?:/.*)?$")
 
 # ---------------------------------------------------------------------------
 # Password hashing (scrypt, stdlib)
@@ -439,6 +441,13 @@ def _is_auth_exempt(path: str) -> bool:
     return any(path.startswith(prefix) for prefix in AUTH_EXEMPT_PREFIXES)
 
 
+def _is_public_plugin_ui_asset(request: Request) -> bool:
+    """Allow iframe documents and their static assets without exposing plugin APIs."""
+    return request.method in {"GET", "HEAD"} and bool(
+        PLUGIN_UI_ASSET_PATH.fullmatch(request.url.path)
+    )
+
+
 def create_auth_middleware(config: WebAccessConfig):
     """Create the authentication middleware function."""
 
@@ -449,8 +458,10 @@ def create_auth_middleware(config: WebAccessConfig):
 
         path = request.url.path
 
-        # Static files and auth endpoints are always accessible
-        if _is_auth_exempt(path):
+        # Static files and auth endpoints are always accessible. Plugin UI
+        # documents are loaded by iframe/resource tags, which cannot attach a
+        # Bearer header; only their read-only static mount is public.
+        if _is_auth_exempt(path) or _is_public_plugin_ui_asset(request):
             return await call_next(request)
 
         # Direct local connections bypass auth (Tauri desktop, curl on the

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -11,6 +11,7 @@
 8. /api/config 需要认证
 9. 记忆管理 API 需要认证（曾有 401 bug）
 10. token 刷新流程
+11. 插件 UI 静态资源免认证，但插件业务 API 仍需认证
 """
 
 from __future__ import annotations
@@ -325,3 +326,42 @@ class TestTokenRefresh:
             },
         )
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 11. Plugin iframe static assets are public; plugin APIs stay protected
+# ---------------------------------------------------------------------------
+
+
+class TestPluginUiRemoteAuth:
+    async def test_plugin_ui_document_does_not_require_auth(self, client, monkeypatch):
+        monkeypatch.setenv("TRUST_PROXY", "true")
+        resp = await client.get(
+            "/api/plugins/example/ui/",
+            headers={"X-Forwarded-For": "203.0.113.50"},
+        )
+        assert resp.status_code != 401
+
+    async def test_plugin_ui_asset_head_does_not_require_auth(self, client, monkeypatch):
+        monkeypatch.setenv("TRUST_PROXY", "true")
+        resp = await client.head(
+            "/api/plugins/example/ui/_assets/app.js",
+            headers={"X-Forwarded-For": "203.0.113.50"},
+        )
+        assert resp.status_code != 401
+
+    async def test_plugin_business_api_still_requires_auth(self, client, monkeypatch):
+        monkeypatch.setenv("TRUST_PROXY", "true")
+        resp = await client.get(
+            "/api/plugins/example/tasks",
+            headers={"X-Forwarded-For": "203.0.113.50"},
+        )
+        assert resp.status_code == 401
+
+    async def test_plugin_ui_post_still_requires_auth(self, client, monkeypatch):
+        monkeypatch.setenv("TRUST_PROXY", "true")
+        resp = await client.post(
+            "/api/plugins/example/ui/",
+            headers={"X-Forwarded-For": "203.0.113.50"},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Allow unauthenticated GET and HEAD requests only for plugin UI iframe documents and static assets while keeping plugin business APIs protected.
- Route HappyHorse API calls, multipart uploads, and remote downloads through the scoped authenticated host bridge so mobile clients retain authentication.
- Add backend, frontend bridge, and HappyHorse UI regression coverage for remote plugin authentication.

## Tests

- `uv run --no-sync pytest tests/integration/test_auth_flow.py -q`
- `uv run --no-sync pytest plugins/happyhorse-video/tests/test_smoke.py plugins/happyhorse-video/tests/test_plugin.py -q`
- `npm run test:run -- src/components/__tests__/PluginBridgeHost.auth.test.ts`
- `npx eslint src/lib/plugin-bridge-host.ts src/components/__tests__/PluginBridgeHost.auth.test.ts`
- `npm run build`
- `uv run --no-sync ruff check src/openakita/api/auth.py tests/integration/test_auth_flow.py plugins/happyhorse-video/tests/test_smoke.py`
