### PR TITLE
reduce backend startup work with lazy Skill hydration and compact tool discovery

### DIFF
--- a/src/openakita/agent/skill_manager.py
+++ b/src/openakita/agent/skill_manager.py
@@ -121,7 +121,7 @@ class SkillManager:
             agent_referenced_skills=agent_skills,
         )
         loaded = self._loader.load_all(settings.project_root, load_filter=load_filter)
-        logger.info(f"Loaded {loaded} skills from standard directories")
+        logger.info("Indexed %d skill descriptors from standard directories", loaded)
 
         try:
             if effective is None:

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -1846,6 +1846,29 @@ def create_app(
     return app
 
 
+async def _wait_for_uvicorn_started(
+    server: Any,
+    api_thread: Any,
+    thread_error: list[Exception],
+    *,
+    timeout: float,
+) -> None:
+    """Wait until uvicorn reports startup completion without probing a bind host."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+
+    while not bool(getattr(server, "started", False)):
+        if thread_error:
+            raise RuntimeError(f"API thread failed to start: {thread_error[0]}")
+        if not api_thread.is_alive():
+            raise RuntimeError("API thread exited before uvicorn reported startup completion")
+
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError(f"uvicorn did not report startup completion within {timeout:.1f}s")
+        await asyncio.sleep(min(0.05, remaining))
+
+
 async def start_api_server(
     agent: Any = None,
     shutdown_event: asyncio.Event | None = None,
@@ -1985,27 +2008,29 @@ async def start_api_server(
         f"(version: {get_version_string()}, dual-loop: {api_loop is not None})"
     )
 
-    # ── Verify server is listening ───────────────────────────────────
-    for attempt in range(max_retries):
-        await asyncio.sleep(1.5)
+    # ``0.0.0.0`` / ``::`` are valid bind addresses but invalid client probe
+    # targets on some platforms. Uvicorn sets ``started`` only after lifespan
+    # startup completes and the listening server has been created, so wait for
+    # that authoritative signal instead of opening a socket to the bind host.
+    startup_timeout = max(1.5, float(max_retries) * 1.5)
+    try:
+        await _wait_for_uvicorn_started(
+            server,
+            api_thread,
+            thread_error,
+            timeout=startup_timeout,
+        )
+    except (Exception, asyncio.CancelledError):
+        server.should_exit = True
+        await asyncio.to_thread(api_thread.join, 1.0)
+        raise
 
-        if not api_thread.is_alive():
-            err = thread_error[0] if thread_error else RuntimeError("API thread died")
-            raise RuntimeError(f"HTTP API server failed to start: {err}")
-
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.settimeout(1.0)
-                s.connect((host, port))
-                logger.info(
-                    f"HTTP API server confirmed listening on http://{host}:{port} "
-                    f"(thread={api_thread.name})"
-                )
-                break
-        except (ConnectionRefusedError, OSError, TimeoutError):
-            if attempt < max_retries - 1:
-                logger.debug(f"Server not yet listening (attempt {attempt + 1}), waiting...")
-                continue
+    logger.info(
+        "HTTP API server confirmed started on http://%s:%s (thread=%s)",
+        host,
+        port,
+        api_thread.name,
+    )
 
     # ── Proxy task — cancelling it triggers graceful shutdown ─────────
     async def _proxy() -> None:

--- a/src/openakita/prompt/builder.py
+++ b/src/openakita/prompt/builder.py
@@ -1835,9 +1835,9 @@ def _build_catalogs_section(
     _tier = prompt_tier or PromptTier.LARGE
     _scope = {str(item).lower() for item in (catalog_scope or set())}
 
-    # Progressive disclosure: use index-only tool catalog for lightweight
-    # scenarios (CONSUMER_CHAT, SMALL tier, early conversation turns, or
-    # non-agent modes) to significantly reduce token consumption.
+    # Other catalogs still use this signal to choose their compact form.  The
+    # tool catalog itself is always progressive: a resident name index plus
+    # intent-relevant category details.
     _index_only = (
         _profile == PromptProfile.CONSUMER_CHAT
         or _tier == PromptTier.SMALL
@@ -1850,10 +1850,9 @@ def _build_catalogs_section(
 
     if tool_catalog:
         try:
-            if _index_only:
-                tools_text = tool_catalog.get_index_catalog()
-            else:
-                tools_text = tool_catalog.get_catalog()
+            tools_text = tool_catalog.get_progressive_catalog(
+                expand_categories=intent_tool_hints,
+            )
             if mode in ("plan", "ask"):
                 mode_note = (
                     "\n> ⚠️ **当前为 {} 模式** — 以下工具清单仅供规划参考。\n"

--- a/src/openakita/skills/loader.py
+++ b/src/openakita/skills/loader.py
@@ -390,7 +390,7 @@ class SkillLoader:
                         logger.debug(f"Failed to load cli-anything skill from {name}: {e}")
 
         if loaded:
-            logger.info(f"Loaded {loaded} cli-anything skills from pip packages")
+            logger.info("Indexed %d cli-anything skill descriptors from pip packages", loaded)
         return loaded
 
     @staticmethod
@@ -498,7 +498,7 @@ class SkillLoader:
 
         if flush_runtime_records:
             self._flush_runtime_registry_records(runtime_records)
-        logger.info(f"Loaded {loaded} skills from {directory}")
+        logger.info("Indexed %d skill descriptors from %s", loaded, directory)
         return loaded
 
     @staticmethod
@@ -683,7 +683,7 @@ class SkillLoader:
                     mark_skills_loaded([record])
             except Exception:
                 logger.debug("Failed to update skill runtime registry for %s", sid, exc_info=True)
-            logger.info(f"Loaded skill: {sid} (name={skill.metadata.name})")
+            logger.debug("Indexed skill descriptor: %s (name=%s)", sid, skill.metadata.name)
             return skill
 
         except Exception as e:
@@ -739,7 +739,7 @@ class SkillLoader:
         """
         skill = self._resolve_skill(key)
         if skill:
-            return skill.body
+            return skill.get_body()
         return None
 
     def compute_effective_allowlist(self, external_allowlist: set[str] | None) -> set[str] | None:

--- a/src/openakita/skills/parser.py
+++ b/src/openakita/skills/parser.py
@@ -1,8 +1,8 @@
 """
 SKILL.md 解析器
 
-遵循 Agent Skills 规范 (agentskills.io/specification)
-解析 SKILL.md 文件的 YAML frontmatter 和 Markdown body
+遵循 Agent Skills 规范 (agentskills.io/specification)。启动时只解析 YAML
+frontmatter；Markdown body 在首次访问时按需读取并缓存。
 """
 
 import copy
@@ -41,6 +41,14 @@ _GLOBAL_PARSE_CACHE_LOCK = threading.Lock()
 _GLOBAL_PARSE_CACHE: dict[tuple[str, float], "ParsedSkill"] = {}
 _GLOBAL_PARSE_CACHE_MAX = 2000
 
+# SKILL.md instructions are substantially larger than their discovery metadata.
+# Keep them out of ParsedSkill until a consumer explicitly asks for the body.
+_GLOBAL_BODY_CACHE_LOCK = threading.Lock()
+_GLOBAL_BODY_CACHE: dict[tuple[str, float], str] = {}
+_GLOBAL_BODY_CACHE_MAX = 2000
+
+_FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+
 
 def _global_cache_get(key: tuple[str, float]) -> "ParsedSkill | None":
     with _GLOBAL_PARSE_CACHE_LOCK:
@@ -75,18 +83,60 @@ def invalidate_global_parse_cache(path: Path | str | None = None) -> int:
         if path is None:
             n = len(_GLOBAL_PARSE_CACHE)
             _GLOBAL_PARSE_CACHE.clear()
-            return n
-        try:
-            target = str(Path(path).resolve())
-        except Exception:
-            return 0
-        prefix = target + _os.sep
-        keys_to_drop = [
-            k for k in list(_GLOBAL_PARSE_CACHE.keys()) if k[0] == target or k[0].startswith(prefix)
-        ]
-        for k in keys_to_drop:
-            _GLOBAL_PARSE_CACHE.pop(k, None)
-        return len(keys_to_drop)
+        else:
+            try:
+                target = str(Path(path).resolve())
+            except Exception:
+                return 0
+            prefix = target + _os.sep
+            keys_to_drop = [
+                k
+                for k in list(_GLOBAL_PARSE_CACHE.keys())
+                if k[0] == target or k[0].startswith(prefix)
+            ]
+            for k in keys_to_drop:
+                _GLOBAL_PARSE_CACHE.pop(k, None)
+            n = len(keys_to_drop)
+
+    with _GLOBAL_BODY_CACHE_LOCK:
+        if path is None:
+            _GLOBAL_BODY_CACHE.clear()
+        else:
+            body_keys_to_drop = [
+                k
+                for k in list(_GLOBAL_BODY_CACHE.keys())
+                if k[0] == target or k[0].startswith(prefix)
+            ]
+            for k in body_keys_to_drop:
+                _GLOBAL_BODY_CACHE.pop(k, None)
+    return n
+
+
+def _body_cache_key(path: Path) -> tuple[str, float]:
+    resolved = str(path.resolve())
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return resolved, mtime
+
+
+def _load_skill_body(path: Path) -> str:
+    cache_key = _body_cache_key(path)
+    with _GLOBAL_BODY_CACHE_LOCK:
+        cached = _GLOBAL_BODY_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    content = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_PATTERN.match(content)
+    body = (match.group(2) if match else content).strip()
+
+    with _GLOBAL_BODY_CACHE_LOCK:
+        if len(_GLOBAL_BODY_CACHE) >= _GLOBAL_BODY_CACHE_MAX:
+            _GLOBAL_BODY_CACHE.clear()
+        _GLOBAL_BODY_CACHE[cache_key] = body
+    return body
 
 
 def _clone_parsed_skill_for_caller(skill: "ParsedSkill") -> "ParsedSkill":
@@ -97,8 +147,8 @@ def _clone_parsed_skill_for_caller(skill: "ParsedSkill") -> "ParsedSkill":
     back the same object that lives inside ``_GLOBAL_PARSE_CACHE``
     those edits would leak across agents. ``copy.deepcopy`` is fine
     here — a ``ParsedSkill`` only carries the metadata dataclass,
-    short ``Path`` objects, and the markdown body string, so the copy
-    cost is ≪ a fresh YAML parse + disk read.
+    short ``Path`` objects, and an optional in-memory body override, so the
+    copy cost is much smaller than a fresh YAML parse.
     """
     return copy.deepcopy(skill)
 
@@ -229,13 +279,33 @@ class ParsedSkill:
     """
 
     metadata: SkillMetadata
-    body: str  # Markdown body
     path: Path  # SKILL.md 文件路径
 
     # 可选目录
     scripts_dir: Path | None = None
     references_dir: Path | None = None
     assets_dir: Path | None = None
+    _body_override: str | None = field(default=None, repr=False)
+
+    @property
+    def body(self) -> str:
+        """Return full instructions, hydrating SKILL.md on first access."""
+        return self.get_body()
+
+    @property
+    def body_loaded(self) -> bool:
+        """Whether the full instructions are already resident in memory."""
+        if self._body_override is not None:
+            return True
+        cache_key = _body_cache_key(self.path)
+        with _GLOBAL_BODY_CACHE_LOCK:
+            return cache_key in _GLOBAL_BODY_CACHE
+
+    def get_body(self) -> str:
+        """Load and cache the SKILL.md body on demand."""
+        if self._body_override is not None:
+            return self._body_override
+        return _load_skill_body(self.path)
 
     @property
     def skill_dir(self) -> Path:
@@ -273,7 +343,7 @@ class SkillParser:
     """
 
     # YAML frontmatter 正则
-    FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+    FRONTMATTER_PATTERN = _FRONTMATTER_PATTERN
 
     # F13: mtime-based parse cache — key: (resolved_path, mtime), value: ParsedSkill
     _parse_cache: dict[tuple[str, float], "ParsedSkill"] = {}
@@ -318,8 +388,7 @@ class SkillParser:
             # ``_clone_parsed_skill_for_caller`` for why this matters.
             return _clone_parsed_skill_for_caller(cached)
 
-        content = path.read_text(encoding="utf-8")
-        result = self.parse_content(content, path)
+        result = self._parse_metadata_file(path)
 
         # Store the FRESH-parsed object in both caches, but hand the
         # caller a deep copy so any post-parse mutation (e.g.
@@ -330,6 +399,63 @@ class SkillParser:
         self._parse_cache[cache_key] = result
         _global_cache_put(cache_key, result)
         return _clone_parsed_skill_for_caller(result)
+
+    def _parse_metadata_file(self, path: Path) -> ParsedSkill:
+        """Parse discovery metadata without reading the complete SKILL.md body."""
+        with path.open("r", encoding="utf-8") as handle:
+            first_line = handle.readline()
+            if first_line.strip() != "---":
+                return self.parse_content(path.read_text(encoding="utf-8"), path)
+
+            yaml_lines: list[str] = []
+            for line in handle:
+                if line.strip() == "---":
+                    break
+                yaml_lines.append(line)
+            else:
+                return self.parse_content(path.read_text(encoding="utf-8"), path)
+
+            yaml_content = "".join(yaml_lines)
+            try:
+                data = yaml.safe_load(yaml_content) or {}
+            except yaml.YAMLError:
+                return self.parse_content(path.read_text(encoding="utf-8"), path)
+
+            # A missing description is allowed to fall back to the first body
+            # paragraph without retaining or scanning the remainder of the file.
+            body_preview = ""
+            if not data.get("description"):
+                paragraph: list[str] = []
+                for line in handle:
+                    if not line.strip():
+                        if paragraph:
+                            break
+                        continue
+                    paragraph.append(line.rstrip("\r\n"))
+                body_preview = "\n".join(paragraph)
+
+        metadata = self._build_metadata(data, path, body=body_preview)
+        return self._make_parsed_skill(metadata, path)
+
+    @staticmethod
+    def _make_parsed_skill(
+        metadata: SkillMetadata,
+        path: Path,
+        *,
+        body: str | None = None,
+    ) -> ParsedSkill:
+        skill_dir = path.parent
+        scripts_dir = skill_dir / "scripts"
+        references_dir = skill_dir / "references"
+        assets_dir = skill_dir / "assets"
+        return ParsedSkill(
+            metadata=metadata,
+            path=path,
+            scripts_dir=scripts_dir if scripts_dir.exists() else None,
+            references_dir=references_dir if references_dir.exists() else None,
+            assets_dir=assets_dir if assets_dir.exists() else None,
+            _body_override=body,
+        )
 
     def parse_content(self, content: str, path: Path) -> ParsedSkill:
         """
@@ -365,28 +491,7 @@ class SkillParser:
         # 构建元数据（body 用于 description 自动提取回退）
         metadata = self._build_metadata(data, path, body=body)
 
-        # 验证目录名匹配（命名空间格式取 @ 后部分比较）
-        skill_dir = path.parent
-        expected_dir = metadata.name.split("@", 1)[-1] if "@" in metadata.name else metadata.name
-        if skill_dir.name != expected_dir:
-            logger.warning(
-                f"Skill directory name '{skill_dir.name}' does not match "
-                f"expected '{expected_dir}' (from skill name '{metadata.name}') in {path}"
-            )
-
-        # 查找可选目录
-        scripts_dir = skill_dir / "scripts"
-        references_dir = skill_dir / "references"
-        assets_dir = skill_dir / "assets"
-
-        return ParsedSkill(
-            metadata=metadata,
-            body=body,
-            path=path,
-            scripts_dir=scripts_dir if scripts_dir.exists() else None,
-            references_dir=references_dir if references_dir.exists() else None,
-            assets_dir=assets_dir if assets_dir.exists() else None,
-        )
+        return self._make_parsed_skill(metadata, path, body=body)
 
     @staticmethod
     def _derive_name_from_path(path: Path) -> str:
@@ -648,21 +753,24 @@ class SkillParser:
                 len(meta.name),
             )
 
