### PR TITLE
improve full desktop build throughput and reduce package size by separating compilation from bundling and excluding Chromium

### DIFF
--- a/.github/actions/desktop-build-prepare/action.yml
+++ b/.github/actions/desktop-build-prepare/action.yml
@@ -36,6 +36,14 @@ inputs:
     required: false
     default: '3.11'
 
+outputs:
+  backend_cache_hit:
+    description: 'Whether the exact-input PyInstaller output cache was restored.'
+    value: ${{ steps.backend_cache.outputs.cache-hit }}
+  rust_binary_cache_hit:
+    description: 'Whether the exact-input Rust desktop binary cache was restored.'
+    value: ${{ steps.rust_binary_cache.outputs.cache-hit }}
+
 runs:
   using: composite
   steps:
@@ -90,6 +98,24 @@ runs:
         prefix-key: ${{ inputs.rust_cache_prefix }}
         cache-bin: false
 
+    - name: Compute Rust desktop fingerprint
+      id: rust_key
+      shell: bash
+      run: python scripts/build_cache_key.py rust --github-output
+
+    - name: Restore exact Rust desktop binary
+      id: rust_binary_cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          apps/setup-center/src-tauri/target/release/openakita-desktop
+          apps/setup-center/src-tauri/target/release/openakita-desktop.exe
+          apps/setup-center/src-tauri/target/release/openakita_setup_center.pdb
+          apps/setup-center/src-tauri/target/${{ inputs.rust_target }}/release/openakita-desktop
+          apps/setup-center/src-tauri/target/${{ inputs.rust_target }}/release/openakita-desktop.exe
+          apps/setup-center/src-tauri/target/${{ inputs.rust_target }}/release/openakita_setup_center.pdb
+        key: desktop-rust-binary-v2-${{ inputs.rust_cache_prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust_target }}-${{ steps.rust_key.outputs.fingerprint }}
+
     - name: Build web frontend for remote browser access
       shell: bash
       working-directory: apps/setup-center
@@ -129,12 +155,44 @@ runs:
           find "${TMPDIR:-/tmp}" -maxdepth 1 -name "_MEI*" -type d -exec rm -rf {} + 2>/dev/null || true
         fi
 
+    - name: Compute backend build fingerprint
+      id: backend_key
+      shell: bash
+      run: python scripts/build_cache_key.py backend --github-output
+
+    - name: Restore exact PyInstaller output
+      id: backend_cache
+      uses: actions/cache@v4
+      with:
+        path: dist/openakita-server
+        key: desktop-backend-v2-${{ inputs.rust_cache_prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.backend_key.outputs.fingerprint }}
+
     - name: Package Python backend (PyInstaller)
+      if: steps.backend_cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
         export OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"
-        python build/build_backend.py
+        python build/build_backend.py --skip-web-build
+
+    - name: Refresh cached backend build identity
+      shell: bash
+      run: |
+        export OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"
+        python scripts/write_build_version.py \
+          --target dist/openakita-server/_internal/openakita/_bundled_version.txt \
+          --require-git
+
+    - name: Upload PyInstaller analysis reports
+      if: ${{ always() && steps.backend_cache.outputs.cache-hit != 'true' }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: pyinstaller-analysis-${{ inputs.target_platform }}
+        path: |
+          build/pyinstaller_work/**/warn-*.txt
+          build/pyinstaller_work/**/xref-*.html
+        if-no-files-found: warn
+        retention-days: 7
 
     - name: Read bootstrap pins (PBS / uv version)
       id: bootstrap_pins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,9 +377,11 @@ jobs:
         working-directory: apps/setup-center
         run: npm ci
 
-      - name: Build web frontend assets
+      - name: Build web and desktop frontend assets
         working-directory: apps/setup-center
-        run: npm run build:web
+        run: |
+          npm run build:web
+          npm run build
 
       - name: Compute exact build fingerprints
         id: build_keys
@@ -420,7 +422,9 @@ jobs:
             echo "# User Custom Persona (placeholder)" > identity/personas/user_custom.md
           fi
 
-      - name: Build backend, desktop frontend, Rust, and docs in parallel
+      # Tauri's generate_context! macro reads frontendDist at Rust compile time,
+      # so the desktop frontend must exist before this parallel phase starts.
+      - name: Build backend, Rust, and docs in parallel
         shell: bash
         env:
           BACKEND_CACHE_HIT: ${{ steps.backend_cache.outputs.cache-hit }}
@@ -438,14 +442,6 @@ jobs:
             fi
           ) &
           backend_pid=$!
