### PR TITLE
Fix IM organization video delivery through channel adapters

### DIFF
--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -15,6 +15,7 @@ import base64
 import collections
 import contextlib
 import hashlib
+import inspect
 import logging
 import os
 import random
@@ -3227,10 +3228,21 @@ class MessageGateway:
             return False
 
     def _get_org_manager(self):
-        """从 OrgCommandService 链路上取出 OrgManager 单例。
+        """取出进程级 OrgManager 单例。
 
         IM 端按名字/ID 解析组织时用。拿不到（服务未就绪）时返回 None。
         """
+        try:
+            from openakita.orgs.store import get_default_org_manager
+
+            manager = get_default_org_manager()
+            if manager is not None:
+                return manager
+        except Exception:
+            pass
+
+        # 兼容未发布默认 manager 的旧组合根。OrgRuntime 在 v2 重构后将
+        # OrgManager 作为 lookup 注入；更早的实现使用 _manager。
         try:
             from openakita.orgs.command_service import get_command_service
 
@@ -3238,7 +3250,9 @@ class MessageGateway:
             if svc is None:
                 return None
             runtime = getattr(svc, "_runtime", None)
-            return getattr(runtime, "_manager", None) if runtime else None
+            if runtime is None:
+                return None
+            return getattr(runtime, "_lookup", None) or getattr(runtime, "_manager", None)
         except Exception:
             return None
 
@@ -3702,6 +3716,51 @@ class MessageGateway:
         return False
 
     @staticmethod
+    def _extract_org_result_attachments(result: dict) -> list[dict]:
+        """Normalize files exposed by an organization command's terminal result."""
+        attachments: list[dict] = []
+        seen: set[str] = set()
+
+        def add_attachment(raw: dict, path: object) -> None:
+            file_path = str(path or "").strip()
+            if not file_path:
+                return
+            key = file_path.lower().replace("\\", "/")
+            if key in seen:
+                return
+            seen.add(key)
+            attachment = dict(raw)
+            attachment["file_path"] = file_path
+            attachments.append(attachment)
+
+        raw_attachments = result.get("file_attachments") or []
+        if isinstance(raw_attachments, list):
+            for raw in raw_attachments:
+                if not isinstance(raw, dict):
+                    continue
+                add_attachment(raw, raw.get("file_path") or raw.get("path"))
+
+        manifest = result.get("delivery_manifest")
+        artifacts = manifest.get("artifacts") if isinstance(manifest, dict) else []
+        if isinstance(artifacts, list):
+            for artifact in artifacts:
+                if not isinstance(artifact, dict):
+                    continue
+                paths = artifact.get("paths") or []
+                if isinstance(paths, str):
+                    paths = [paths]
+                if not isinstance(paths, list):
+                    continue
+                metadata = {
+                    "kind": artifact.get("kind"),
+                    "name": artifact.get("name"),
+                }
+                for path in paths:
+                    add_attachment(metadata, path)
+
+        return attachments
+
+    @staticmethod
     def _append_attachment_media_lines(final_text: str, attachments: list[dict]) -> str:
         media_lines: list[str] = []
         seen: set[str] = set()
@@ -3834,7 +3893,7 @@ class MessageGateway:
                 return True
 
             chat_type = message.chat_type or "private"
