### PR TITLE
Allow the mobile release contract to inspect draft release assets

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -35,7 +35,7 @@ jobs:
   release_contract:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -42,6 +42,9 @@ def test_mobile_release_waits_for_draft_creation_without_an_independent_tag_trig
     assert mobile_job["secrets"] == "inherit"
     assert "github.event_name == 'push'" in mobile_job["if"]
 
+    release_contract_job = mobile_workflow["jobs"]["release_contract"]
+    assert release_contract_job["permissions"] == {"contents": "write"}
+
 
 def test_packaging_verifies_checkout_identity_and_chat_api() -> None:
     workflow_sources = [


### PR DESCRIPTION
## Summary

- allow the mobile release contract job to inspect draft release assets
- prevent regressions by asserting the reusable workflow job permission

## Tests

- `uv run --no-sync pytest tests/unit/test_release_workflow_contract.py tests/unit/test_release_contract.py -q`
- `uv run --no-sync ruff check tests/unit/test_release_workflow_contract.py`