-        # Directory name vs expected
-        expected_dir = meta.name.split("@", 1)[-1] if "@" in meta.name else meta.name
-        if skill.skill_dir and skill.skill_dir.name != expected_dir:
+        # Plain Agent Skills use their directory name as ``name``. Namespaced
+        # metadata names identify the upstream skill, while OpenAkita uses the
+        # directory as an independent, stable registry ID.
+        if "@" not in meta.name and skill.skill_dir and skill.skill_dir.name != meta.name:
             errors.append(
                 f"Directory name '{skill.skill_dir.name}' should match "
-                f"expected '{expected_dir}' (from skill name '{meta.name}')"
+                f"expected '{meta.name}' (from skill name '{meta.name}')"
             )
 
-        # Body length
-        body_lines = skill.body.count("\n") + 1
-        if body_lines > 500:
-            errors.append(
-                f"SKILL.md body has {body_lines} lines. "
-                f"Recommended: keep under 500 lines for efficient context usage."
-            )
+        # Direct parse_content() callers already supplied the body, so retain
+        # the advisory there. Normal startup validation must not hydrate it.
+        if skill._body_override is not None:
+            body_lines = skill._body_override.count("\n") + 1
+            if body_lines > 500:
+                errors.append(
+                    f"SKILL.md body has {body_lines} lines. "
+                    f"Recommended: keep under 500 lines for efficient context usage."
+                )
 
         # System skill must have handler and tool_name
         if meta.system and not meta.handler:

--- a/src/openakita/skills/registry.py
+++ b/src/openakita/skills/registry.py
@@ -314,7 +314,10 @@ class SkillEntry:
     def get_body(self) -> str | None:
         """获取技能 body (Level 2)"""
         if self._parsed_skill:
-            return self._parsed_skill.body
+            get_body = getattr(self._parsed_skill, "get_body", None)
+            if callable(get_body):
+                return get_body()
+            return getattr(self._parsed_skill, "body", None)
         return None
 
     def to_capability_descriptor(self) -> CapabilityDescriptor:
@@ -568,7 +571,7 @@ class SkillRegistry:
         # cheap and keeps other tools' caches warm.
         if entry.approval_class:
             self._invalidate_policy_classifier_cache(entry.get_exposed_tool_name())
-        logger.info(f"Registered skill: {entry.skill_id} (name={entry.name})")
+        logger.debug("Registered skill descriptor: %s (name=%s)", entry.skill_id, entry.name)
         return True
 
     @staticmethod

--- a/src/openakita/tools/catalog.py
+++ b/src/openakita/tools/catalog.py
@@ -30,6 +30,7 @@
 
 import difflib
 import logging
+import re
 from collections import OrderedDict
 
 from .defer_config import STABLE_MAIN_CHAT_CORE_TOOLS
