### PR TITLE
forward orchestrated IM security confirmations to the source channel

### DIFF
--- a/src/openakita/agents/orchestrator.py
+++ b/src/openakita/agents/orchestrator.py
@@ -210,9 +210,10 @@ async def _call_agent_streaming(
     *,
     gateway: Any,
     mode: str,
-    stream_meta: dict[str, Any],
+    stream_meta: dict[str, Any] | None,
+    forward_gateway_events: bool = False,
 ) -> str:
-    """Consume a sub-agent stream, forwarding events while preserving final text."""
+    """Consume an agent stream, forwarding selected events while preserving final text."""
     stream_method = getattr(agent, "chat_with_session_stream", None)
     if not inspect.isasyncgenfunction(stream_method):
         raise _SubAgentStreamingUnavailable(
@@ -240,7 +241,12 @@ async def _call_agent_streaming(
             reply_text = event.get("content", "") or ""
         elif event_type == "ask_user" and not reply_text:
             reply_text = event.get("question", "") or ""
-        await _broadcast_sub_stream_event(stream_meta, event)
+        if forward_gateway_events and event_type == "security_confirm":
+            handler = getattr(gateway, "handle_agent_security_confirm", None)
+            if handler is not None:
+                await handler(session, event)
+        if stream_meta is not None:
+            await _broadcast_sub_stream_event(stream_meta, event)
     return reply_text
 
 
@@ -851,6 +857,9 @@ class AgentOrchestrator:
         self._broadcast_sub_state_change(state_key, "starting", self._sub_agent_states[state_key])
 
         gw = self._gateway if pass_gateway else None
+        forward_gateway_events = bool(
+            gw is not None and session.get_metadata("_current_message") is not None
+        )
 
         task = asyncio.create_task(
             self._call_agent(
@@ -860,6 +869,7 @@ class AgentOrchestrator:
                 gateway=gw,
                 is_sub_agent=(depth > 0),
                 stream_meta=stream_meta if depth > 0 else None,
+                forward_gateway_events=forward_gateway_events,
             )
         )
 
@@ -1169,6 +1179,7 @@ class AgentOrchestrator:
         gateway: Any = None,
         is_sub_agent: bool = True,
         stream_meta: dict[str, Any] | None = None,
+        forward_gateway_events: bool = False,
     ) -> str:
         """Thin wrapper around agent.chat_with_session for use as a task target.
 
@@ -1217,7 +1228,7 @@ class AgentOrchestrator:
             _start = time.time()
             exit_reason = "completed"
             try:
-                if is_sub_agent and stream_meta:
+                if (is_sub_agent and stream_meta) or forward_gateway_events:
                     try:
                         result = await _call_agent_streaming(
                             agent,
@@ -1225,7 +1236,8 @@ class AgentOrchestrator:
                             message,
                             gateway=gateway,
                             mode=_mode,
-                            stream_meta=stream_meta,
+                            stream_meta=stream_meta if is_sub_agent else None,
+                            forward_gateway_events=forward_gateway_events,
                         )
                     except _SubAgentStreamingUnavailable:
                         session_messages = session.context.get_messages()

--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -6354,6 +6354,15 @@ class MessageGateway:
             except Exception as exc:
                 logger.warning(f"[Security] IM confirm resolve failed: {exc}")
 
+    async def handle_agent_security_confirm(self, session: "Session", event: dict) -> bool:
+        """Render an orchestrator-consumed security confirmation in its source IM channel."""
+        adapter = self._adapters.get(session.channel)
+        message = session.get_metadata("_current_message")
+        if adapter is None or message is None:
+            return False
+        await self._handle_im_security_confirm(session, event, adapter, message)
+        return True
+
     async def _wait_for_interrupt(self, session_key: str) -> "InterruptMessage | None":
         """Block until an interrupt message arrives for the session."""
         queue = self._interrupt_queues.get(session_key)

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -334,6 +334,36 @@ class TestMessageGatewayBroadcast:
         assert actions == ["security_allow", "security_deny"]
 
     @pytest.mark.asyncio
+    async def test_orchestrator_security_confirm_uses_source_im_adapter(self, monkeypatch):
+        import openakita.core.policy_v2 as policy_v2_module
+
+        monkeypatch.setattr(policy_v2_module, "read_permission_mode_label", lambda: "default")
+
+        adapter = MagicMock()
+        adapter.build_simple_card.side_effect = lambda **kwargs: kwargs
+        adapter.send_card = AsyncMock(return_value="message-1")
+        gateway = MessageGateway(session_manager=MagicMock())
+        gateway._adapters["feishu:owner"] = adapter
+        session = create_test_session(channel="feishu:owner", chat_id="chat-1", user_id="user-1")
+        message = create_channel_message(channel="feishu:owner", chat_id="chat-1", user_id="user-1")
+        session.set_metadata("_current_message", message)
+
+        handled = await gateway.handle_agent_security_confirm(
+            session,
+            {
+                "type": "security_confirm",
+                "tool": "run_shell",
+                "id": "confirm-feishu-1",
+                "reason": "needs confirmation",
+                "options": ["allow_once", "deny"],
+            },
+        )
+
+        assert handled is True
+        adapter.send_card.assert_awaited_once()
+        assert adapter.send_card.await_args.args[0] == "chat-1"
+
+    @pytest.mark.asyncio
     async def test_broadcast_sends_normal_text(self):
         session = MagicMock()
         session.id = "session-1"

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -1022,6 +1022,39 @@ class TestAgentOrchestrator:
         mock_pool.get_or_create.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_top_level_im_security_confirm_is_forwarded_to_gateway(
+        self, orchestrator, mock_pool
+    ):
+        session = _make_session(session_id="sess-feishu-confirm")
+        session.channel = "feishu:owner"
+        session.set_metadata("_current_message", object())
+        gateway = MagicMock()
+        gateway.handle_agent_security_confirm = AsyncMock(return_value=True)
+        orchestrator.set_gateway(gateway)
+
+        confirm_event = {
+            "type": "security_confirm",
+            "tool": "run_shell",
+            "id": "confirm-feishu-1",
+            "reason": "test",
+            "options": ["allow_once", "deny"],
+        }
+
+        async def fake_stream(**kwargs):
+            yield confirm_event
+            yield {"type": "text_delta", "content": "done"}
+            yield {"type": "done"}
+
+        mock_agent = mock_pool.get_or_create.return_value
+        mock_agent.chat_with_session_stream = fake_stream
+
+        result = await orchestrator.handle_message(session, "run a command")
+
+        assert result == "done"
+        gateway.handle_agent_security_confirm.assert_awaited_once_with(session, confirm_event)
+        mock_agent.chat_with_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_sub_agent_dispatch_keeps_structured_tool_response(self, orchestrator):
         session = _make_session()
 


### PR DESCRIPTION
## Summary

- Forward top-level orchestrator security confirmation events to the originating IM gateway.
- Reuse the existing Feishu confirmation card and shared resolution flow while preserving sub-agent desktop broadcasts.

## Tests

- `uv run --no-sync ruff check src/openakita/agents/orchestrator.py src/openakita/channels/gateway.py tests/unit/test_multi_agent.py tests/integration/test_gateway.py`
- `uv run --no-sync pytest tests/integration/test_gateway.py -q` (30 passed)
- `uv run --no-sync pytest tests/unit/test_multi_agent.py -q` (153 passed)
- `uv run --no-sync pytest tests/unit/channels/test_feishu_cardkit.py -q` (11 passed)
- Focused post-rebase regression run (4 passed)