-            started = svc.submit(
+            started = await svc.submit(
                 OrgCommandRequest(
                     org_id=org_id,
                     content=task,
@@ -3916,9 +3975,7 @@ class MessageGateway:
                         attachments: list[dict] = []
                         if isinstance(result, dict):
                             final_text = str(result.get("result") or result.get("error") or result)
-                            raw_attachments = result.get("file_attachments") or []
-                            if isinstance(raw_attachments, list):
-                                attachments = [a for a in raw_attachments if isinstance(a, dict)]
+                            attachments = self._extract_org_result_attachments(result)
                         else:
                             final_text = str(error or result or "组织命令已完成")
                         if attachments:
@@ -5681,6 +5738,21 @@ class MessageGateway:
         """补发从回复文本中解析出的图片/文件"""
         reply_to = original.thread_id or original.channel_message_id
 
+        def reply_kwargs(method: Callable[..., Any]) -> dict[str, str]:
+            if not reply_to:
+                return {}
+            try:
+                parameters = inspect.signature(method).parameters.values()
+            except (TypeError, ValueError):
+                return {}
+            if any(
+                parameter.name == "reply_to"
+                or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            ):
+                return {"reply_to": reply_to}
+            return {}
+
         if adapter.has_capability("send_image"):
             for img in media_result.images:
                 if img.is_url:
@@ -5711,7 +5783,7 @@ class MessageGateway:
                     await adapter.send_file(
                         original.chat_id,
                         file.path,
-                        reply_to=reply_to,
+                        **reply_kwargs(adapter.send_file),
                     )
                 except Exception as e:
                     logger.warning(f"[SendResponse] send extracted file failed: {e}")
@@ -5732,7 +5804,7 @@ class MessageGateway:
                     await adapter.send_voice(
                         original.chat_id,
                         audio.path,
-                        reply_to=reply_to,
+                        **reply_kwargs(adapter.send_voice),
                     )
                 except Exception as e:
                     logger.warning(f"[SendResponse] send extracted audio failed: {e}")

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -105,6 +105,51 @@ class TestMessageTypes:
         assert mc.videos == []
 
 
+class TestExtractedMediaDelivery:
+    @pytest.mark.asyncio
+    async def test_video_adapter_without_reply_to_receives_real_file(self, tmp_path):
+        from openakita.channels.media_parser import parse_media_from_text
+
+        video_path = tmp_path / "preview.mp4"
+        video_path.write_bytes(b"video")
+
+        class StrictFileAdapter:
+            def __init__(self):
+                self.sent_files: list[tuple[str, str]] = []
+                self.fallback_texts: list[str] = []
+
+            @staticmethod
+            def has_capability(name: str) -> bool:
+                return name == "send_file"
+
+            async def send_file(
+                self,
+                chat_id: str,
+                file_path: str,
+                caption: str | None = None,
+            ) -> str:
+                self.sent_files.append((chat_id, file_path))
+                return "video-message-id"
+
+            async def send_text(self, chat_id: str, text: str, **kwargs) -> str:
+                self.fallback_texts.append(text)
+                return "fallback-message-id"
+
+        gateway = MessageGateway(session_manager=MagicMock())
+        adapter = StrictFileAdapter()
+        original = create_channel_message(
+            channel="wechat:test",
+            chat_id="chat-1",
+        )
+        original.channel_message_id = "source-message-id"
+        media_result = parse_media_from_text(f"MEDIA: {video_path}")
+
+        await gateway._send_extracted_media(adapter, original, media_result, {})
+
+        assert adapter.sent_files == [("chat-1", str(video_path))]
+        assert adapter.fallback_texts == []
+
+
 class TestMessageGatewayBroadcast:
     @pytest.mark.asyncio
     async def test_send_rejects_non_text_payload(self):

--- a/tests/integration/test_gateway_org_control.py
+++ b/tests/integration/test_gateway_org_control.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -234,6 +235,18 @@ class TestOrgLastCommand:
 
 
 class TestOrgCommandsDoNotStartTyping:
+    def test_org_manager_uses_process_default(self, gateway):
+        """IM org lookup must follow the manager published by the API composition root."""
+        from openakita.orgs.store import get_default_org_manager, set_default_org_manager
+
+        previous = get_default_org_manager()
+        manager = MagicMock()
+        set_default_org_manager(manager)
+        try:
+            assert gateway._get_org_manager() is manager
+        finally:
+            set_default_org_manager(previous)
+
     async def test_org_list_returns_before_typing_placeholder(self, gateway, session_manager):
         """短组织命令应直接回复，不创建“思考中”占位卡片。"""
         session = create_test_session(chat_id="chat-list", channel="telegram")
@@ -263,6 +276,117 @@ class TestOrgCommandsDoNotStartTyping:
         reply = gateway._send_response.await_args.args[1]
         assert "当前共 1 个组织" in reply
         fake_adapter.send_typing.assert_not_awaited()
+
+    async def test_org_task_awaits_async_submit(self, gateway, session_manager):
+        """IM task submission must await OrgCommandService.submit before reading its result."""
+        session = create_test_session(
+            chat_id="chat-submit",
+            channel="telegram",
+            user_id="user-submit",
+        )
+        session.set_metadata("bound_org_id", "org_content")
+
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "result": {"result": "组织任务完成", "file_attachments": []},
+            }
+        )
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_submit"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value=None)
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+
+        msg = create_channel_message(
+            text="@org 写一段产品文案",
+            chat_id="chat-submit",
+            user_id="user-submit",
+        )
+        from openakita.orgs import command_service as cs_module
+
+        with patch.object(cs_module, "get_command_service", return_value=fake_svc):
+            handled = await gateway._try_handle_org_command(
+                msg,
+                session,
+                "@org 写一段产品文案",
+            )
+
+        assert handled is True
+        fake_svc.submit.assert_awaited_once()
+        assert fake_svc.subscribe_summary.call_args.args[0] == "cmd_submit"
+        fake_svc.unsubscribe_summary.assert_called_once_with("cmd_submit", queue)
+        reply = gateway._send_response.await_args.args[1]
+        assert reply == "组织任务完成"
+
+    async def test_org_task_sends_delivery_manifest_media(self, gateway, session_manager):
+        """Final manifest paths must enter the normal IM media delivery pipeline."""
+        session = create_test_session(
+            chat_id="chat-delivery",
+            channel="telegram",
+            user_id="user-delivery",
+        )
+        session.set_metadata("bound_org_id", "org_content")
+
+        image_path = r"D:\outputs\key-frame.png"
+        video_path = r"D:\outputs\preview.mp4"
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "result": {
+                    "result": "组织任务完成",
+                    "file_attachments": [{"file_path": image_path}],
+                    "delivery_manifest": {
+                        "artifacts": [
+                            {
+                                "kind": "image",
+                                "name": "关键帧",
+                                "paths": [image_path],
+                            },
+                            {
+                                "kind": "video",
+                                "name": "视频预览",
+                                "paths": [video_path],
+                            },
+                        ]
+                    },
+                },
+            }
+        )
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_delivery"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value=None)
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+
+        msg = create_channel_message(
+            text="@org 生成视频",
+            chat_id="chat-delivery",
+            user_id="user-delivery",
+        )
+        from openakita.orgs import command_service as cs_module
+
+        with patch.object(cs_module, "get_command_service", return_value=fake_svc):
+            handled = await gateway._try_handle_org_command(msg, session, "@org 生成视频")
+
+        assert handled is True
+        reply = gateway._send_response.await_args.args[1]
+        assert reply == (f"组织任务完成\n\nMEDIA: {image_path}\nMEDIA: {video_path}")
+        assert reply.count(image_path) == 1
 
 
 class TestPatchOrgStatusCard:


### PR DESCRIPTION
## Summary

- Resolve the process-level organization manager and await asynchronous IM organization submissions.
- Project delivery-manifest artifacts into IM media references with path deduplication.
- Send extracted files and voice attachments with only the reply arguments supported by each channel adapter.

## Tests

- `uv run --no-sync pytest tests/integration/test_gateway.py tests/integration/test_gateway_org_control.py -q` (65 passed)
- `uv run --no-sync ruff check src/openakita/channels/gateway.py tests/integration/test_gateway.py tests/integration/test_gateway_org_control.py`
- `git diff --check`