@@ -426,6 +427,77 @@ but with full schema you'll fill arguments more reliably.
             "before calling any tool above."
         )
         return "\n".join(lines)
+
+    def get_progressive_catalog(
+        self,
+        expand_categories: list[str] | tuple[str, ...] | None = None,
+        exclude_high_freq: bool = True,
+    ) -> str:
+        """Return the stable tool index plus details for intent-relevant categories.
+
+        The index keeps every discoverable tool name resident in the prompt.  Category
+        descriptions are the second disclosure stage: callers opt into them with the
+        structured intent analyzer's tool hints, while ``tool_search`` remains the path
+        to full schemas and deferred-tool promotion.
+        """
+        index = self.get_index_catalog(exclude_high_freq=exclude_high_freq)
+        if not index or not expand_categories:
+            return index
+
+        def _category_key(value: object) -> str:
+            return re.sub(r"[^a-z0-9]", "", str(value).casefold())
+
+        requested = {_category_key(category) for category in expand_categories}
+        requested.discard("")
+        if not requested:
+            return index
+
+        # IntentAnalyzer uses a deliberately small category vocabulary.  A few
+        # older tool definitions use narrower labels for the same capability.
+        category_aliases = {
+            "websearch": {"websearch", "web", "search"},
+        }
+        requested = set().union(*(category_aliases.get(key, {key}) for key in requested))
+
+        categories: OrderedDict[str, list[tuple[str, dict]]] = OrderedDict()
+        for name in sorted(self._tools):
+            if exclude_high_freq and name in _CATALOG_EXCLUDED_SET:
+                continue
+            tool = self._tools[name]
+            category = tool.get("category") or infer_category(name)
+            if not category and name in self._tool_sources:
+                category = "Plugin"
+            category = category or "Other"
+            display_name = self.CATEGORY_DISPLAY_NAMES.get(category, category)
+            category_keys = {_category_key(category), _category_key(display_name)}
+            if category_keys & requested:
+                categories.setdefault(category, []).append((name, tool))
+
+        if not categories:
+            return index
+
+        sections: list[str] = []
+        emitted: set[str] = set()
+        for category in self.CATEGORY_ORDER:
+            tools = categories.get(category)
+            if not tools:
+                continue
+            display_name = self.CATEGORY_DISPLAY_NAMES.get(category, category)
+            section = self._format_category_section(display_name, tools)
+            if section:
+                sections.append(section)
+            emitted.add(category)
+        for category, tools in categories.items():
+            if category in emitted:
+                continue
+            display_name = self.CATEGORY_DISPLAY_NAMES.get(category, category)
+            section = self._format_category_section(display_name, tools)
+            if section:
+                sections.append(section)
+
+        if not sections:
+            return index
+        return index + "\n\n## Intent-Relevant Tool Details\n" + "\n".join(sections)
 
     def get_catalog(
         self,

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -139,3 +139,82 @@ class TestCatalogGeneration:
         catalog = ToolCatalog(_sample_tools())
         schemas = catalog.get_direct_tool_schemas()
         assert isinstance(schemas, list)
+
+
+def test_progressive_catalog_keeps_index_and_expands_only_requested_category():
+    catalog = ToolCatalog(
+        [
+            {
+                "name": "read_project_file",
+                "category": "File System",
+                "description": "Read a file from the current project.",
+                "input_schema": {},
+            },
+            {
+                "name": "search_public_web",
+                "category": "Web Search",
+                "description": "Search public web pages for current information.",
+                "input_schema": {},
+            },
+        ]
+    )
+
+    output = catalog.get_progressive_catalog(["File System"], exclude_high_freq=False)
+
+    assert "read_project_file" in output
+    assert "search_public_web" in output
+    assert "Intent-Relevant Tool Details" in output
+    assert "Read a file from the current project." in output
+    assert "Search public web pages for current information." not in output
+
+
+def test_progressive_catalog_without_intent_is_index_only():
+    catalog = ToolCatalog(
+        [
+            {
+                "name": "search_public_web",
+                "category": "Web Search",
+                "description": "Search public web pages for current information.",
+                "input_schema": {},
+            }
+        ]
+    )
+
+    output = catalog.get_progressive_catalog(exclude_high_freq=False)
+
+    assert "search_public_web" in output
+    assert "Search public web pages for current information." not in output
+
+
+def test_progressive_catalog_normalizes_category_spelling():
+    catalog = ToolCatalog(
+        [
+            {
+                "name": "read_project_file",
+                "category": "filesystem",
+                "description": "Read a file from the current project.",
+                "input_schema": {},
+            }
+        ]
+    )
+
+    output = catalog.get_progressive_catalog(["File System"], exclude_high_freq=False)
+
+    assert "Read a file from the current project." in output
+
+
+def test_progressive_catalog_expands_legacy_web_category_aliases():
+    catalog = ToolCatalog(
+        [
+            {
+                "name": "fetch_web_page",
+                "category": "Web",
+                "description": "Fetch a public web page.",
+                "input_schema": {},
+            }
+        ]
+    )
+
+    output = catalog.get_progressive_catalog(["Web Search"], exclude_high_freq=False)
+
+    assert "Fetch a public web page." in output

--- a/tests/unit/test_external_skill_catalog.py
+++ b/tests/unit/test_external_skill_catalog.py
@@ -79,6 +79,21 @@ def test_system_presets_do_not_reference_removed_external_skills() -> None:
     assert external_references <= available_names
 
 
+def test_external_skill_registry_ids_pass_directory_validation() -> None:
+    parser = SkillParser()
+    directory_warnings: dict[str, list[str]] = {}
+
+    for skill_dir in SKILLS_ROOT.iterdir():
+        if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").is_file():
+            continue
+        skill = parser.parse_directory(skill_dir)
+        warnings = [warning for warning in parser.validate(skill) if "Directory name" in warning]
+        if warnings:
+            directory_warnings[skill_dir.name] = warnings
+
+    assert directory_warnings == {}
+
+
 def test_catalog_defaults_apply_but_user_binding_wins(tmp_path: Path) -> None:
     skills_root = tmp_path / "skills"
     skill_dir = skills_root / "demo-skill"

--- a/tests/unit/test_serve_startup_order.py
+++ b/tests/unit/test_serve_startup_order.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from fastapi import APIRouter
 from httpx import ASGITransport, AsyncClient
 
-from openakita.api.server import create_app, update_runtime_refs
+from openakita.api.server import _wait_for_uvicorn_started, create_app, update_runtime_refs
 from openakita.core.agent import Agent
 
 
@@ -80,3 +80,50 @@ async def test_agent_initialize_is_single_flight(monkeypatch) -> None:
 
     assert calls == 1
     assert agent._initialized is True
+
+
+class _FakeApiThread:
+    def __init__(self, *, alive: bool = True) -> None:
+        self.alive = alive
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+
+async def test_wait_for_uvicorn_started_uses_server_signal() -> None:
+    server = SimpleNamespace(started=False)
+    api_thread = _FakeApiThread()
+
+    async def mark_started() -> None:
+        await asyncio.sleep(0.01)
+        server.started = True
+
+    marker = asyncio.create_task(mark_started())
+    await _wait_for_uvicorn_started(server, api_thread, [], timeout=1.0)
+    await marker
+
+    assert server.started is True
+
+
+async def test_wait_for_uvicorn_started_fails_when_thread_exits() -> None:
+    server = SimpleNamespace(started=False)
+    api_thread = _FakeApiThread(alive=False)
+
+    try:
+        await _wait_for_uvicorn_started(server, api_thread, [], timeout=1.0)
+    except RuntimeError as exc:
+        assert "exited before uvicorn" in str(exc)
+    else:
+        raise AssertionError("dead API thread must fail startup readiness")
+
+
+async def test_wait_for_uvicorn_started_has_bounded_timeout() -> None:
+    server = SimpleNamespace(started=False)
+    api_thread = _FakeApiThread()
+
+    try:
+        await _wait_for_uvicorn_started(server, api_thread, [], timeout=0.01)
+    except TimeoutError as exc:
+        assert "startup completion" in str(exc)
+    else:
+        raise AssertionError("missing uvicorn started signal must time out")

--- a/tests/unit/test_skill_parser_global_cache.py
+++ b/tests/unit/test_skill_parser_global_cache.py
@@ -16,6 +16,7 @@ import pytest
 
 from openakita.skills.events import SkillEvent, notify_skills_changed
 from openakita.skills.parser import (
+    _GLOBAL_BODY_CACHE,
     _GLOBAL_PARSE_CACHE,
     SkillParser,
     invalidate_global_parse_cache,
@@ -83,6 +84,52 @@ def test_second_parser_reuses_global_cache_without_reading_disk(tmp_path: Path, 
         "second parse must serve from the global cache without reading SKILL.md from disk again"
     )
     assert skill.metadata.name == "cache-probe"
+
+
+def test_parse_reads_metadata_only_then_hydrates_body_on_demand(tmp_path: Path, monkeypatch):
+    skill_dir = _make_skill(tmp_path)
+    skill_md = skill_dir / "SKILL.md"
+    original_read_text = Path.read_text
+    body_reads: list[Path] = []
+
+    def _spy_read_text(self, *args, **kwargs):
+        if self == skill_md:
+            body_reads.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _spy_read_text)
+
+    skill = SkillParser().parse_directory(skill_dir)
+
+    assert skill.metadata.name == "cache-probe"
+    assert skill.body_loaded is False
+    assert body_reads == []
+    assert not _GLOBAL_BODY_CACHE
+
+    assert skill.get_body() == "This is the skill body."
+    assert skill.body_loaded is True
+    assert body_reads == [skill_md]
+    assert _GLOBAL_BODY_CACHE
+
+
+def test_hydrated_body_cache_is_shared_across_parser_instances(tmp_path: Path, monkeypatch):
+    skill_dir = _make_skill(tmp_path)
+    first = SkillParser().parse_directory(skill_dir)
+    assert first.get_body() == "This is the skill body."
+
+    skill_md = skill_dir / "SKILL.md"
+    original_read_text = Path.read_text
+
+    def _fail_body_read(self, *args, **kwargs):
+        if self == skill_md:
+            raise AssertionError("hydrated body should be served from the process cache")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _fail_body_read)
+
+    second = SkillParser().parse_directory(skill_dir)
+    assert second.body_loaded is True
+    assert second.get_body() == "This is the skill body."
 
 
 def test_cache_hit_returns_isolated_copy_so_mutation_does_not_leak(tmp_path: Path):