-
-          (
-            echo "[frontend] Starting desktop frontend build"
-            cd apps/setup-center
-            npm run build
-            echo "[frontend] Completed"
-          ) &
-          frontend_pid=$!
 
           (
             if [ "$RUST_BINARY_CACHE_HIT" = "true" ]; then
@@ -481,7 +477,6 @@ jobs:
 
           failed=0
           wait_for_build "$backend_pid" backend || failed=1
-          wait_for_build "$frontend_pid" frontend || failed=1
           wait_for_build "$rust_pid" rust || failed=1
           wait_for_build "$docs_pid" docs || failed=1
           if [ "$failed" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,15 +373,6 @@ jobs:
           pip install ./openakita-plugin-sdk
           pip install build "pyinstaller>=6.18.0"
 
-      - name: Clean previous PyInstaller output
-        run: |
-          rm -rf dist/
-          rm -rf build/openakita-server
-          rm -rf build/pyinstaller_work
-
-      - name: Package Python backend (PyInstaller)
-        run: python build/build_backend.py
-
       - name: Install frontend dependencies
         working-directory: apps/setup-center
         run: npm ci
@@ -390,11 +381,134 @@ jobs:
         working-directory: apps/setup-center
         run: npm run build:web
 
-      - name: Build user docs assets
-        working-directory: docs-site
+      - name: Compute exact build fingerprints
+        id: build_keys
+        shell: bash
         run: |
-          npm ci
-          npm run build
+          BACKEND_KEY=$(python scripts/build_cache_key.py backend)
+          RUST_KEY=$(python scripts/build_cache_key.py rust)
+          echo "backend=${BACKEND_KEY}" >> "$GITHUB_OUTPUT"
+          echo "rust=${RUST_KEY}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore exact PyInstaller output
+        id: backend_cache
+        uses: actions/cache@v4
+        with:
+          path: dist/openakita-server
+          key: desktop-backend-v2-ci-full-ubuntu-latest-${{ runner.os }}-${{ runner.arch }}-${{ steps.build_keys.outputs.backend }}
+
+      - name: Restore exact Rust desktop binary
+        id: rust_binary_cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/setup-center/src-tauri/target/release/openakita-desktop
+            apps/setup-center/src-tauri/target/release/openakita_setup_center.pdb
+          key: desktop-rust-binary-v2-ci-full-ubuntu-latest-${{ runner.os }}-${{ runner.arch }}-${{ steps.build_keys.outputs.rust }}
+
+      - name: Clean previous PyInstaller output
+        if: steps.backend_cache.outputs.cache-hit != 'true'
+        run: |
+          rm -rf dist/
+          rm -rf build/openakita-server
+          rm -rf build/pyinstaller_work
+
+      - name: Create gitignored placeholders
+        run: |
+          mkdir -p identity/personas
+          if [ ! -f identity/personas/user_custom.md ]; then
+            echo "# User Custom Persona (placeholder)" > identity/personas/user_custom.md
+          fi
+
+      - name: Build backend, desktop frontend, Rust, and docs in parallel
+        shell: bash
+        env:
+          BACKEND_CACHE_HIT: ${{ steps.backend_cache.outputs.cache-hit }}
+          RUST_BINARY_CACHE_HIT: ${{ steps.rust_binary_cache.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+
+          (
+            if [ "$BACKEND_CACHE_HIT" = "true" ]; then
+              echo "[backend] Reusing exact cached PyInstaller output"
+            else
+              echo "[backend] Starting PyInstaller"
+              python build/build_backend.py --skip-web-build
+              echo "[backend] Completed"
+            fi
+          ) &
+          backend_pid=$!
+
+          (
+            echo "[frontend] Starting desktop frontend build"
+            cd apps/setup-center
+            npm run build
+            echo "[frontend] Completed"
+          ) &
+          frontend_pid=$!
+
+          (
+            if [ "$RUST_BINARY_CACHE_HIT" = "true" ]; then
+              echo "[rust] Reusing exact cached desktop binary"
+            else
+              echo "[rust] Starting release build"
+              cd apps/setup-center/src-tauri
+              cargo build --release --features tauri/custom-protocol
+              echo "[rust] Completed"
+            fi
+          ) &
+          rust_pid=$!
+
+          (
+            echo "[docs] Starting dependency install and build"
+            cd docs-site
+            npm ci
+            npm run build
+            echo "[docs] Completed"
+          ) &
+          docs_pid=$!
+
+          wait_for_build() {
+            local pid="$1"
+            local name="$2"
+            if wait "$pid"; then
+              echo "[$name] Parallel task succeeded"
+            else
+              echo "::error::$name parallel task failed"
+              return 1
+            fi
+          }
+
+          failed=0
+          wait_for_build "$backend_pid" backend || failed=1
+          wait_for_build "$frontend_pid" frontend || failed=1
+          wait_for_build "$rust_pid" rust || failed=1
+          wait_for_build "$docs_pid" docs || failed=1
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Prepare Cargo binary for Tauri bundler
+        run: python scripts/prepare_tauri_binary.py
+
+      - name: Refresh cached backend build identity
+        shell: bash
+        run: |
+          export OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"
+          python scripts/write_build_version.py \
+            --target dist/openakita-server/_internal/openakita/_bundled_version.txt \
+            --require-git
+
+      - name: Upload PyInstaller analysis reports
+        if: ${{ always() && steps.backend_cache.outputs.cache-hit != 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: pyinstaller-analysis-ci-linux-x64
+          path: |
+            build/pyinstaller_work/**/warn-*.txt
+            build/pyinstaller_work/**/xref-*.html
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Prepare bootstrap resources (wheel + uv + standalone Python seed)
         run: |
@@ -439,21 +553,16 @@ jobs:
             --expected-git-hash "$(git rev-parse HEAD)" \
             --check-chat-api
 
-      - name: Create gitignored placeholders
-        run: |
-          mkdir -p identity/personas
-          if [ ! -f identity/personas/user_custom.md ]; then
-            echo "# User Custom Persona (placeholder)" > identity/personas/user_custom.md
-          fi
-
       - name: Build Tauri bundles (full build)
         working-directory: apps/setup-center
         env:
           NO_STRIP: true
         # Fork PRs do not receive repository secrets. Disable updater artifact
         # signing in CI; release/dryrun workflows still sign updater artifacts.
+        # The desktop frontend and Rust binary were built in parallel above;
+        # this stage only packages the existing binary and resources.
         run: >
-          npx tauri build
+          npx tauri bundle
           --bundles "deb"
           --config '{"bundle":{"createUpdaterArtifacts":false}}'
 

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -184,6 +184,7 @@ jobs:
       # 注意 inputs 全是字符串，所以 disable_bootstrap_cache 透传为
       # `'true'/'false'` 字符串，由 action 内部用字符串比较判断。
       - name: Desktop build prepare
+        id: desktop_prepare
         uses: ./.github/actions/desktop-build-prepare
         with:
           target_platform: ${{ matrix.target_platform }}
@@ -259,9 +260,9 @@ jobs:
             echo "# User Custom Persona (placeholder)" > identity/personas/user_custom.md
           fi
 
-      - name: Install frontend dependencies
+      - name: Build desktop frontend
         working-directory: apps/setup-center
-        run: npm ci
+        run: npm run build
 
       # macOS runners ship Homebrew Rust shims that can shadow rustup's real cargo and
       # make `cargo fetch` invoke rustup-init with a bogus "fetch" argv (see GH dryrun).
@@ -269,39 +270,33 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
-      - name: Preflight Rust dependency check
+      - name: Compile Rust desktop binary
+        if: steps.desktop_prepare.outputs.rust_binary_cache_hit != 'true'
         working-directory: apps/setup-center/src-tauri
+        timeout-minutes: 120
         shell: bash
         run: |
-          set -euo pipefail
-          CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
-          # Clear cached build-scripts to avoid glibc mismatch across Ubuntu versions
-          rm -rf target/debug/build
-          "$CARGO_BIN/cargo" fetch --locked
-          CHECK_ARGS=""
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            CHECK_ARGS="--target ${{ matrix.rust_target }}"
-          fi
-          if ! "$CARGO_BIN/cargo" check $CHECK_ARGS; then
-            echo "::warning::Preflight cargo check failed — stale cache detected, cleaning and retrying"
-            "$CARGO_BIN/cargo" clean
-            "$CARGO_BIN/cargo" check $CHECK_ARGS
-          fi
+          set +e
+          cargo fetch --locked || exit $?
+          for attempt in 1 2; do
+            echo "=== Rust build attempt ${attempt}/2 ==="
+            cargo build --release --features tauri/custom-protocol ${{ matrix.args }}
+            exit_code=$?
+            if [ "$exit_code" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 1 ]; then
+              echo "::warning::Rust build failed; clearing stale cache before retry"
+              cargo clean
+              sleep 30
+            fi
+          done
+          exit "$exit_code"
 
-      - name: Clean Rust release intermediates for current target
-        shell: bash
-        run: |
-          set -euo pipefail
-          TARGET_BASE="apps/setup-center/src-tauri/target"
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            RELEASE_DIR="${TARGET_BASE}/${{ matrix.rust_target }}/release"
-          else
-            RELEASE_DIR="${TARGET_BASE}/release"
-          fi
-          rm -rf "${RELEASE_DIR}/deps" "${RELEASE_DIR}/build" "${RELEASE_DIR}/.fingerprint"
-          mkdir -p "${RELEASE_DIR}"
+      - name: Prepare Cargo binary for Tauri bundler
+        run: python scripts/prepare_tauri_binary.py --target "${{ matrix.rust_target }}"
 
-      - name: Build Tauri bundles
+      - name: Bundle Tauri installers
         working-directory: apps/setup-center
         timeout-minutes: 150
         env:
@@ -319,14 +314,14 @@ jobs:
           MAX_ATTEMPTS=2
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "=== Build attempt $ATTEMPT/$MAX_ATTEMPTS ==="
-            npx tauri build --bundles "${{ matrix.bundles }}" ${{ matrix.args }}
+            echo "=== Bundle attempt $ATTEMPT/$MAX_ATTEMPTS ==="
+            npx tauri bundle --bundles "${{ matrix.bundles }}" ${{ matrix.args }}
             EXIT_CODE=$?
             if [ $EXIT_CODE -eq 0 ]; then
-              echo "Build succeeded on attempt $ATTEMPT"
+              echo "Bundle succeeded on attempt $ATTEMPT"
               exit 0
             fi
-            echo "Build failed (exit $EXIT_CODE) on attempt $ATTEMPT"
+            echo "Bundle failed (exit $EXIT_CODE) on attempt $ATTEMPT"
             ATTEMPT=$((ATTEMPT + 1))
             if [ $ATTEMPT -le $MAX_ATTEMPTS ]; then
               echo "Waiting 30s before retry..."
@@ -512,7 +507,9 @@ jobs:
           echo "Building DMG: ${dmg_file}"
           echo "  source app : ${app}"
 
-          brew install create-dmg 2>/dev/null || true
+          if [ "${{ matrix.suffix }}" != "macos-x64" ]; then
+            brew install create-dmg 2>/dev/null || true
+          fi
 
           for vol in /Volumes/"${app_name}"*; do
             [ -d "${vol}" ] && hdiutil detach "${vol}" -force 2>/dev/null || true
@@ -523,7 +520,14 @@ jobs:
           DMG_STAGE="$(mktemp -d)"
           cp -a "${app}" "${DMG_STAGE}/"
 
-          if command -v create-dmg &>/dev/null; then
+          if [ "${{ matrix.suffix }}" = "macos-x64" ]; then
+            echo "Intel runner: using hdiutil directly to avoid known create-dmg AppleScript hangs"
+            ln -sf /Applications "${DMG_STAGE}/Applications"
+            hdiutil create -volname "${app_name}" \
+              -srcfolder "${DMG_STAGE}" -ov -format UDRW "/tmp/_rw_$$.dmg"
+            hdiutil convert "/tmp/_rw_$$.dmg" -format UDZO -o "${dmg_file}"
+            rm -f "/tmp/_rw_$$.dmg"
+          elif command -v create-dmg &>/dev/null; then
             DMG_BG="/tmp/dmg_bg_$$.png"
             if command -v magick &>/dev/null; then
               magick -size 660x400 xc:'#EDEDED' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,7 @@ jobs:
       # .github/actions/desktop-build-prepare/action.yml。dryrun 与 release
       # 使用同一份 composite action，避免漂移。
       - name: Desktop build prepare
+        id: desktop_prepare
         uses: ./.github/actions/desktop-build-prepare
         with:
           target_platform: ${{ matrix.target_platform }}
@@ -457,63 +458,42 @@ jobs:
             echo "# User Custom Persona (placeholder)" > identity/personas/user_custom.md
           fi
 
-      - name: Install frontend dependencies
+      - name: Build desktop frontend
         working-directory: apps/setup-center
-        run: npm ci
+        run: npm run build
 
       # macOS runners ship Homebrew Rust shims that can shadow rustup's real cargo.
       - name: Prefer rustup Cargo on PATH
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
-      - name: Preflight Rust dependency check
+      - name: Compile Rust desktop binary
+        if: steps.desktop_prepare.outputs.rust_binary_cache_hit != 'true'
         working-directory: apps/setup-center/src-tauri
+        timeout-minutes: 120
         shell: bash
-        env:
-          CARGO_HTTP_MULTIPLEXING: "false"
         run: |
-          set -euo pipefail
-          CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
-          # Clear cached build-scripts to avoid glibc mismatch across Ubuntu versions
-          rm -rf target/debug/build
-          "$CARGO_BIN/cargo" fetch --locked
-          CHECK_ARGS=""
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            CHECK_ARGS="--target ${{ matrix.rust_target }}"
-          fi
-          MAX_ATTEMPTS=3
-          ATTEMPT=1
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "=== Preflight attempt $ATTEMPT/$MAX_ATTEMPTS ==="
-            if "$CARGO_BIN/cargo" check $CHECK_ARGS; then
-              echo "Preflight succeeded"
+          set +e
+          cargo fetch --locked || exit $?
+          for attempt in 1 2; do
+            echo "=== Rust build attempt ${attempt}/2 ==="
+            cargo build --release --features tauri/custom-protocol ${{ matrix.args }}
+            exit_code=$?
+            if [ "$exit_code" -eq 0 ]; then
               exit 0
             fi
-            echo "Preflight failed (attempt $ATTEMPT)"
-            if [ $ATTEMPT -eq 1 ]; then
-              echo "::warning::Stale cache detected, running cargo clean before retry"
-              "$CARGO_BIN/cargo" clean
+            if [ "$attempt" -eq 1 ]; then
+              echo "::warning::Rust build failed; clearing stale cache before retry"
+              cargo clean
+              sleep 30
             fi
-            ATTEMPT=$((ATTEMPT + 1))
-            [ $ATTEMPT -le $MAX_ATTEMPTS ] && { echo "Retrying in 30s..."; sleep 30; }
           done
-          echo "All preflight attempts failed"
-          exit 1
+          exit "$exit_code"
 
-      - name: Clean Rust release intermediates for current target
-        shell: bash
-        run: |
-          set -euo pipefail
-          TARGET_BASE="apps/setup-center/src-tauri/target"
-          if [ -n "${{ matrix.rust_target }}" ]; then
-            RELEASE_DIR="${TARGET_BASE}/${{ matrix.rust_target }}/release"
-          else
-            RELEASE_DIR="${TARGET_BASE}/release"
-          fi
-          rm -rf "${RELEASE_DIR}/deps" "${RELEASE_DIR}/build" "${RELEASE_DIR}/.fingerprint"
-          mkdir -p "${RELEASE_DIR}"
+      - name: Prepare Cargo binary for Tauri bundler
+        run: python scripts/prepare_tauri_binary.py --target "${{ matrix.rust_target }}"
 
-      - name: Build Tauri bundles
+      - name: Bundle Tauri installers
         working-directory: apps/setup-center
         timeout-minutes: 150
         env:
@@ -531,14 +511,14 @@ jobs:
           MAX_ATTEMPTS=2
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "=== Build attempt $ATTEMPT/$MAX_ATTEMPTS ==="
-            npx tauri build --bundles "${{ matrix.bundles }}" ${{ matrix.args }}
+            echo "=== Bundle attempt $ATTEMPT/$MAX_ATTEMPTS ==="
+            npx tauri bundle --bundles "${{ matrix.bundles }}" ${{ matrix.args }}
             EXIT_CODE=$?
             if [ $EXIT_CODE -eq 0 ]; then
-              echo "Build succeeded on attempt $ATTEMPT"
+              echo "Bundle succeeded on attempt $ATTEMPT"
               exit 0
             fi
-            echo "Build failed (exit $EXIT_CODE) on attempt $ATTEMPT"
+            echo "Bundle failed (exit $EXIT_CODE) on attempt $ATTEMPT"
             ATTEMPT=$((ATTEMPT + 1))
             if [ $ATTEMPT -le $MAX_ATTEMPTS ]; then
               echo "Waiting 30s before retry..."
@@ -737,7 +717,9 @@ jobs:
           echo "Building DMG: ${dmg_file}"
           echo "  source app : ${app}"
 
-          brew install create-dmg 2>/dev/null || true
+          if [ "${{ matrix.suffix }}" != "macos-x64" ]; then
+            brew install create-dmg 2>/dev/null || true
+          fi
 
           # Detach any leftover volumes from a previous run that share
           # the volname; otherwise hdiutil/create-dmg can fail with
@@ -751,7 +733,14 @@ jobs:
           DMG_STAGE="$(mktemp -d)"
           cp -a "${app}" "${DMG_STAGE}/"
 
-          if command -v create-dmg &>/dev/null; then
+          if [ "${{ matrix.suffix }}" = "macos-x64" ]; then
+            echo "Intel runner: using hdiutil directly to avoid known create-dmg AppleScript hangs"
+            ln -sf /Applications "${DMG_STAGE}/Applications"
+            hdiutil create -volname "${app_name}" \
+              -srcfolder "${DMG_STAGE}" -ov -format UDRW "/tmp/_rw_$$.dmg"
+            hdiutil convert "/tmp/_rw_$$.dmg" -format UDZO -o "${dmg_file}"
+            rm -f "/tmp/_rw_$$.dmg"
+          elif command -v create-dmg &>/dev/null; then
             # Polished layout: App (left) → arrow → Applications (right)
             DMG_BG="/tmp/dmg_bg_$$.png"
             if command -v magick &>/dev/null; then

--- a/apps/setup-center/src-tauri/tauri.conf.json
+++ b/apps/setup-center/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "identifier": "com.openakita.setupcenter",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build:web && npm run build",
+    "beforeBuildCommand": "npm run build",
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist"
   },

--- a/build/build_backend.py
+++ b/build/build_backend.py
@@ -311,43 +311,6 @@ def clean_dist():
         shutil.rmtree(legacy_cache)
 
 
-def ensure_playwright_chromium():
-    """Ensure Playwright Chromium is installed for bundling"""
-    try:
-        import playwright
-        pw_dir = Path(playwright.__file__).parent
-        local_browsers = pw_dir / ".local-browsers"
-        if local_browsers.exists():
-            print("  [OK] Playwright Chromium already installed (local-browsers)")
-            return
-
-        # Check default system path
-        if sys.platform == "win32":
-            pw_cache = Path.home() / "AppData" / "Local" / "ms-playwright"
-        elif sys.platform == "darwin":
-            pw_cache = Path.home() / "Library" / "Caches" / "ms-playwright"
-        else:
-            pw_cache = Path.home() / ".cache" / "ms-playwright"
-
-        chromium_found = False
-        if pw_cache.exists():
-            for d in pw_cache.iterdir():
-                if d.is_dir() and "chromium" in d.name.lower():
-                    chromium_found = True
-                    break
-
-        if chromium_found:
-            print(f"  [OK] Playwright Chromium found at {pw_cache}")
-        else:
-            print("  [INFO] Installing Playwright Chromium for bundling...")
-            run_cmd([sys.executable, "-m", "playwright", "install", "chromium"])
-    except ImportError:
-        print("  [WARN] playwright not installed, installing...")
-        run_cmd([sys.executable, "-m", "pip", "install", "playwright", "browser-use", "langchain-openai"])
-        print("  [INFO] Installing Playwright Chromium...")
-        run_cmd([sys.executable, "-m", "playwright", "install", "chromium"])
-
-
 def build_backend(mode: str, fast: bool = False, skip_web_build: bool = False):
     """Execute PyInstaller packaging"""
     label = f"{mode.upper()}" + (" [FAST]" if fast else "")
@@ -355,16 +318,13 @@ def build_backend(mode: str, fast: bool = False, skip_web_build: bool = False):
     print(f"  OpenAkita Backend Build - Mode: {label}")
     print(f"{'='*60}\n")
 
-    print("[1/5] Checking dependencies...")
+    print("[1/4] Checking dependencies...")
     check_pyinstaller()
 
-    print("\n[2/5] Ensuring Playwright Chromium for bundling...")
-    ensure_playwright_chromium()
-
-    print("\n[3/5] Cleaning old build...")
+    print("\n[2/4] Cleaning old build...")
     clean_dist()
 
-    print("\n[4/5] Running PyInstaller...")
+    print("\n[3/4] Running PyInstaller...")
     env = {"OPENAKITA_BUILD_MODE": mode}
     if fast:
         env["OPENAKITA_NO_UPX"] = "1"
@@ -381,8 +341,8 @@ def build_backend(mode: str, fast: bool = False, skip_web_build: bool = False):
 
     run_cmd(cmd, env=env)
 
-    print("\n[5/5] Verifying build output...")
-    
+    print("\n[4/4] Verifying build output...")
+
     if sys.platform == "win32":
         exe_path = OUTPUT_DIR / "openakita-server.exe"
     else:

--- a/build/build_full.ps1
+++ b/build/build_full.ps1
@@ -23,20 +23,31 @@ if ($Fast) {
     Write-Host "============================================" -ForegroundColor Cyan
 }
 
-# Step 1: Package Python backend (full mode)
-Write-Host "`n[1/4] Packaging Python backend (full mode)..." -ForegroundColor Yellow
-$backendArgs = @("$ScriptDir\build_backend.py", "--mode", "full")
+# Step 1: Build the shared web frontend once before either packager consumes it
+Write-Host "`n[1/5] Building web frontend..." -ForegroundColor Yellow
+Push-Location $SetupCenterDir
+try {
+    if (-not (Test-Path "node_modules")) { npm install }
+    npm run build:web
+    if ($LASTEXITCODE -ne 0) { throw "Web frontend build failed" }
+} finally {
+    Pop-Location
+}
+
+# Step 2: Package Python backend (full mode)
+Write-Host "`n[2/5] Packaging Python backend (full mode)..." -ForegroundColor Yellow
+$backendArgs = @("$ScriptDir\build_backend.py", "--mode", "full", "--skip-web-build")
 if ($Fast) { $backendArgs += "--fast" }
 python @backendArgs
 if ($LASTEXITCODE -ne 0) { throw "Python backend packaging failed" }
 
-# Step 2: Pre-bundle optional modules
-Write-Host "`n[2/4] Pre-bundling optional modules..." -ForegroundColor Yellow
+# Step 3: Pre-bundle optional modules
+Write-Host "`n[3/5] Pre-bundling optional modules..." -ForegroundColor Yellow
 python "$ScriptDir\bundle_modules.py"
 if ($LASTEXITCODE -ne 0) { throw "Module pre-bundling failed" }
 
-# Step 3: Copy to Tauri resources
-Write-Host "`n[3/4] Copying backend and modules to Tauri resources..." -ForegroundColor Yellow
+# Step 4: Copy to Tauri resources
+Write-Host "`n[4/5] Copying backend and modules to Tauri resources..." -ForegroundColor Yellow
 $DistServerDir = Join-Path $ProjectRoot "dist\openakita-server"
 $ModulesDir = Join-Path $ScriptDir "modules"
 $TargetServerDir = Join-Path $ResourceDir "openakita-server"
@@ -52,8 +63,8 @@ if (Test-Path $ModulesDir) {
 Write-Host "  Backend: $TargetServerDir"
 Write-Host "  Modules: $TargetModulesDir"
 
-# Step 4: Build Tauri app (add modules resource via TAURI_CONFIG)
-Write-Host "`n[4/4] Building Tauri app..." -ForegroundColor Yellow
+# Step 5: Build Tauri app (add modules resource via TAURI_CONFIG)
+Write-Host "`n[5/5] Building Tauri app..." -ForegroundColor Yellow
 Push-Location $SetupCenterDir
 try {
     # Full package needs additional modules resource directory

--- a/build/build_full.sh
+++ b/build/build_full.sh
@@ -22,19 +22,29 @@ else
     echo "============================================"
 fi
 
-# Step 1: Package Python backend (full mode)
+# Step 1: Build the shared web frontend once before either packager consumes it
 echo ""
-echo "[1/4] Packaging Python backend (full mode)..."
-python3 "$SCRIPT_DIR/build_backend.py" --mode full $FAST_FLAG
+echo "[1/5] Building web frontend..."
+cd "$SETUP_CENTER_DIR"
+if [[ ! -d node_modules ]]; then
+    npm install
+fi
+npm run build:web
 
-# Step 2: Pre-bundle optional modules
+# Step 2: Package Python backend (full mode)
 echo ""
-echo "[2/4] Pre-bundling optional modules..."
+echo "[2/5] Packaging Python backend (full mode)..."
+cd "$PROJECT_ROOT"
+python3 "$SCRIPT_DIR/build_backend.py" --mode full --skip-web-build $FAST_FLAG
+
+# Step 3: Pre-bundle optional modules
+echo ""
+echo "[3/5] Pre-bundling optional modules..."
 python3 "$SCRIPT_DIR/bundle_modules.py"
 
-# Step 3: Copy to Tauri resources
+# Step 4: Copy to Tauri resources
 echo ""
-echo "[3/4] Copying backend and modules to Tauri resources..."
+echo "[4/5] Copying backend and modules to Tauri resources..."
 DIST_SERVER_DIR="$PROJECT_ROOT/dist/openakita-server"
 MODULES_DIR="$SCRIPT_DIR/modules"
 TARGET_SERVER_DIR="$RESOURCE_DIR/openakita-server"
@@ -49,9 +59,9 @@ fi
 echo "  Backend: $TARGET_SERVER_DIR"
 echo "  Modules: $TARGET_MODULES_DIR"
 
-# Step 4: Build Tauri app (add modules resource via TAURI_CONFIG)
+# Step 5: Build Tauri app (add modules resource via TAURI_CONFIG)
 echo ""
-echo "[4/4] Building Tauri app..."
+echo "[5/5] Building Tauri app..."
 cd "$SETUP_CENTER_DIR"
 # Full package needs additional modules resource directory
 export TAURI_CONFIG='{"bundle":{"resources":["resources/openakita-server/","resources/modules/"]}}'

--- a/build/bundle_modules.py
+++ b/build/bundle_modules.py
@@ -37,8 +37,8 @@ model = SentenceTransformer("shibing624/text2vec-base-chinese")
 print(f"Model downloaded to: {model._model_card_text if hasattr(model, '_model_card_text') else 'cache'}")
 """,
     },
-    # browser (playwright + browser-use + langchain-openai) 已内置到 core 包，
-    # 不再作为外置模块。构建前需运行 'playwright install chromium'。
+    # browser Python packages and the Playwright driver are built into core;
+    # Chromium itself is downloaded to the managed runtime only after the user confirms.
     "whisper": {
         "description": "Offline speech-to-text (OpenAI Whisper, ~2.5GB with PyTorch)",
         "packages": [

--- a/build/openakita.spec
+++ b/build/openakita.spec
@@ -247,7 +247,8 @@ hidden_imports_core = [
     "requests.sessions",
     "requests.structures",
     "requests.utils",
-    "requests_toolbelt",        # lark_oapi 依赖: multipart 上传等
+    # requests_toolbelt is copied as loose data below for lark_oapi. Adding it
+    # here as well makes PyInstaller analyze and archive the same package twice.
     "urllib3",                  # requests 依赖: HTTP 连接池 (可能已由 httpx 间接引入)
     "charset_normalizer",       # requests 依赖: 编码检测
     "dingtalk_stream",          # DingTalk Stream (~2MB)
@@ -647,61 +648,8 @@ try:
 except ImportError:
     print("[spec] WARNING: playwright not installed, driver not bundled")
 
-# Playwright Chromium browser binary (bundled to avoid user needing 'playwright install chromium')
-# 构建时需预先运行: playwright install chromium
-# Chromium 默认位于 PLAYWRIGHT_BROWSERS_PATH 或 playwright 包内的 .local-browsers
-#
-# macOS is intentionally excluded here. Chromium is distributed as a nested
-# ``Google Chrome for Testing.app`` bundle; when PyInstaller sees the Mach-O
-# executable inside datas during COLLECT, it tries to ad-hoc codesign the
-# nested app and fails with "bundle format unrecognized" before Tauri's own
-# app signing/notarization step can run. macOS users can still install the
-# browser runtime through the in-app dependency panel.
-try:
-    _pw_browsers_bundled = False
-    if sys.platform == "darwin":
-        print("[spec] Skipping Playwright Chromium bundle on macOS (nested .app codesign)")
-    else:
-        # 优先检查 playwright 包内的浏览器（playwright install --with-deps 后的位置）
-        _pw_local_browsers = _pw_pkg_dir / ".local-browsers"
-        if _pw_local_browsers.exists():
-            datas.append((str(_pw_local_browsers), "playwright/.local-browsers"))
-            _pw_browsers_bundled = True
-            print(f"[spec] Bundling Playwright local browsers: {_pw_local_browsers}")
-        else:
-            # 检查默认浏览器安装路径
-            import subprocess as _sp2
-            try:
-                _pw_browser_path = _sp2.check_output(
-                    [sys.executable, "-c",
-                     "from playwright._impl._driver import compute_driver_executable; "
-                     "import os; print(os.environ.get('PLAYWRIGHT_BROWSERS_PATH', ''))"],
-                    text=True, stderr=_sp2.DEVNULL
-                ).strip()
-            except Exception:
-                _pw_browser_path = ""
-
-            if not _pw_browser_path:
-                # 使用 playwright 默认路径
-                if sys.platform == "win32":
-                    _pw_browser_path = str(Path.home() / "AppData" / "Local" / "ms-playwright")
-                else:
-                    _pw_browser_path = str(Path.home() / ".cache" / "ms-playwright")
-
-            _pw_browser_dir = Path(_pw_browser_path)
-            if _pw_browser_dir.exists():
-                # 只打包 chromium 目录（不打包其他浏览器）
-                for _chromium_dir in _pw_browser_dir.iterdir():
-                    if _chromium_dir.is_dir() and "chromium" in _chromium_dir.name.lower():
-                        datas.append((str(_chromium_dir), f"playwright-browsers/{_chromium_dir.name}"))
-                        _pw_browsers_bundled = True
-                        print(f"[spec] Bundling Playwright Chromium: {_chromium_dir}")
-                        break
-
-    if not _pw_browsers_bundled:
-        print("[spec] WARNING: Playwright Chromium not found. Run 'playwright install chromium' before building.")
-except Exception as _pw_err:
-    print(f"[spec] WARNING: Failed to detect Playwright browsers: {_pw_err}")
+# Chromium is intentionally not bundled. BrowserManager downloads the revision
+# matching this Playwright driver after user confirmation, or uses an installed Chrome.
 
 # Built-in MCP server configs (chrome-browser, desktop-control, web-search, etc.)
 mcps_dir = PROJECT_ROOT / "mcps"
@@ -732,12 +680,21 @@ a = Analysis(
     binaries=[],
     datas=datas,
     hiddenimports=hidden_imports,
-    hookspath=[],
+    hookspath=[str(PROJECT_ROOT / "scripts" / "pyinstaller_hooks")],
     hooksconfig={},
     runtime_hooks=[],
     excludes=excludes,
     noarchive=False,
 )
+
+# Defense in depth for package-provided hooks and future Playwright layouts:
+# never allow a developer-local browser cache into the distributable.
+a.datas = [
+    entry
+    for entry in a.datas
+    if ".local-browsers" not in entry[0].replace("\\", "/")
+    and not entry[0].replace("\\", "/").startswith("playwright-browsers/")
+]
 
 # Add importable source for bridge subprocesses, but keep the build-owned
 # VERSION+commit file as the sole _bundled_version.txt provider. Supplying the

--- a/scripts/build_cache_key.py
+++ b/scripts/build_cache_key.py
@@ -34,6 +34,12 @@ INPUTS = {
         "mcps",
     ),
     "rust": (
+        "apps/setup-center/src",
+        "apps/setup-center/index.html",
+        "apps/setup-center/package.json",
+        "apps/setup-center/package-lock.json",
+        "apps/setup-center/vite.config.ts",
+        "apps/setup-center/tsconfig.json",
         "apps/setup-center/src-tauri/Cargo.toml",
         "apps/setup-center/src-tauri/Cargo.lock",
         "apps/setup-center/src-tauri/build.rs",

--- a/scripts/build_cache_key.py
+++ b/scripts/build_cache_key.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compute stable cache fingerprints for expensive desktop build outputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INPUTS = {
+    "backend": (
+        "VERSION",
+        "pyproject.toml",
+        "build/build_backend.py",
+        "build/openakita.spec",
+        "scripts/build_cache_key.py",
+        "scripts/write_build_version.py",
+        "src/openakita",
+        "openakita-plugin-sdk",
+        "apps/setup-center/src",
+        "apps/setup-center/index.html",
+        "apps/setup-center/package.json",
+        "apps/setup-center/package-lock.json",
+        "apps/setup-center/vite.config.ts",
+        "apps/setup-center/tsconfig.json",
+        "skills",
+        "mcps",
+    ),
+    "rust": (
+        "apps/setup-center/src-tauri/Cargo.toml",
+        "apps/setup-center/src-tauri/Cargo.lock",
+        "apps/setup-center/src-tauri/build.rs",
+        "apps/setup-center/src-tauri/src",
+        "apps/setup-center/src-tauri/capabilities",
+        "apps/setup-center/src-tauri/icons",
+        "apps/setup-center/src-tauri/tauri.conf.json",
+        "apps/setup-center/src-tauri/Entitlements.plist",
+        "identity",
+        "data/llm_endpoints.json.example",
+        "scripts/build_cache_key.py",
+        "scripts/prepare_tauri_binary.py",
+    ),
+}
+
+
+def _tracked_files(inputs: tuple[str, ...]) -> list[Path]:
+    output = subprocess.check_output(["git", "-C", str(ROOT), "ls-files", "-z", "--", *inputs])
+    return sorted((ROOT / item.decode()).resolve() for item in output.split(b"\0") if item)
+
+
+def _add_file(digest: Any, path: Path) -> None:
+    relative = path.relative_to(ROOT).as_posix().encode()
+    digest.update(len(relative).to_bytes(4, "big"))
+    digest.update(relative)
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+
+
+def _backend_environment() -> list[str]:
+    distributions = sorted(
+        f"{dist.metadata['Name'].lower()}=={dist.version}"
+        for dist in importlib.metadata.distributions()
+        if dist.metadata.get("Name")
+    )
+    return [sys.version, *distributions]
+
+
+def _rust_environment() -> list[str]:
+    rustc = subprocess.check_output(["rustc", "-Vv"], text=True, encoding="utf-8")
+    return [rustc, os.environ.get("CARGO_BUILD_TARGET", "native")]
+
+
+def fingerprint(kind: str) -> str:
+    digest = hashlib.sha256()
+    files = _tracked_files(INPUTS[kind])
+    if not files:
+        raise RuntimeError(f"no tracked inputs found for {kind}")
+    for path in files:
+        _add_file(digest, path)
+    environment = _backend_environment() if kind == "backend" else _rust_environment()
+    for value in environment:
+        digest.update(b"\0env\0")
+        digest.update(value.encode())
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=sorted(INPUTS))
+    parser.add_argument("--github-output", action="store_true")
+    args = parser.parse_args()
+    value = fingerprint(args.kind)
+    if args.github_output:
+        output = os.environ.get("GITHUB_OUTPUT")
+        if not output:
+            raise RuntimeError("GITHUB_OUTPUT is not set")
+        with Path(output).open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(f"fingerprint={value}\n")
+    print(value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_chat_smoke.py
+++ b/scripts/package_chat_smoke.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 async def _run(internal_dir: Path) -> None:
     sys.path.insert(0, str(internal_dir))
 
+    import requests_toolbelt
     from httpx import ASGITransport, AsyncClient
 
     import openakita
@@ -22,6 +23,14 @@ async def _run(internal_dir: Path) -> None:
     imported_from = Path(openakita.__file__).resolve()
     if not imported_from.is_relative_to(internal_dir):
         raise RuntimeError(f"openakita imported from {imported_from}, not bundle {internal_dir}")
+    bundled_toolbelt = internal_dir / "requests_toolbelt"
+    toolbelt_from = Path(requests_toolbelt.__file__).resolve()
+    if bundled_toolbelt.is_dir() and not toolbelt_from.is_relative_to(internal_dir):
+        raise RuntimeError(
+            f"requests_toolbelt imported from {toolbelt_from}, not bundle {internal_dir}"
+        )
+    if not bundled_toolbelt.is_dir() and internal_dir.name != "src":
+        raise RuntimeError(f"bundled requests_toolbelt missing from {internal_dir}")
 
     agent = MagicMock()
     agent.initialized = True

--- a/scripts/package_chat_smoke.py
+++ b/scripts/package_chat_smoke.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock
 async def _run(internal_dir: Path) -> None:
     sys.path.insert(0, str(internal_dir))
 
-    import requests_toolbelt
     from httpx import ASGITransport, AsyncClient
 
     import openakita
@@ -23,14 +22,17 @@ async def _run(internal_dir: Path) -> None:
     imported_from = Path(openakita.__file__).resolve()
     if not imported_from.is_relative_to(internal_dir):
         raise RuntimeError(f"openakita imported from {imported_from}, not bundle {internal_dir}")
-    bundled_toolbelt = internal_dir / "requests_toolbelt"
-    toolbelt_from = Path(requests_toolbelt.__file__).resolve()
-    if bundled_toolbelt.is_dir() and not toolbelt_from.is_relative_to(internal_dir):
-        raise RuntimeError(
-            f"requests_toolbelt imported from {toolbelt_from}, not bundle {internal_dir}"
-        )
-    if not bundled_toolbelt.is_dir() and internal_dir.name != "src":
-        raise RuntimeError(f"bundled requests_toolbelt missing from {internal_dir}")
+    if internal_dir.name != "src":
+        import requests_toolbelt
+
+        bundled_toolbelt = internal_dir / "requests_toolbelt"
+        toolbelt_from = Path(requests_toolbelt.__file__).resolve()
+        if not bundled_toolbelt.is_dir():
+            raise RuntimeError(f"bundled requests_toolbelt missing from {internal_dir}")
+        if not toolbelt_from.is_relative_to(internal_dir):
+            raise RuntimeError(
+                f"requests_toolbelt imported from {toolbelt_from}, not bundle {internal_dir}"
+            )
 
     agent = MagicMock()
     agent.initialized = True

--- a/scripts/prepare_tauri_binary.py
+++ b/scripts/prepare_tauri_binary.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Place a Cargo-built desktop executable where `tauri bundle` expects it."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TAURI_DIR = ROOT / "apps" / "setup-center" / "src-tauri"
+
+
+def prepare_binary(target: str = "") -> Path:
+    config = json.loads((TAURI_DIR / "tauri.conf.json").read_text(encoding="utf-8"))
+    destination_name = config["mainBinaryName"]
+    suffix = ".exe" if sys.platform == "win32" else ""
+    release_dir = TAURI_DIR / "target"
+    if target:
+        release_dir /= target
+    release_dir /= "release"
+
+    destination = release_dir / f"{destination_name}{suffix}"
+    source = release_dir / f"openakita-setup-center{suffix}"
+    if source.is_file():
+        shutil.copy2(source, destination)
+        print(f"Prepared Tauri binary: {source.name} -> {destination.name}")
+    elif destination.is_file():
+        print(f"Tauri binary already prepared: {destination}")
+    else:
+        raise FileNotFoundError(f"Cargo binary missing: expected {source} or {destination}")
+    return destination
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", default="", help="Optional Rust target triple")
+    args = parser.parse_args()
+    prepare_binary(args.target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pyinstaller_hooks/hook-playwright.async_api.py
+++ b/scripts/pyinstaller_hooks/hook-playwright.async_api.py
@@ -1,0 +1,8 @@
+"""Keep Playwright browser binaries out of the frozen core package.
+
+The upstream hook collects every Playwright data file, including an optional
+``.local-browsers`` directory. The driver is added explicitly by openakita.spec;
+Chromium is installed into the managed user runtime only after user confirmation.
+"""
+
+datas = []

--- a/scripts/pyinstaller_hooks/hook-playwright.sync_api.py
+++ b/scripts/pyinstaller_hooks/hook-playwright.sync_api.py
@@ -1,0 +1,7 @@
+"""Keep Playwright browser binaries out of the frozen core package.
+
+See hook-playwright.async_api.py. BrowserManager uses the same explicitly
+bundled driver for both APIs.
+"""
+
+datas = []

--- a/src/openakita/tools/browser/manager.py
+++ b/src/openakita/tools/browser/manager.py
@@ -32,6 +32,13 @@ _MACHO_MAGICS = frozenset(
 )
 
 _LAUNCH_TIMEOUT = 30  # seconds
+_CHROMIUM_INSTALL_TIMEOUT = 15 * 60
+_CHROMIUM_INSTALL_LOCK = asyncio.Lock()
+_CHROMIUM_INSTALL_REQUIRED_MESSAGE = (
+    "未安装浏览器自动化所需的 Chromium（约 400 MB）。"
+    "请先询问用户是否下载安装；只有用户明确确认后，才能调用 "
+    'browser_open({"install_chromium": true})。'
+)
 
 _COMMON_CHROMIUM_ARGS = [
     "--disable-blink-features=AutomationControlled",
@@ -137,6 +144,73 @@ def _ensure_macos_executability(target: Path) -> None:
                 pass
     if fixed:
         logger.info(f"[Browser] Fixed execute permissions for {fixed} binaries in {target.name}")
+
+
+def _managed_browsers_dir() -> Path:
+    """Return the user-owned Playwright browser directory."""
+    configured = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    root = os.environ.get("OPENAKITA_ROOT", "").strip()
+    base = Path(root).expanduser() if root else Path.home() / ".openakita"
+    return base / "modules" / "browser" / "browsers"
+
+
+def _has_managed_chromium(browsers_dir: Path) -> bool:
+    return any(path.is_dir() for path in browsers_dir.glob("chromium-*"))
+
+
+async def _download_managed_chromium(browsers_dir: Path) -> None:
+    """Download the Chromium revision matching the bundled Playwright driver."""
+    from playwright._impl._driver import compute_driver_executable
+
+    node, cli = compute_driver_executable()
+    browsers_dir.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_dir)
+
+    kwargs: dict[str, Any] = {}
+    if platform.system() == "Windows":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+    logger.info("[Browser] Downloading Chromium after explicit user confirmation")
+    process = await asyncio.create_subprocess_exec(
+        str(node),
+        str(cli),
+        "install",
+        "--no-shell",
+        "chromium",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+        **kwargs,
+    )
+    try:
+        output, _ = await asyncio.wait_for(
+            process.communicate(),
+            timeout=_CHROMIUM_INSTALL_TIMEOUT,
+        )
+    except asyncio.CancelledError:
+        process.kill()
+        await process.communicate()
+        raise
+    except TimeoutError as exc:
+        process.kill()
+        await process.communicate()
+        raise RuntimeError("Chromium download timed out after 15 minutes") from exc
+
+    details = output.decode("utf-8", errors="replace").strip()
+    for line in details.splitlines():
+        logger.info("[Browser install] %s", line)
+    if process.returncode != 0:
+        tail = details[-2000:] if details else "no installer output"
+        raise RuntimeError(f"Chromium download failed (exit {process.returncode}): {tail}")
+    if not _has_managed_chromium(browsers_dir):
+        raise RuntimeError(
+            f"Chromium installer succeeded but no runtime was found in {browsers_dir}"
+        )
+    _ensure_macos_executability(browsers_dir)
+    logger.info("[Browser] Chromium runtime installed in %s", browsers_dir)
 
 
 def _find_bundled_browser_executable() -> str | None:
@@ -341,6 +415,9 @@ class BrowserManager:
         self._cdp_url: str | None = None
         self._last_successful_strategy: StartupStrategy | None = None
         self._startup_errors: list[str] = []
+        self._chromium_install_error: str | None = None
+        self._chromium_install_allowed = False
+        self.chromium_install_required = False
         self._startup_lock = asyncio.Lock()
         self._is_server = _is_server_environment()
 
@@ -414,7 +491,7 @@ class BrowserManager:
 
     # ── 启动 / 停止 ────────────────────────────────────
 
-    async def start(self, visible: bool = True) -> bool:
+    async def start(self, visible: bool = True, *, install_chromium: bool = False) -> bool:
         async with self._startup_lock:
             if self.state == BrowserState.READY:
                 if visible != self.visible:
@@ -426,6 +503,9 @@ class BrowserManager:
             self.state = BrowserState.STARTING
             self.visible = visible
             self._startup_errors.clear()
+            self._chromium_install_error = None
+            self._chromium_install_allowed = install_chromium
+            self.chromium_install_required = False
 
             headless = not visible
 
@@ -454,6 +534,8 @@ class BrowserManager:
                         f"[Browser] Strategy {strategy.value} failed: {e}",
                         exc_info=True,
                     )
+                    if self.chromium_install_required:
+                        break
                     if self._is_driver_pipe_broken(e) or await self._is_driver_dead():
                         logger.warning(
                             "[Browser] Playwright driver died/pipe broken, "
@@ -463,7 +545,7 @@ class BrowserManager:
                         if not await self._start_playwright_driver():
                             break
 
-            if not headless:
+            if not headless and not self.chromium_install_required:
                 logger.info(
                     "[Browser] All headed strategies failed, restarting driver for headless retry..."
                 )
@@ -655,9 +737,7 @@ class BrowserManager:
                         logger.info(f"[Browser] Using bundled {pw_name}: {bundled}")
                         return
 
-        _root = os.environ.get("OPENAKITA_ROOT", "").strip()
-        _base = Path(_root) if _root else Path.home() / ".openakita"
-        browsers_dir = _base / "modules" / "browser" / "browsers"
+        browsers_dir = _managed_browsers_dir()
         if browsers_dir.is_dir():
             os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_dir)
             logger.info(f"[Browser] Using external Chromium: {browsers_dir}")
@@ -828,9 +908,10 @@ class BrowserManager:
         return None
 
     async def _try_bundled_chromium(self, headless: bool) -> bool:
-        """使用 Chromium 启动。
+        """Use the bundled-or-managed Chromium runtime.
 
         策略（按顺序）：
+        0. Download the matching managed Chromium revision after user confirmation
         1. persistent_context — 原子式创建浏览器 + 上下文 + 页面，避免进程间隙崩溃
         2. launch + new_context + new_page — 传统方式兜底
         """
@@ -841,7 +922,31 @@ class BrowserManager:
         else:
             preflight_err = self._preflight_chromium()
             if preflight_err:
-                raise RuntimeError(preflight_err)
+                if not self._chromium_install_allowed:
+                    self.chromium_install_required = True
+                    raise RuntimeError(_CHROMIUM_INSTALL_REQUIRED_MESSAGE)
+                if self._chromium_install_error:
+                    raise RuntimeError(self._chromium_install_error)
+                browsers_dir = _managed_browsers_dir()
+                try:
+                    async with _CHROMIUM_INSTALL_LOCK:
+                        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_dir)
+                        # The CLI is idempotent and checks the exact revision. Do
+                        # not treat an older chromium-* directory as a cache hit.
+                        await _download_managed_chromium(browsers_dir)
+                except Exception as exc:
+                    self._chromium_install_error = str(exc)
+                    raise
+
+                # The driver captures PLAYWRIGHT_BROWSERS_PATH when it starts.
+                # Restart it after installation so executable_path is resolved
+                # against the managed directory rather than the default cache.
+                await self._cleanup_playwright()
+                if not await self._start_playwright_driver():
+                    raise RuntimeError("Playwright driver failed to restart after Chromium install")
+                preflight_err = self._preflight_chromium()
+                if preflight_err:
+                    raise RuntimeError(preflight_err)
 
         effective_headless = headless
         if self._is_server and not headless:

--- a/src/openakita/tools/definitions/browser.py
+++ b/src/openakita/tools/definitions/browser.py
@@ -36,6 +36,7 @@ BROWSER_TOOLS = [
             params_desc={
                 "visible": "True=有界面/headed 自动化模式，False=后台/headless 模式；True 不等于已验证窗口在桌面前台",
                 "user_confirmed": "当浏览器之前被用户关闭后，只有用户明确确认继续时才传 True 重新打开前台浏览器",
+                "install_chromium": "仅当工具提示 Chromium 缺失且用户明确同意约 400 MB 下载后才传 True",
             },
             notes=[
                 "⚠️ 每次浏览器任务前建议调用此工具确认状态",
@@ -44,6 +45,7 @@ BROWSER_TOOLS = [
                 "默认使用有界面/headed 模式，但工具结果不代表窗口已在用户桌面前台",
                 "如果用户说看不到浏览器，必须使用桌面截图/窗口工具验证并切换；不要只根据 browser_open 的 headed/visible 断言已在前台",
                 "如果工具提示浏览器可能被用户关闭，不要自动重开；先询问用户，得到明确确认后传 user_confirmed=True",
+                "如果工具提示 Chromium 缺失，不要自动安装；先询问用户，得到明确确认后传 install_chromium=True",
             ],
         ),
         "triggers": [
@@ -91,6 +93,11 @@ BROWSER_TOOLS = [
                 "user_confirmed": {
                     "type": "boolean",
                     "description": "仅当用户明确确认重新打开前台浏览器时传 True；用于浏览器被用户关闭后的重启保护",
+                    "default": False,
+                },
+                "install_chromium": {
+                    "type": "boolean",
+                    "description": "仅当用户明确确认下载约 400 MB 的 Chromium 后传 True",
                     "default": False,
                 },
             },

--- a/src/openakita/tools/handlers/browser.py
+++ b/src/openakita/tools/handlers/browser.py
@@ -144,6 +144,12 @@ class BrowserHandler:
 
         result = await self._dispatch_with_lock(actual_tool_name, params)
 
+        if (
+            not result.get("success")
+            and getattr(self.agent.browser_manager, "chromium_install_required", False)
+        ):
+            result = self._chromium_install_confirmation_result()
+
         if actual_tool_name == "browser_get_content" and result.get("success"):
             output = self._format_get_content_result(result, params)
         elif result.get("success"):
@@ -401,7 +407,13 @@ class BrowserHandler:
             logger.warning("[Browser] Incomplete browser state, resetting")
             await manager.reset_state()
 
-        success = await manager.start(visible=visible)
+        # This flag authorizes a large network download, so require the schema's
+        # literal boolean true rather than accepting arbitrary truthy values.
+        install_chromium = params.get("install_chromium") is True
+        success = await manager.start(
+            visible=visible,
+            install_chromium=install_chromium,
+        )
 
         if success:
             if params.get("user_confirmed") or not visible:
@@ -439,6 +451,9 @@ class BrowserHandler:
 
             return {"success": True, "result": result_data}
         else:
+            if getattr(manager, "chromium_install_required", False):
+                return self._chromium_install_confirmation_result()
+
             hints: list[str] = []
             try:
                 from ..browser.chrome_finder import (
@@ -492,6 +507,19 @@ class BrowserHandler:
                 "result": {"is_open": False, "status": "failed"},
                 "error": error_msg,
             }
+
+    @staticmethod
+    def _chromium_install_confirmation_result() -> dict:
+        return {
+            "success": False,
+            "result": {"is_open": False, "status": "install_confirmation_required"},
+            "error": (
+                "未安装浏览器自动化所需的 Chromium（约 400 MB）。"
+                "本次不会自动下载。请先询问用户是否安装；只有用户明确确认后，"
+                "才能再次调用 "
+                'browser_open({"install_chromium": true})。'
+            ),
+        }
 
     @staticmethod
     def _build_open_status_result(

--- a/tests/unit/test_browser_handler.py
+++ b/tests/unit/test_browser_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -60,9 +61,10 @@ class _StartableBrowserManager:
         self.page = None
         self.reset_count += 1
 
-    async def start(self, visible=True):
+    async def start(self, visible=True, *, install_chromium=False):
         self.started = True
         self.visible = visible
+        self.install_chromium = install_chromium
         self.is_ready = True
         self.page = _FakePage()
         self.context = SimpleNamespace(pages=[self.page])
@@ -168,6 +170,83 @@ async def test_user_confirmed_browser_open_clears_closed_gate():
     assert "status" in result
     assert manager.started is True
     assert agent._browser_user_closed is False
+
+
+@pytest.mark.asyncio
+async def test_browser_open_reports_chromium_confirmation_requirement():
+    manager = _StartableBrowserManager()
+    manager.chromium_install_required = True
+
+    async def fail_start(visible=True, *, install_chromium=False):
+        return False
+
+    manager.start = fail_start
+    agent = SimpleNamespace(
+        name="tester",
+        browser_manager=manager,
+        pw_tools=_FakePlaywrightTools(),
+    )
+
+    result = await BrowserHandler(agent).handle("browser_open", {"visible": True})
+
+    assert "本次不会自动下载" in result
+    assert 'browser_open({"install_chromium": true})' in result
+
+
+@pytest.mark.asyncio
+async def test_browser_open_passes_explicit_chromium_install_confirmation():
+    manager = _StartableBrowserManager()
+    agent = SimpleNamespace(
+        name="tester",
+        browser_manager=manager,
+        pw_tools=_FakePlaywrightTools(),
+    )
+
+    result = await BrowserHandler(agent).handle(
+        "browser_open",
+        {"visible": True, "install_chromium": True},
+    )
+
+    assert "status" in result
+    assert manager.install_chromium is True
+
+
+@pytest.mark.asyncio
+async def test_browser_open_rejects_truthy_non_boolean_install_confirmation():
+    manager = _StartableBrowserManager()
+    agent = SimpleNamespace(
+        name="tester",
+        browser_manager=manager,
+        pw_tools=_FakePlaywrightTools(),
+    )
+
+    await BrowserHandler(agent).handle(
+        "browser_open",
+        {"visible": True, "install_chromium": "true"},
+    )
+
+    assert manager.install_chromium is False
+
+
+@pytest.mark.asyncio
+async def test_implicit_browser_start_also_requests_install_confirmation():
+    manager = _StartableBrowserManager()
+    manager.chromium_install_required = True
+    agent = SimpleNamespace(
+        name="tester",
+        browser_manager=manager,
+        pw_tools=SimpleNamespace(
+            navigate=AsyncMock(return_value={"success": False, "error": "浏览器启动失败"})
+        ),
+    )
+
+    result = await BrowserHandler(agent).handle(
+        "browser_navigate",
+        {"url": "https://example.com"},
+    )
+
+    assert "本次不会自动下载" in result
+    assert 'browser_open({"install_chromium": true})' in result
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_browser_runtime_install.py
+++ b/tests/unit/test_browser_runtime_install.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openakita.tools.browser import manager
+
+
+class _InstallProcess:
+    def __init__(self, browsers_dir: Path, *, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self._browsers_dir = browsers_dir
+        self.killed = False
+
+    async def communicate(self):
+        if self.returncode == 0:
+            (self._browsers_dir / "chromium-expected").mkdir(parents=True, exist_ok=True)
+        return b"playwright install output", b""
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def test_managed_browsers_dir_respects_openakita_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.setenv("OPENAKITA_ROOT", str(tmp_path))
+
+    assert manager._managed_browsers_dir() == tmp_path / "modules" / "browser" / "browsers"
+
+
+@pytest.mark.asyncio
+async def test_download_managed_chromium_uses_bundled_driver_cli(
+    tmp_path: Path, monkeypatch
+) -> None:
+    browsers_dir = tmp_path / "browsers"
+    calls = []
+
+    async def fake_subprocess(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _InstallProcess(browsers_dir)
+
+    monkeypatch.setattr(
+        "playwright._impl._driver.compute_driver_executable",
+        lambda: (tmp_path / "node", tmp_path / "cli.js"),
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    await manager._download_managed_chromium(browsers_dir)
+
+    args, kwargs = calls[0]
+    assert args[-3:] == ("install", "--no-shell", "chromium")
+    assert kwargs["env"]["PLAYWRIGHT_BROWSERS_PATH"] == str(browsers_dir)
+    assert (browsers_dir / "chromium-expected").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_download_managed_chromium_reports_installer_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    browsers_dir = tmp_path / "browsers"
+
+    monkeypatch.setattr(
+        "playwright._impl._driver.compute_driver_executable",
+        lambda: (tmp_path / "node", tmp_path / "cli.js"),
+    )
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        lambda *args, **kwargs: _async_value(_InstallProcess(browsers_dir, returncode=1)),
+    )
+
+    with pytest.raises(RuntimeError, match="Chromium download failed"):
+        await manager._download_managed_chromium(browsers_dir)
+
+
+async def _async_value(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_missing_chromium_downloads_then_restarts_driver(tmp_path: Path, monkeypatch) -> None:
+    missing_executable = tmp_path / "missing" / "chrome.exe"
+    installed_executable = tmp_path / "browsers" / "chromium-current" / "chrome.exe"
+    installed_executable.parent.mkdir(parents=True)
+    installed_executable.write_bytes(b"x" * 1_100_000)
+
+    browser_type = SimpleNamespace(executable_path=str(missing_executable))
+    browser_manager = object.__new__(manager.BrowserManager)
+    browser_manager._bundled_executable = None
+    browser_manager._playwright = SimpleNamespace(chromium=browser_type)
+    browser_manager._chromium_install_error = None
+    browser_manager._chromium_install_allowed = True
+    browser_manager.chromium_install_required = False
+    browser_manager._is_server = False
+    browser_manager._cleanup_playwright = AsyncMock()
+    browser_manager._launch_persistent = AsyncMock(return_value=True)
+    browser_manager._launch_standard = AsyncMock(return_value=False)
+
+    async def restart_driver() -> bool:
+        browser_type.executable_path = str(installed_executable)
+        return True
+
+    browser_manager._start_playwright_driver = restart_driver
+    download = AsyncMock()
+    monkeypatch.setattr(manager, "_managed_browsers_dir", lambda: tmp_path / "browsers")
+    monkeypatch.setattr(manager, "_download_managed_chromium", download)
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+
+    assert await browser_manager._try_bundled_chromium(headless=True)
+    download.assert_awaited_once_with(tmp_path / "browsers")
+    browser_manager._cleanup_playwright.assert_awaited_once()
+    browser_manager._launch_persistent.assert_awaited_once_with(None, True)
+    assert manager.os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(tmp_path / "browsers")
+
+
+@pytest.mark.asyncio
+async def test_missing_chromium_requires_confirmation_without_downloading(
+    tmp_path: Path, monkeypatch
+) -> None:
+    browser_manager = object.__new__(manager.BrowserManager)
+    browser_manager._bundled_executable = None
+    browser_manager._playwright = SimpleNamespace(
+        chromium=SimpleNamespace(executable_path=str(tmp_path / "missing" / "chrome.exe"))
+    )
+    browser_manager._chromium_install_error = None
+    browser_manager._chromium_install_allowed = False
+    browser_manager.chromium_install_required = False
+    browser_manager._is_server = False
+    download = AsyncMock()
+    monkeypatch.setattr(manager, "_download_managed_chromium", download)
+
+    with pytest.raises(RuntimeError, match="请先询问用户是否下载安装"):
+        await browser_manager._try_bundled_chromium(headless=True)
+
+    assert browser_manager.chromium_install_required is True
+    download.assert_not_awaited()
+
+
+def test_packaging_excludes_chromium_but_keeps_playwright_driver() -> None:
+    root = Path(__file__).parents[2]
+    spec = (root / "build" / "openakita.spec").read_text(encoding="utf-8")
+    backend = (root / "build" / "build_backend.py").read_text(encoding="utf-8")
+
+    assert 'datas.append((str(_pw_driver_dir), "playwright/driver"))' in spec
+    assert "_pw_browser_dir" not in spec
+    assert "Bundling Playwright Chromium" not in spec
+    assert '".local-browsers" not in entry[0]' in spec
+    assert 'scripts" / "pyinstaller_hooks' in spec
+    assert "ensure_playwright_chromium" not in backend
+    assert '"playwright", "install", "chromium"' not in backend
+
+    hook_dir = root / "scripts" / "pyinstaller_hooks"
+    for api in ("async_api", "sync_api"):
+        hook = (hook_dir / f"hook-playwright.{api}.py").read_text(encoding="utf-8")
+        assert "collect_data_files" not in hook
+        assert "datas = []" in hook

--- a/tests/unit/test_build_cache_key.py
+++ b/tests/unit/test_build_cache_key.py
@@ -10,6 +10,12 @@ def test_cache_inputs_separate_backend_and_rust_ownership() -> None:
     assert "src/openakita" not in INPUTS["rust"]
 
 
+def test_rust_cache_tracks_frontend_assets_embedded_by_tauri() -> None:
+    assert "apps/setup-center/src" in INPUTS["rust"]
+    assert "apps/setup-center/package-lock.json" in INPUTS["rust"]
+    assert "apps/setup-center/vite.config.ts" in INPUTS["rust"]
+
+
 def test_fingerprints_are_stable_sha256_values() -> None:
     for kind in INPUTS:
         value = fingerprint(kind)

--- a/tests/unit/test_build_cache_key.py
+++ b/tests/unit/test_build_cache_key.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from scripts.build_cache_key import INPUTS, fingerprint
+
+
+def test_cache_inputs_separate_backend_and_rust_ownership() -> None:
+    assert "src/openakita" in INPUTS["backend"]
+    assert "apps/setup-center/src-tauri/src" not in INPUTS["backend"]
+    assert "apps/setup-center/src-tauri/src" in INPUTS["rust"]
+    assert "src/openakita" not in INPUTS["rust"]
+
+
+def test_fingerprints_are_stable_sha256_values() -> None:
+    for kind in INPUTS:
+        value = fingerprint(kind)
+        assert len(value) == 64
+        assert int(value, 16) >= 0
+
+
+def test_all_declared_single_file_inputs_exist() -> None:
+    root = Path(__file__).parents[2]
+    for inputs in INPUTS.values():
+        for value in inputs:
+            path = root / value
+            assert path.exists(), value

--- a/tests/unit/test_bundled_python_contract.py
+++ b/tests/unit/test_bundled_python_contract.py
@@ -34,8 +34,23 @@ def test_bundled_chat_smoke_exercises_request_without_mode() -> None:
     _run_bundled_chat_smoke(Path("src").resolve())
 
 
+def test_bundled_chat_smoke_checks_loose_toolbelt_import() -> None:
+    smoke_source = (Path("scripts") / "package_chat_smoke.py").read_text(encoding="utf-8")
+
+    assert "import requests_toolbelt" in smoke_source
+    assert "requests_toolbelt imported from" in smoke_source
+
+
 def test_pyinstaller_source_tree_excludes_build_owned_version_file() -> None:
     spec_source = (Path("build") / "openakita.spec").read_text(encoding="utf-8")
 
     assert 'excludes=["_bundled_version.txt"]' in spec_source
     assert 'datas.append((str(_openakita_src), "openakita"))' not in spec_source
+
+
+def test_pyinstaller_does_not_analyze_loose_requests_toolbelt_copy_twice() -> None:
+    spec_source = (Path("build") / "openakita.spec").read_text(encoding="utf-8")
+
+    hidden_imports = spec_source.split("hidden_imports_core = [", 1)[1].split("]", 1)[0]
+    assert '"requests_toolbelt"' not in hidden_imports
+    assert 'datas.append((_rt_dir, "requests_toolbelt"))' in spec_source

--- a/tests/unit/test_bundled_python_contract.py
+++ b/tests/unit/test_bundled_python_contract.py
@@ -37,6 +37,7 @@ def test_bundled_chat_smoke_exercises_request_without_mode() -> None:
 def test_bundled_chat_smoke_checks_loose_toolbelt_import() -> None:
     smoke_source = (Path("scripts") / "package_chat_smoke.py").read_text(encoding="utf-8")
 
+    assert 'if internal_dir.name != "src":' in smoke_source
     assert "import requests_toolbelt" in smoke_source
     assert "requests_toolbelt imported from" in smoke_source
 

--- a/tests/unit/test_prepare_tauri_binary.py
+++ b/tests/unit/test_prepare_tauri_binary.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import scripts.prepare_tauri_binary as module
+
+
+def test_prepare_binary_copies_cargo_name_to_tauri_main_binary(tmp_path: Path, monkeypatch) -> None:
+    tauri_dir = tmp_path / "src-tauri"
+    release_dir = tauri_dir / "target" / "release"
+    release_dir.mkdir(parents=True)
+    (tauri_dir / "tauri.conf.json").write_text(
+        '{"mainBinaryName":"openakita-desktop"}', encoding="utf-8"
+    )
+    suffix = ".exe" if module.sys.platform == "win32" else ""
+    source = release_dir / f"openakita-setup-center{suffix}"
+    source.write_bytes(b"cargo-binary")
+    monkeypatch.setattr(module, "TAURI_DIR", tauri_dir)
+
+    destination = module.prepare_binary()
+
+    assert destination.name == f"openakita-desktop{suffix}"
+    assert destination.read_bytes() == b"cargo-binary"
+
+
+def test_prepare_binary_accepts_restored_destination(tmp_path: Path, monkeypatch) -> None:
+    tauri_dir = tmp_path / "src-tauri"
+    release_dir = tauri_dir / "target" / "custom-target" / "release"
+    release_dir.mkdir(parents=True)
+    (tauri_dir / "tauri.conf.json").write_text(
+        '{"mainBinaryName":"openakita-desktop"}', encoding="utf-8"
+    )
+    suffix = ".exe" if module.sys.platform == "win32" else ""
+    expected = release_dir / f"openakita-desktop{suffix}"
+    expected.write_bytes(b"cached-binary")
+    monkeypatch.setattr(module, "TAURI_DIR", tauri_dir)
+
+    assert module.prepare_binary("custom-target") == expected

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -93,17 +93,19 @@ def test_ci_full_build_parallelizes_independent_packagers() -> None:
     steps = workflow["jobs"]["tauri_full_build_check"]["steps"]
     steps_by_name = {step.get("name"): step for step in steps}
 
-    parallel_run = steps_by_name["Build backend, desktop frontend, Rust, and docs in parallel"][
-        "run"
-    ]
+    frontend_run = steps_by_name["Build web and desktop frontend assets"]["run"]
+    assert "npm run build:web" in frontend_run.splitlines()
+    assert "npm run build" in frontend_run.splitlines()
+
+    parallel_run = steps_by_name["Build backend, Rust, and docs in parallel"]["run"]
     assert "python build/build_backend.py --skip-web-build" in parallel_run
-    assert "npm run build" in parallel_run
     assert "cargo build --release --features tauri/custom-protocol" in parallel_run
     assert "wait_for_build" in parallel_run
     assert all(
         f'wait_for_build "${name}_pid" {name}' in parallel_run
-        for name in ("backend", "frontend", "rust", "docs")
+        for name in ("backend", "rust", "docs")
     )
+    assert "frontend_pid" not in parallel_run
 
     tauri_run = steps_by_name["Build Tauri bundles (full build)"]["run"]
     assert "npx tauri bundle" in tauri_run

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -1,11 +1,16 @@
+import json
 from pathlib import Path
 
 import yaml
 
 ROOT = Path(__file__).parents[2]
 RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+DRY_RUN = ROOT / ".github" / "workflows" / "release-dryrun.yml"
 MOBILE = ROOT / ".github" / "workflows" / "mobile.yml"
 PREPARE = ROOT / ".github" / "actions" / "desktop-build-prepare" / "action.yml"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+TAURI_CONFIG = ROOT / "apps" / "setup-center" / "src-tauri" / "tauri.conf.json"
+FULL_BUILD_SCRIPTS = (ROOT / "build" / "build_full.ps1", ROOT / "build" / "build_full.sh")
 
 
 def test_release_workflows_never_clobber_existing_assets() -> None:
@@ -63,11 +68,99 @@ def test_packaging_verifies_checkout_identity_and_chat_api() -> None:
     assert 'OPENAKITA_BUILD_GIT_HASH="$(git rev-parse HEAD)"' in prepare_source
 
 
+def test_full_builds_compile_each_frontend_target_once() -> None:
+    tauri_config = json.loads(TAURI_CONFIG.read_text(encoding="utf-8"))
+    assert tauri_config["build"]["beforeBuildCommand"] == "npm run build"
+
+    prepare_source = PREPARE.read_text(encoding="utf-8")
+    assert prepare_source.count("npm run build:web") == 1
+    assert "python build/build_backend.py --skip-web-build" in prepare_source
+
+    ci_source = CI.read_text(encoding="utf-8")
+    full_build_job = ci_source.index("tauri_full_build_check:")
+    web_build = ci_source.index("npm run build:web", full_build_job)
+    backend_build = ci_source.index("python build/build_backend.py --skip-web-build", web_build)
+    assert web_build < backend_build
+
+    for path in FULL_BUILD_SCRIPTS:
+        source = path.read_text(encoding="utf-8")
+        assert source.count("npm run build:web") == 1
+        assert "--skip-web-build" in source
+
+
+def test_ci_full_build_parallelizes_independent_packagers() -> None:
+    workflow = yaml.load(CI.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["tauri_full_build_check"]["steps"]
+    steps_by_name = {step.get("name"): step for step in steps}
+
+    parallel_run = steps_by_name["Build backend, desktop frontend, Rust, and docs in parallel"][
+        "run"
+    ]
+    assert "python build/build_backend.py --skip-web-build" in parallel_run
+    assert "npm run build" in parallel_run
+    assert "cargo build --release --features tauri/custom-protocol" in parallel_run
+    assert "wait_for_build" in parallel_run
+    assert all(
+        f'wait_for_build "${name}_pid" {name}' in parallel_run
+        for name in ("backend", "frontend", "rust", "docs")
+    )
+
+    tauri_run = steps_by_name["Build Tauri bundles (full build)"]["run"]
+    assert "npx tauri bundle" in tauri_run
+    assert "npx tauri build" not in tauri_run
+
+
+def test_desktop_workflows_cache_exact_expensive_outputs() -> None:
+    prepare_source = PREPARE.read_text(encoding="utf-8")
+    ci_source = CI.read_text(encoding="utf-8")
+
+    for source in (prepare_source, ci_source):
+        assert "python scripts/build_cache_key.py backend" in source
+        assert "desktop-backend-v2-" in source
+        assert "dist/openakita-server" in source
+    assert "python scripts/build_cache_key.py rust" in prepare_source
+    assert "desktop-rust-binary-v2-" in prepare_source
+    assert "Refresh cached backend build identity" in prepare_source
+
+
+def test_release_workflows_compile_then_bundle_without_destroying_rust_cache() -> None:
+    for path, job_name in ((RELEASE, "desktop_release"), (DRY_RUN, "dryrun_build")):
+        workflow = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+        steps = workflow["jobs"][job_name]["steps"]
+        steps_by_name = {step.get("name"): step for step in steps}
+
+        compile_step = steps_by_name["Compile Rust desktop binary"]
+        assert "cargo build --release --features tauri/custom-protocol" in compile_step["run"]
+        assert "rust_binary_cache_hit != 'true'" in compile_step["if"]
+
+        bundle_run = steps_by_name["Bundle Tauri installers"]["run"]
+        assert "npx tauri bundle" in bundle_run
+        assert "npx tauri build" not in bundle_run
+        assert "Clean Rust release intermediates for current target" not in steps_by_name
+        assert "Preflight Rust dependency check" not in steps_by_name
+        assert "cargo clean" in compile_step["run"]
+        prepare_run = steps_by_name["Prepare Cargo binary for Tauri bundler"]["run"]
+        assert "scripts/prepare_tauri_binary.py" in prepare_run
+
+
+def test_intel_macos_dmg_bypasses_create_dmg() -> None:
+    for path in (RELEASE, DRY_RUN):
+        source = path.read_text(encoding="utf-8")
+        assert 'if [ "${{ matrix.suffix }}" = "macos-x64" ]; then' in source
+        assert "Intel runner: using hdiutil directly" in source
+
+
+def test_pyinstaller_analysis_reports_are_uploaded() -> None:
+    for source in (PREPARE.read_text(encoding="utf-8"), CI.read_text(encoding="utf-8")):
+        assert "warn-*.txt" in source
+        assert "xref-*.html" in source
+
+
 def test_changed_workflow_yaml_is_valid() -> None:
     paths = (
         RELEASE,
         MOBILE,
-        ROOT / ".github" / "workflows" / "release-dryrun.yml",
+        DRY_RUN,
         ROOT / ".github" / "workflows" / "ci.yml",
         PREPARE,
     )


### PR DESCRIPTION
## Summary

- Build the shared web assets once, parallelize independent full-build jobs, and reuse exact PyInstaller and Rust outputs across CI and release workflows.
- Split Rust compilation from Tauri bundling, preserve reusable artifacts, publish PyInstaller diagnostics, and avoid the Intel macOS create-dmg hang.
- Remove bundled Chromium from desktop packages, keep the Playwright driver, and require explicit user confirmation before downloading the managed browser runtime.

## Tests

- `uv run --no-sync pytest tests/unit -x -q` (4,369 passed, 16 skipped)
- `uv run --no-sync ruff check` on all changed Python files and PyInstaller hooks
- `npm run build`
- `cargo build --release --features tauri/custom-protocol`
- PowerShell parser validation for `build/build_full.ps1`
- Local Windows PyInstaller build and bundled backend contract smoke test