--- a/tests/unit/test_skill_token_paths.py
+++ b/tests/unit/test_skill_token_paths.py
@@ -204,6 +204,28 @@ def test_catalog_builder_passes_context_window_to_stable_skill_metadata_catalog(
     assert captured["priority_categories"] == ("file-tools", "filesystem", "file")
 
 
+def test_catalog_builder_uses_progressive_tool_catalog_with_intent_hints():
+    captured = {}
+
+    class _CapturingToolCatalog:
+        def get_progressive_catalog(self, **kwargs):
+            captured.update(kwargs)
+            return "## Available System Tools (index)\n**File System**: read_file"
+
+        def get_catalog(self):
+            raise AssertionError("full tool catalog must not be loaded into the prompt")
+
+    output = _build_catalogs_section(
+        tool_catalog=_CapturingToolCatalog(),
+        skill_catalog=None,
+        mcp_catalog=None,
+        intent_tool_hints=["File System"],
+    )
+
+    assert "read_file" in output
+    assert captured["expand_categories"] == ["File System"]
+
+
 def test_skill_catalog_marks_instructions_as_guidance():
     catalog = _make_catalog(
         [_FakeSkill("brainstorming", "Must ask one question first", category="workflow")]

--- a/tests/unit/test_skills_system.py
+++ b/tests/unit/test_skills_system.py
@@ -1,6 +1,9 @@
 """L1 Unit Tests: Skill registry, loader, and parser."""
 
+import logging
+
 from openakita.skills.loader import SkillLoader
+from openakita.skills.parser import SkillParser
 from openakita.skills.registry import SkillEntry, SkillRegistry
 
 
@@ -69,8 +72,12 @@ class TestSkillLoader:
         )
         loader = SkillLoader()
         result = loader.load_skill(skill_dir)
-        if result:
-            assert result.metadata.name == "test-skill"
+        assert result is not None
+        assert result.metadata.name == "test-skill"
+        assert result.body_loaded is False
+
+        assert loader.get_skill_body("test-skill") == "# Test Skill\nDoes stuff."
+        assert result.body_loaded is True
 
     def test_load_all_from_empty(self, tmp_path):
         skills_dir = tmp_path / "skills"
@@ -128,3 +135,68 @@ class TestSkillParser:
         )
         result = parse_skill_directory(skill_dir)
         assert result.metadata.name == "dir-skill"
+
+    def test_namespaced_skill_allows_independent_registry_directory_id(self, tmp_path, caplog):
+        skill_dir = tmp_path / "superpowers-debugging"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: obra/superpowers@systematic-debugging\n"
+            "description: Debug systematically\n"
+            "---\n"
+            "# Systematic Debugging\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            skill = SkillParser().parse_directory(skill_dir)
+            warnings = SkillParser().validate(skill)
+
+        assert warnings == []
+        assert not any("directory name" in message.lower() for message in caplog.messages)
+
+    def test_plain_skill_directory_mismatch_is_logged_once(self, tmp_path, caplog):
+        skill_dir = tmp_path / "registry-alias"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: canonical-skill\n"
+            "description: Plain skill with a mismatched directory\n"
+            "---\n"
+            "# Canonical Skill\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = SkillLoader().load_skill(skill_dir)
+
+        directory_warnings = [
+            message for message in caplog.messages if "Directory name 'registry-alias'" in message
+        ]
+        assert result is not None
+        assert len(directory_warnings) == 1
+
+    def test_single_skill_index_events_are_logged_at_debug(self, tmp_path, caplog):
+        skill_dir = tmp_path / "quiet-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: quiet-skill\ndescription: Quiet startup logging\n---\n# Quiet Skill\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            result = SkillLoader().load_skill(skill_dir)
+
+        debug_messages = [
+            record.message for record in caplog.records if record.levelno == logging.DEBUG
+        ]
+        assert result is not None
+        assert any(
+            "Registered skill descriptor: quiet-skill" in message for message in debug_messages
+        )
+        assert any("Indexed skill descriptor: quiet-skill" in message for message in debug_messages)
+        assert not any(
+            "skill descriptor: quiet-skill" in record.message.lower()
+            for record in caplog.records
+            if record.levelno == logging.INFO
+        )


### PR DESCRIPTION
## Summary

- Index Skill metadata during startup and hydrate SKILL.md bodies only when instructions are requested.
- Wait for uvicorn's authoritative startup state instead of repeatedly probing the bind address.
- Keep a compact tool-name index resident and expand only intent-relevant tool categories.
- Reduce per-Skill startup log noise while preserving aggregate INFO messages and validation warnings.

## Tests

- `uv run --no-sync ruff check src/openakita/agent/skill_manager.py src/openakita/api/server.py src/openakita/prompt/builder.py src/openakita/skills/loader.py src/openakita/skills/parser.py src/openakita/skills/registry.py src/openakita/tools/catalog.py tests/unit/test_catalog.py tests/unit/test_external_skill_catalog.py tests/unit/test_serve_startup_order.py tests/unit/test_skill_parser_global_cache.py tests/unit/test_skill_token_paths.py tests/unit/test_skills_system.py`
- `uv run --no-sync pytest tests/unit/test_catalog.py tests/unit/test_external_skill_catalog.py tests/unit/test_serve_startup_order.py tests/unit/test_skill_parser_global_cache.py tests/unit/test_skill_token_paths.py tests/unit/test_skills_system.py tests/unit/test_budget.py tests/unit/test_tool_progressive_disclosure.py tests/unit/test_intent_prompt_contract.py tests/integration/test_optimization_flow.py -q` (`174 passed`)
