### PR TITLE
Add OSS-accelerated optional browser component installation with resumable progress

### DIFF
--- a/.github/optional-assets.json
+++ b/.github/optional-assets.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "features": [
+    {
+      "id": "browser.playwright-runtime",
+      "provider": "python_lock_wheel",
+      "package": "playwright",
+      "strategy": "python_wheel_driver",
+      "mirror_path": "optional/python/playwright",
+      "platforms": {
+        "windows-x64": "win_amd64.whl",
+        "windows-arm64": "win_arm64.whl",
+        "macos-x64": "macosx_10_13_x86_64.whl",
+        "macos-arm64": "macosx_11_0_arm64.whl",
+        "linux-x64": "manylinux1_x86_64.whl",
+        "linux-arm64": "manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+      }
+    },
+    {
+      "id": "browser.chromium",
+      "provider": "playwright",
+      "strategy": "playwright_download_host",
+      "mirror_path": "optional/playwright",
+      "install_args": ["--no-shell", "chromium"],
+      "platforms": [
+        "win64",
+        "mac15",
+        "mac15-arm64",
+        "ubuntu24.04-x64",
+        "ubuntu24.04-arm64"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -102,6 +102,89 @@ jobs:
           fi
           echo "✅ Release $TAG exists"
 
+      # ── 发布前同步可选功能资源，避免用户首次下载走境外链路 ──
+      - name: Configure Aliyun OSS
+        if: ${{ env.HAS_OSS_KEY != '' }}
+        env:
+          OSS_ACCESS_KEY_ID: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}
+          OSS_ENDPOINT: ${{ secrets.ALIYUN_OSS_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          curl -fsSL https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash
+          ossutil config \
+            -e "${OSS_ENDPOINT}" \
+            -i "${OSS_ACCESS_KEY_ID}" \
+            -k "${OSS_ACCESS_KEY_SECRET}"
+
+      - name: Mirror optional feature assets to Aliyun OSS
+        if: ${{ env.HAS_OSS_KEY != '' }}
+        env:
+          OSS_BUCKET: ${{ secrets.ALIYUN_OSS_BUCKET }}
+          CDN_BASE_URL: https://${{ secrets.ALIYUN_OSS_CDN_DOMAIN }}
+        run: |
+          set -euo pipefail
+
+          PLAYWRIGHT_VERSION=$(python - <<'PY'
+          import tomllib
+          with open("uv.lock", "rb") as f:
+              lock = tomllib.load(f)
+          print(next(p["version"] for p in lock["package"] if p["name"] == "playwright"))
+          PY
+          )
+          python -m pip install --disable-pip-version-check --no-deps \
+            "playwright==${PLAYWRIGHT_VERSION}"
+          EXISTING_OPTIONAL_ARGS=()
+          if curl -sf "${CDN_BASE_URL}/api/optional-assets.json" \
+            -o manifest-out/existing-optional-assets.json; then
+            EXISTING_OPTIONAL_ARGS=(
+              --existing-manifest manifest-out/existing-optional-assets.json
+            )
+          fi
+          python scripts/prepare_optional_assets.py \
+            --catalog .github/optional-assets.json \
+            --inventory manifest-out/optional-assets-inventory.json \
+            --manifest manifest-out/optional-assets.json \
+            --cdn-base-url "${CDN_BASE_URL}" \
+            "${EXISTING_OPTIONAL_ARGS[@]}"
+
+          jq -c '.artifacts[]' manifest-out/optional-assets-inventory.json | while read -r artifact; do
+            OBJECT_PATH=$(jq -r '.object_path' <<<"${artifact}")
+            DESTINATION="oss://${OSS_BUCKET}/${OBJECT_PATH}"
+            if ossutil stat "${DESTINATION}" >/dev/null 2>&1; then
+              echo "Already mirrored: ${OBJECT_PATH}"
+              continue
+            fi
+
+            TEMP_FILE=$(mktemp)
+            DOWNLOADED=false
+            while read -r SOURCE_URL; do
+              echo "Downloading ${SOURCE_URL}"
+              if curl -fL --retry 3 --retry-delay 2 -o "${TEMP_FILE}" "${SOURCE_URL}"; then
+                DOWNLOADED=true
+                break
+              fi
+            done < <(jq -r '.sources[]' <<<"${artifact}")
+            if [ "${DOWNLOADED}" != "true" ]; then
+              rm -f "${TEMP_FILE}"
+              echo "Failed to download ${OBJECT_PATH} from all upstream sources" >&2
+              exit 1
+            fi
+            EXPECTED_SHA256=$(jq -r '.sha256 // empty' <<<"${artifact}")
+            if [ -n "${EXPECTED_SHA256}" ]; then
+              echo "${EXPECTED_SHA256}  ${TEMP_FILE}" | sha256sum --check --status
+            fi
+            ossutil cp "${TEMP_FILE}" "${DESTINATION}" -f \
+              --meta "Cache-Control:public, max-age=31536000, immutable"
+            rm -f "${TEMP_FILE}"
+            echo "Mirrored: ${OBJECT_PATH}"
+          done
+
+          ossutil cp manifest-out/optional-assets.json \
+            "oss://${OSS_BUCKET}/api/optional-assets.json" -f \
+            --meta "Cache-Control:public, max-age=60"
+          echo "Optional feature manifest uploaded"
+
       # ── 发布 Release：移除 draft 标记，设置 latest / prerelease 标志 ──
       - name: Publish release
         env:
@@ -235,12 +318,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          curl -fsSL https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash
-          ossutil config \
-            -e "${OSS_ENDPOINT}" \
-            -i "${OSS_ACCESS_KEY_ID}" \
-            -k "${OSS_ACCESS_KEY_SECRET}"
-
           TAG="${{ inputs.tag }}"
           CC="Cache-Control:public, max-age=60"
           MD="$GITHUB_WORKSPACE/manifest-out"
@@ -309,4 +386,3 @@ jobs:
           else
             echo "No changes to push"
           fi
-

--- a/apps/setup-center/src/types.ts
+++ b/apps/setup-center/src/types.ts
@@ -231,6 +231,7 @@ export type ChatMessage = {
   todo?: ChatTodo | null;
   progressEvents?: ChatProgressEvent[] | null;
   askUser?: ChatAskUser | null;
+  optionalFeatureInstall?: OptionalFeatureInstallRequest | null;
   attachments?: ChatAttachment[] | null;
   artifacts?: ChatArtifact[] | null;
   sources?: ChatSource[] | null;
@@ -305,7 +306,31 @@ export type MessagePart =
   | { kind: "tools"; id: string }
   | { kind: "attachment"; id: string; artifact?: ChatArtifact }
   | { kind: "ask_user"; id: string; ask?: ChatAskUser }
+  | { kind: "optional_feature_install"; id: string; request?: OptionalFeatureInstallRequest }
   | { kind: "error"; id: string };
+
+export type OptionalFeatureInstallRequest = {
+  request_id: string;
+  conversation_id: string;
+  feature_id: string;
+  title: string;
+  description: string;
+  components: Array<{ id: string; name: string }>;
+  estimated_download_mb: number;
+  estimated_disk_mb: number;
+  status: "pending" | "installing" | "installed" | "failed" | "cancelled";
+  progress: number;
+  phase?: "awaiting_confirmation" | "downloading" | "installing" | "complete";
+  phase_progress?: number;
+  downloaded_bytes?: number;
+  total_bytes?: number;
+  current_item?: string;
+  install_progress?: number;
+  message: string;
+  visible?: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
 
 // ─── 思维链 (Thinking Chain) 类型 ───
 

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -43,6 +43,7 @@ import type {
   OrgTimelineEntry,
   MessagePart,
   MessageCompletionAction,
+  OptionalFeatureInstallRequest,
   EnvMap,
 } from "../types";
 import type { FeedbackPrefill } from "./FeedbackModal";
@@ -1725,7 +1726,7 @@ export function ChatView({
   const hydrateSeqRef = useRef(0);
 
   const mapBackendHistoryToMessages = useCallback(
-    (rows: { id: string; index?: number; role: string; content: string; timestamp: number; chain_summary?: ChainSummaryItem[]; chain_timeline?: ChainTimelineGroup[]; artifacts?: ChatArtifact[]; sources?: ChatSource[]; mcp_calls?: ChatMcpCall[]; attachments?: ChatAttachment[]; org_timeline?: OrgTimelineEntry[]; ask_user?: ChatAskUser; error_info?: { message?: string; raw?: string; error_code?: string; org_status?: string | null }; todo?: ChatTodo; progress_events?: ChatProgressEvent[]; parts?: MessagePart[]; usage?: ChatMessage["usage"]; completion_actions?: MessageCompletionAction[] }[]): ChatMessage[] => {
+    (rows: { id: string; index?: number; role: string; content: string; timestamp: number; chain_summary?: ChainSummaryItem[]; chain_timeline?: ChainTimelineGroup[]; artifacts?: ChatArtifact[]; sources?: ChatSource[]; mcp_calls?: ChatMcpCall[]; attachments?: ChatAttachment[]; org_timeline?: OrgTimelineEntry[]; ask_user?: ChatAskUser; optional_feature_install?: OptionalFeatureInstallRequest; error_info?: { message?: string; raw?: string; error_code?: string; org_status?: string | null }; todo?: ChatTodo; progress_events?: ChatProgressEvent[]; parts?: MessagePart[]; usage?: ChatMessage["usage"]; completion_actions?: MessageCompletionAction[] }[]): ChatMessage[] => {
       return rows.map((m) => ({
         id: m.id,
         ...(typeof m.index === "number" ? { historyIndex: m.index } : {}),
@@ -1747,6 +1748,7 @@ export function ChatView({
         ...(m.todo?.steps?.length ? { todo: m.todo } : {}),
         ...(m.progress_events?.length ? { progressEvents: m.progress_events } : {}),
         ...(m.ask_user ? { askUser: m.ask_user, content: "" } : {}),
+        ...(m.optional_feature_install ? { optionalFeatureInstall: m.optional_feature_install } : {}),
         ...(m.error_info ? {
           errorInfo: (() => {
             const message = localizeOrgCommandStateError(t, m.error_info)
@@ -4975,6 +4977,24 @@ export function ChatView({
                 if (currentContent && event.question && event.question.includes(currentContent.trim())) {
                   currentContent = "";
                 }
+                break;
+              }
+              case "optional_feature_install": {
+                const installRequest = event as unknown as OptionalFeatureInstallRequest;
+                const cardId = `optional-feature-${installRequest.request_id}`;
+                updateMessages((prev) => {
+                  if (prev.some((message) => message.id === cardId)) return prev;
+                  const card: ChatMessage = {
+                    id: cardId,
+                    role: "assistant",
+                    content: "浏览器自动化组件需要安装。",
+                    timestamp: Date.now(),
+                    optionalFeatureInstall: installRequest,
+                  };
+                  const streamIndex = prev.findIndex((message) => message.id === assistantMsg.id);
+                  if (streamIndex < 0) return [...prev, card];
+                  return [...prev.slice(0, streamIndex), card, ...prev.slice(streamIndex)];
+                });
                 break;
               }
               case "ui_preference":

--- a/apps/setup-center/src/views/chat/components/MessageParts.tsx
+++ b/apps/setup-center/src/views/chat/components/MessageParts.tsx
@@ -8,6 +8,7 @@ import { ErrorCard } from "./ErrorCard";
 import { SourceStrip } from "./SourceStrip";
 import { MCPCallStrip } from "./MCPCallStrip";
 import { MarkdownContent } from "./MarkdownContent";
+import { OptionalFeatureInstallCard } from "./OptionalFeatureInstallCard";
 
 /**
  * Ordered renderer for an assistant message's `MessagePart[]`.
@@ -107,6 +108,12 @@ export function MessageParts({
             ) : (
               <AskUserBlock key={part.id} ask={ask} onAnswer={(ans) => onAskAnswer?.(msg.id, ans)} />
             );
+          }
+          case "optional_feature_install": {
+            const request = part.request || msg.optionalFeatureInstall;
+            return request && apiBaseUrl ? (
+              <OptionalFeatureInstallCard key={part.id} request={request} apiBaseUrl={apiBaseUrl} />
+            ) : null;
           }
           case "error":
             return msg.errorInfo ? (

--- a/apps/setup-center/src/views/chat/components/OptionalFeatureInstallCard.tsx
+++ b/apps/setup-center/src/views/chat/components/OptionalFeatureInstallCard.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { safeFetch } from "../../../providers";
+import type { OptionalFeatureInstallRequest } from "../utils/chatTypes";
+
+function formatBytes(value = 0): string {
+  if (value <= 0) return "0 MB";
+  return `${(value / 1024 / 1024).toFixed(value >= 100 * 1024 * 1024 ? 0 : 1)} MB`;
+}
+
+function ProgressRow({ label, value, detail }: { label: string; value: number; detail?: string }) {
+  const percent = Math.max(0, Math.min(100, value));
+  return (
+    <div style={{ display: "grid", gap: 5 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, fontSize: 12 }}>
+        <span>{label}</span>
+        <span style={{ opacity: 0.65 }}>{detail || `${percent}%`}</span>
+      </div>
+      <div style={{ height: 6, borderRadius: 3, background: "var(--panel2)", overflow: "hidden" }}>
+        <div style={{ width: `${percent}%`, height: "100%", background: "var(--brand)", transition: "width 0.2s" }} />
+      </div>
+    </div>
+  );
+}
+
+export function OptionalFeatureInstallCard({
+  request: initialRequest,
+  apiBaseUrl,
+}: {
+  request: OptionalFeatureInstallRequest;
+  apiBaseUrl: string;
+}) {
+  const { t } = useTranslation();
+  const [request, setRequest] = useState(initialRequest);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => setRequest(initialRequest), [initialRequest]);
+
+  const refresh = useCallback(async () => {
+    const response = await safeFetch(
+      `${apiBaseUrl}/api/optional-features/${encodeURIComponent(request.request_id)}`,
+    );
+    if (!response.ok) return;
+    setRequest(await response.json() as OptionalFeatureInstallRequest);
+  }, [apiBaseUrl, request.request_id]);
+
+  useEffect(() => {
+    void refresh().catch(() => {});
+  }, [refresh]);
+
+  useEffect(() => {
+    if (request.status !== "installing") return;
+    const timer = window.setInterval(() => void refresh().catch(() => {}), 1000);
+    return () => window.clearInterval(timer);
+  }, [refresh, request.status]);
+
+  const install = async () => {
+    if (submitting || request.status === "installing") return;
+    setSubmitting(true);
+    setError("");
+    setRequest((current) => ({ ...current, status: "installing", progress: 1, message: "准备安装" }));
+    try {
+      const response = await safeFetch(
+        `${apiBaseUrl}/api/optional-features/${encodeURIComponent(request.request_id)}/install`,
+        { method: "POST" },
+      );
+      const payload = await response.json().catch(() => null) as OptionalFeatureInstallRequest | { detail?: string } | null;
+      if (!response.ok) throw new Error((payload as { detail?: string } | null)?.detail || "安装失败");
+      setRequest(payload as OptionalFeatureInstallRequest);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      await refresh().catch(() => {});
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const cancel = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await safeFetch(
+        `${apiBaseUrl}/api/optional-features/${encodeURIComponent(request.request_id)}/cancel`,
+        { method: "POST" },
+      );
+      const payload = await response.json().catch(() => null) as OptionalFeatureInstallRequest | { detail?: string } | null;
+      if (!response.ok) throw new Error((payload as { detail?: string } | null)?.detail || "取消失败");
+      setRequest(payload as OptionalFeatureInstallRequest);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const terminal = request.status === "installed" || request.status === "cancelled";
+  return (
+    <div style={{ margin: "8px 0", padding: 14, border: "1px solid var(--line)", borderRadius: 8, background: "var(--panel)" }}>
+      <div style={{ fontSize: 14, fontWeight: 700 }}>{request.title}</div>
+      <div style={{ marginTop: 5, fontSize: 12, opacity: 0.72, lineHeight: 1.5 }}>{request.description}</div>
+      <div style={{ marginTop: 10, display: "grid", gap: 5 }}>
+        {request.components.map((component) => (
+          <div key={component.id} style={{ fontSize: 12, display: "flex", justifyContent: "space-between", gap: 12 }}>
+            <span>{component.name}</span><span style={{ opacity: 0.55 }}>{component.id}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 10, fontSize: 12, opacity: 0.72 }}>
+        {t("chat.optionalFeatureDownload", "预计下载 {{download}} MB，占用磁盘约 {{disk}} MB", {
+          download: request.estimated_download_mb,
+          disk: request.estimated_disk_mb,
+        })}
+      </div>
+      {(request.status === "installing" || request.status === "installed" || request.status === "failed") && (
+        <div style={{ marginTop: 12, display: "grid", gap: 10 }}>
+          <ProgressRow
+            label={request.current_item ? `下载 · ${request.current_item}` : "下载"}
+            value={request.phase === "installing" || request.phase === "complete" ? 100 : request.phase_progress || 0}
+            detail={request.total_bytes ? `${formatBytes(request.downloaded_bytes)} / ${formatBytes(request.total_bytes)}` : undefined}
+          />
+          <ProgressRow
+            label="安装"
+            value={request.install_progress || (request.phase === "complete" ? 100 : 0)}
+          />
+        </div>
+      )}
+      <div style={{ marginTop: 8, fontSize: 12, color: request.status === "failed" ? "var(--danger)" : "var(--text)" }}>
+        {request.message}
+      </div>
+      {error && <div style={{ marginTop: 6, fontSize: 12, color: "var(--danger)" }}>{error}</div>}
+      {!terminal && request.status !== "installing" && (
+        <div style={{ marginTop: 12, display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button type="button" className="btnSecondary" disabled={submitting} onClick={() => void cancel()}>
+            {t("common.cancel", "取消")}
+          </button>
+          <button type="button" className="btnPrimary" disabled={submitting} onClick={() => void install()}>
+            {request.status === "failed" ? t("common.retry", "重试") : t("chat.downloadAndInstall", "下载并安装")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/setup-center/src/views/chat/utils/__tests__/messageParts.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/messageParts.test.ts
@@ -70,4 +70,31 @@ describe("message parts projection", () => {
 
     expect(hasRenderableBody(msg, parts, true, "")).toBe(false);
   });
+
+  it("restores an optional feature install card without duplicate fallback text", () => {
+    const msg: ChatMessage = {
+      id: "optional-1",
+      role: "assistant",
+      content: "浏览器自动化组件需要安装。",
+      timestamp: 1,
+      optionalFeatureInstall: {
+        request_id: "request-1",
+        conversation_id: "conversation-1",
+        feature_id: "browser.automation",
+        title: "安装浏览器自动化组件",
+        description: "安装浏览器自动化组件",
+        components: [],
+        estimated_download_mb: 450,
+        estimated_disk_mb: 550,
+        status: "pending",
+        progress: 0,
+        message: "等待用户确认",
+      },
+    };
+
+    const parts = resolveMessageParts(msg);
+
+    expect(parts.map((part) => part.kind)).toEqual(["optional_feature_install"]);
+    expect(hasRenderableBody(msg, parts, true, "")).toBe(true);
+  });
 });

--- a/apps/setup-center/src/views/chat/utils/chatHelpers.ts
+++ b/apps/setup-center/src/views/chat/utils/chatHelpers.ts
@@ -699,6 +699,7 @@ type BackendHistoryMessage = {
   usage?: ChatMessage["usage"];
   todo?: ChatTodo | null;
   ask_user?: ChatAskUser | null;
+  optional_feature_install?: ChatMessage["optionalFeatureInstall"] | null;
   errorInfo?: ChatErrorInfo | null;
   parts?: MessagePart[] | null;
   completion_actions?: MessageCompletionAction[] | null;
@@ -884,6 +885,13 @@ export function patchMessagesWithBackendDetailed(
       patches.askUser = m.askUser
         ? { ...m.askUser, ...backend.ask_user, answered: true, answer: backend.ask_user.answer }
         : backend.ask_user;
+    }
+
+    if (
+      backend.optional_feature_install &&
+      JSON.stringify(m.optionalFeatureInstall) !== JSON.stringify(backend.optional_feature_install)
+    ) {
+      patches.optionalFeatureInstall = backend.optional_feature_install;
     }
 
     if (backend.errorInfo && !m.errorInfo) {

--- a/apps/setup-center/src/views/chat/utils/chatTypes.ts
+++ b/apps/setup-center/src/views/chat/utils/chatTypes.ts
@@ -9,6 +9,7 @@ import type {
   ChatTodoStep,
   ChatAskUser,
   ChatAskQuestion,
+  OptionalFeatureInstallRequest,
   ChatAttachment,
   ChatArtifact,
   ChatSource,
@@ -37,6 +38,7 @@ export type {
   ChatTodoStep,
   ChatAskUser,
   ChatAskQuestion,
+  OptionalFeatureInstallRequest,
   ChatAttachment,
   ChatArtifact,
   ChatSource,
@@ -187,6 +189,7 @@ export type StreamEvent =
   | { type: "todo_cancelled"; planId?: string; plan_id?: string }
   | { type: "plan_ready_for_approval"; data: { conversation_id: string; summary: string; plan_id: string; plan_file: string }; conversation_id?: string; plan_id?: string; plan_file?: string; protocol_version?: number }
   | { type: "ask_user"; question: string; options?: { id: string; label: string }[]; allow_multiple?: boolean; questions?: { id: string; prompt: string; options?: { id: string; label: string }[]; allow_multiple?: boolean }[]; confirmation_id?: string; risk_intent?: Record<string, unknown> }
+  | ({ type: "optional_feature_install" } & OptionalFeatureInstallRequest)
   | { type: "user_insert"; content: string }
   | { type: "agent_switch"; agentName: string; reason: string }
   | { type: "agent_handoff"; from_agent: string; to_agent: string; reason?: string }

--- a/apps/setup-center/src/views/chat/utils/messageParts.ts
+++ b/apps/setup-center/src/views/chat/utils/messageParts.ts
@@ -33,6 +33,7 @@ const KNOWN_KINDS = new Set<MessagePart["kind"]>([
   "tools",
   "attachment",
   "ask_user",
+  "optional_feature_install",
   "error",
 ]);
 
@@ -74,7 +75,14 @@ export function deriveMessageParts(msg: ChatMessage): MessagePart[] {
       progressEvents: msg.progressEvents || undefined,
     });
   }
-  if (msg.content) {
+  if (msg.optionalFeatureInstall) {
+    parts.push({
+      kind: "optional_feature_install",
+      id: pid(msg.id, "optional_feature_install", msg.optionalFeatureInstall.request_id),
+      request: msg.optionalFeatureInstall,
+    });
+  }
+  if (msg.content && !msg.optionalFeatureInstall) {
     parts.push({ kind: "text", id: pid(msg.id, "text") });
   }
   // Legacy ToolCallsGroup only renders when there is no structured chain.
@@ -133,8 +141,13 @@ export function coerceMessageParts(raw: unknown, msg: ChatMessage): MessagePart[
         out.push({ kind: "ask_user", id, ask });
         break;
       }
+      case "optional_feature_install": {
+        const request = ((item as { request?: ChatMessage["optionalFeatureInstall"] }).request ?? msg.optionalFeatureInstall) || undefined;
+        out.push({ kind: "optional_feature_install", id, request });
+        break;
+      }
       default:
-        out.push({ kind: kind as Exclude<MessagePart["kind"], "plan" | "attachment" | "ask_user">, id });
+        out.push({ kind: kind as Exclude<MessagePart["kind"], "plan" | "attachment" | "ask_user" | "optional_feature_install">, id });
     }
   }
   return out.length > 0 ? out : null;
@@ -182,6 +195,8 @@ export function hasRenderableBody(
         return !!part.artifact;
       case "ask_user":
         return !!(part.ask || msg.askUser);
+      case "optional_feature_install":
+        return !!(part.request || msg.optionalFeatureInstall);
       case "error":
         return !!msg.errorInfo;
       default:
@@ -218,6 +233,12 @@ function mergeWithDerivedParts(explicit: MessagePart[], msg: ChatMessage): Messa
       return {
         ...part,
         ask: part.ask || (derivedPart.kind === "ask_user" ? derivedPart.ask : undefined),
+      };
+    }
+    if (part.kind === "optional_feature_install") {
+      return {
+        ...part,
+        request: part.request || (derivedPart.kind === "optional_feature_install" ? derivedPart.request : undefined),
       };
     }
     return part;

--- a/build/openakita.spec
+++ b/build/openakita.spec
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 from PyInstaller.building.datastruct import Tree
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, copy_metadata
 
 # Project root directory
 PROJECT_ROOT = Path(SPECPATH).parent
@@ -634,19 +634,11 @@ datas.append((_pip_dir, "pip"))
 # Already included in pip directory, no extra handling needed
 
 # Playwright driver (node.js executable + browser protocol implementation)
-# playwright._impl._driver 在运行时通过 subprocess 启动 node 进程，
-# 必须将 driver 目录打包，否则 "playwright install" 可以完成但运行时找不到 driver。
-try:
-    import playwright
-    _pw_pkg_dir = Path(playwright.__file__).parent
-    _pw_driver_dir = _pw_pkg_dir / "driver"
-    if _pw_driver_dir.exists():
-        datas.append((str(_pw_driver_dir), "playwright/driver"))
-        print(f"[spec] Bundling Playwright driver: {_pw_driver_dir}")
-    else:
-        print(f"[spec] WARNING: Playwright driver dir not found: {_pw_driver_dir}")
-except ImportError:
-    print("[spec] WARNING: playwright not installed, driver not bundled")
+# Playwright's Python API stays in core, while its platform-specific Node and
+# driver package are installed into the user runtime after explicit approval.
+# Keep only the small dist-info directory so the runtime can resolve the exact
+# Playwright version and select a matching optional driver artifact.
+datas += copy_metadata("playwright")
 
 # Chromium is intentionally not bundled. BrowserManager downloads the revision
 # matching this Playwright driver after user confirmation, or uses an installed Chrome.

--- a/scripts/prepare_optional_assets.py
+++ b/scripts/prepare_optional_assets.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Resolve optional feature artifacts for OSS mirroring.
+
+Providers are adapters that turn a repository catalog entry into immutable
+upstream URLs.  The output inventory is consumed by the release workflow,
+which checks OSS before downloading anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import tomllib
+from datetime import UTC, datetime
+from importlib.metadata import version
+from pathlib import Path
+from urllib.parse import urlparse
+
+_PLAYWRIGHT_HEADER = re.compile(r"^(.+?) \(playwright (.+?) v([^\)]+)\)$")
+_PLAYWRIGHT_URL = re.compile(r"^\s*Download (?:url|fallback \d+):\s+(https?://\S+)\s*$")
+
+
+def parse_playwright_dry_run(output: str) -> list[dict]:
+    artifacts: list[dict] = []
+    current: dict | None = None
+    for line in output.splitlines():
+        header = _PLAYWRIGHT_HEADER.match(line.strip())
+        if header:
+            current = {
+                "name": header.group(1),
+                "component": header.group(2),
+                "revision": header.group(3),
+                "sources": [],
+            }
+            continue
+        url_match = _PLAYWRIGHT_URL.match(line)
+        if url_match and current is not None:
+            current["sources"].append(url_match.group(1))
+            if len(current["sources"]) == 1:
+                artifacts.append(current)
+    return artifacts
+
+
+def _playwright_artifacts(feature: dict) -> tuple[str, list[dict]]:
+    from playwright._impl._driver import compute_driver_executable
+
+    node, cli = compute_driver_executable()
+    resolved: dict[str, dict] = {}
+    for platform_name in feature["platforms"]:
+        env = dict(os.environ)
+        env["PLAYWRIGHT_HOST_PLATFORM_OVERRIDE"] = platform_name
+        env.pop("PLAYWRIGHT_DOWNLOAD_HOST", None)
+        result = subprocess.run(
+            [str(node), str(cli), "install", "--dry-run", *feature["install_args"]],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
+        for artifact in parse_playwright_dry_run(result.stdout):
+            upstream_path = urlparse(artifact["sources"][0]).path
+            marker = "/builds/"
+            if marker not in upstream_path:
+                raise ValueError(f"Unsupported Playwright artifact URL: {upstream_path}")
+            relative_path = "builds/" + upstream_path.split(marker, 1)[1]
+            object_path = f"{feature['mirror_path'].strip('/')}/{relative_path}"
+            entry = resolved.setdefault(
+                object_path,
+                {
+                    **artifact,
+                    "object_path": object_path,
+                    "relative_path": relative_path,
+                    "platforms": [],
+                },
+            )
+            entry["platforms"].append(platform_name)
+            for source in artifact["sources"]:
+                if source not in entry["sources"]:
+                    entry["sources"].append(source)
+    return version("playwright"), list(resolved.values())
+
+
+def _python_wheel_artifacts(feature: dict, lock_path: Path) -> tuple[str, list[dict]]:
+    with open(lock_path, "rb") as lock_file:
+        lock = tomllib.load(lock_file)
+    package_name = feature["package"]
+    package = next(
+        (item for item in lock.get("package", []) if item.get("name") == package_name),
+        None,
+    )
+    if not isinstance(package, dict):
+        raise ValueError(f"Package {package_name!r} was not found in {lock_path}")
+    package_version = str(package["version"])
+    wheels = package.get("wheels") or []
+    artifacts: list[dict] = []
+    for platform_name, suffix in feature["platforms"].items():
+        wheel = next(
+            (
+                item
+                for item in wheels
+                if isinstance(item, dict) and str(item.get("url", "")).endswith(suffix)
+            ),
+            None,
+        )
+        if not isinstance(wheel, dict):
+            raise ValueError(f"No {package_name} wheel ending in {suffix!r}")
+        upstream_url = str(wheel["url"])
+        filename = upstream_url.rsplit("/", 1)[-1]
+        hash_value = str(wheel.get("hash") or "")
+        sha256 = hash_value.removeprefix("sha256:")
+        object_path = f"{feature['mirror_path'].strip('/')}/{package_version}/{filename}"
+        artifacts.append(
+            {
+                "name": filename,
+                "component": package_name,
+                "revision": package_version,
+                "object_path": object_path,
+                "relative_path": f"{package_version}/{filename}",
+                "platforms": [platform_name],
+                "platform": platform_name,
+                "sources": [upstream_url],
+                "upstream_url": upstream_url,
+                "sha256": sha256,
+                "size": int(wheel.get("size") or 0),
+            }
+        )
+    return package_version, artifacts
+
+
+def prepare(
+    catalog: dict,
+    cdn_base_url: str,
+    *,
+    lock_path: Path = Path("uv.lock"),
+    existing_manifest: dict | None = None,
+) -> tuple[dict, dict]:
+    inventory: list[dict] = []
+    public_features: dict[str, dict] = {}
+    for feature in catalog.get("features", []):
+        provider = feature.get("provider")
+        if provider == "playwright":
+            provider_version, artifacts = _playwright_artifacts(feature)
+        elif provider == "python_lock_wheel":
+            provider_version, artifacts = _python_wheel_artifacts(feature, lock_path)
+        else:
+            raise ValueError(f"Unsupported optional asset provider: {provider}")
+        inventory.extend({"feature_id": feature["id"], **item} for item in artifacts)
+        mirror_base = f"{cdn_base_url.rstrip('/')}/{feature['mirror_path'].strip('/')}"
+        public_feature = {
+            "provider": provider,
+            "provider_version": provider_version,
+            "strategy": feature["strategy"],
+            "mirror_base_url": mirror_base,
+            "platforms": feature["platforms"],
+            "artifacts": [
+                {
+                    "name": item["name"],
+                    "component": item["component"],
+                    "revision": item["revision"],
+                    "path": item["relative_path"],
+                    "platforms": item["platforms"],
+                }
+                for item in artifacts
+            ],
+        }
+        if provider == "python_lock_wheel":
+            previous_feature = (existing_manifest or {}).get("features", {}).get(feature["id"], {})
+            versions = dict(previous_feature.get("versions") or {})
+            versions[provider_version] = {
+                "artifacts": [
+                    {
+                        "name": item["name"],
+                        "platform": item["platform"],
+                        "size": item["size"],
+                        "sha256": item["sha256"],
+                        "path": item["object_path"],
+                        "mirror_url": f"{cdn_base_url.rstrip('/')}/{item['object_path']}",
+                        "upstream_url": item["upstream_url"],
+                    }
+                    for item in artifacts
+                ]
+            }
+            public_feature["versions"] = versions
+        public_features[feature["id"]] = public_feature
+    generated_at = datetime.now(UTC).isoformat()
+    return (
+        {"schema_version": 1, "generated_at": generated_at, "artifacts": inventory},
+        {"schema_version": 1, "generated_at": generated_at, "features": public_features},
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True)
+    parser.add_argument("--inventory", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--cdn-base-url", required=True)
+    parser.add_argument("--lock", default="uv.lock")
+    parser.add_argument("--existing-manifest", default="")
+    args = parser.parse_args()
+
+    catalog = json.loads(Path(args.catalog).read_text(encoding="utf-8"))
+    existing_manifest = None
+    if args.existing_manifest:
+        existing_manifest = json.loads(Path(args.existing_manifest).read_text(encoding="utf-8"))
+    inventory, manifest = prepare(
+        catalog,
+        args.cdn_base_url,
+        lock_path=Path(args.lock),
+        existing_manifest=existing_manifest,
+    )
+    for path, payload in ((args.inventory, inventory), (args.manifest, manifest)):
+        output = Path(path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    print(f"Resolved {len(inventory['artifacts'])} optional artifact(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pyinstaller_hooks/hook-playwright.async_api.py
+++ b/scripts/pyinstaller_hooks/hook-playwright.async_api.py
@@ -1,8 +1,8 @@
 """Keep Playwright browser binaries out of the frozen core package.
 
 The upstream hook collects every Playwright data file, including an optional
-``.local-browsers`` directory. The driver is added explicitly by openakita.spec;
-Chromium is installed into the managed user runtime only after user confirmation.
+``.local-browsers`` directory. Driver/Node and Chromium are installed into the
+managed user runtime only after user confirmation.
 """
 
 datas = []

--- a/scripts/pyinstaller_hooks/hook-playwright.sync_api.py
+++ b/scripts/pyinstaller_hooks/hook-playwright.sync_api.py
@@ -1,7 +1,7 @@
 """Keep Playwright browser binaries out of the frozen core package.
 
-See hook-playwright.async_api.py. BrowserManager uses the same explicitly
-bundled driver for both APIs.
+See hook-playwright.async_api.py. BrowserManager resolves the same managed
+optional driver for both APIs.
 """
 
 datas = []

--- a/src/openakita/api/message_parts.py
+++ b/src/openakita/api/message_parts.py
@@ -208,11 +208,7 @@ def build_message_parts(
         if progress_events is not None
         else normalize_progress_events(msg.get("progress_events"))
     )
-    plan = (
-        todo
-        if todo is not None
-        else project_progress_events_to_todo(events) or msg.get("todo")
-    )
+    plan = todo if todo is not None else project_progress_events_to_todo(events) or msg.get("todo")
     plan_todo = serialize_plan_to_chat_todo(plan) if isinstance(plan, dict) else plan
     if isinstance(plan_todo, dict) and plan_todo.get("steps"):
         part = {"kind": "plan", "id": f"plan:{plan_todo.get('id', '')}", "todo": plan_todo}
@@ -220,8 +216,18 @@ def build_message_parts(
             part["progressEvents"] = events
         parts.append(part)
 
+    optional_feature = msg.get("optional_feature_install")
+    if isinstance(optional_feature, dict):
+        parts.append(
+            {
+                "kind": "optional_feature_install",
+                "id": f"optional_feature_install:{optional_feature.get('request_id', '')}",
+                "request": optional_feature,
+            }
+        )
+
     content = msg.get("content")
-    if isinstance(content, str) and content.strip():
+    if not isinstance(optional_feature, dict) and isinstance(content, str) and content.strip():
         parts.append({"kind": "text", "id": "text"})
 
     artifacts = msg.get("artifacts")

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -1807,6 +1807,24 @@ async def _stream_chat(
                 _ask_user_question = event.get("question", "")
                 _ask_user_options = event.get("options", [])
                 _ask_user_questions = event.get("questions", [])
+            elif event_type == "optional_feature_install":
+                request_id = str(event.get("request_id") or "")
+                if session is not None and request_id:
+                    already_saved = any(
+                        isinstance(message.get("optional_feature_install"), dict)
+                        and message["optional_feature_install"].get("request_id") == request_id
+                        for message in session.context.messages
+                    )
+                    if not already_saved:
+                        session.add_message(
+                            "assistant",
+                            "浏览器自动化组件需要安装。",
+                            optional_feature_install={
+                                key: value for key, value in event.items() if key != "type"
+                            },
+                        )
+                        if session_manager is not None:
+                            session_manager.persist()
             elif event_type == "pending_approval":
                 _pending_approval = True
             elif event_type == "plan_ready_for_approval":

--- a/src/openakita/api/routes/optional_features.py
+++ b/src/openakita/api/routes/optional_features.py
@@ -1,0 +1,63 @@
+"""Install optional feature resources after direct user confirmation."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ...optional_features import (
+    get_install_request,
+    install_browser_automation,
+    update_install_request,
+)
+
+router = APIRouter(prefix="/api/optional-features")
+
+
+@router.get("/{request_id}")
+async def optional_feature_status(request_id: str):
+    request = get_install_request(request_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="optional feature request not found")
+    return request
+
+
+@router.post("/{request_id}/install")
+async def install_optional_feature(request: Request, request_id: str):
+    install_request = get_install_request(request_id)
+    if not install_request:
+        raise HTTPException(status_code=404, detail="optional feature request not found")
+    if install_request.get("status") == "cancelled":
+        raise HTTPException(status_code=409, detail="optional feature request was cancelled")
+    try:
+        result = await install_browser_automation(request_id)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    agent = getattr(request.app.state, "agent", None)
+    manager = getattr(agent, "browser_manager", None)
+    if manager is not None:
+        try:
+            await manager.start(
+                visible=bool(install_request.get("visible", True)),
+                install_chromium=False,
+            )
+        except Exception:
+            pass
+    return result
+
+
+@router.post("/{request_id}/cancel")
+async def cancel_optional_feature(request_id: str):
+    request = get_install_request(request_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="optional feature request not found")
+    if request.get("status") == "installing":
+        raise HTTPException(status_code=409, detail="installation is already running")
+    if request.get("status") == "installed":
+        return request
+    return update_install_request(
+        request_id,
+        status="cancelled",
+        message="用户已取消安装",
+        progress=0,
+    )

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -211,7 +211,9 @@ def _last_activity_ms(session, visible_msgs: list[dict]) -> int:
         return 0
 
 
-def _session_list_item(session, visible_msgs: list[dict] | None = None, last_ms: int | None = None) -> dict:
+def _session_list_item(
+    session, visible_msgs: list[dict] | None = None, last_ms: int | None = None
+) -> dict:
     """Serialize one session for conversation-list sync surfaces."""
     if visible_msgs is None:
         visible_msgs = [m for _, m in _visible_history_messages(session)]
@@ -460,6 +462,17 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     ask_user = msg.get("ask_user")
     if ask_user:
         entry["ask_user"] = ask_user
+    optional_feature_install = msg.get("optional_feature_install")
+    if isinstance(optional_feature_install, dict):
+        request_id = str(optional_feature_install.get("request_id") or "")
+        if request_id:
+            try:
+                from ...optional_features import get_install_request
+
+                current_request = get_install_request(request_id)
+            except Exception:
+                current_request = None
+            entry["optional_feature_install"] = current_request or optional_feature_install
     error_info = msg.get("error_info")
     if isinstance(error_info, dict):
         entry["error_info"] = error_info
@@ -498,8 +511,11 @@ def _history_entry(session, conversation_id: str, original_idx: int, msg: dict) 
     )
     if todo_norm and todo_norm.get("steps"):
         entry["todo"] = todo_norm
+    projected_message = {**msg, "content": content}
+    if "optional_feature_install" in entry:
+        projected_message["optional_feature_install"] = entry["optional_feature_install"]
     parts = build_message_parts(
-        {**msg, "content": content},
+        projected_message,
         todo=todo_norm,
         progress_events=progress_events,
     )
@@ -785,7 +801,9 @@ async def create_session(
         manually_set = bool(body.title_manually_set)
         session.set_metadata(_META_CONVERSATION_TITLE, title)
         session.set_metadata(_META_TITLE_MANUALLY_SET, manually_set)
-        session.set_metadata(_META_TITLE_GENERATED, False if manually_set else bool(body.title_generated))
+        session.set_metadata(
+            _META_TITLE_GENERATED, False if manually_set else bool(body.title_generated)
+        )
 
     if existing is None or body.pinned:
         session.set_metadata(_META_PINNED, bool(body.pinned))
@@ -1196,7 +1214,9 @@ def _resolve_file_tree_parent(root: Path, parent: str) -> tuple[Path, str]:
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Directory not found") from exc
     except (OSError, RuntimeError, ValueError) as exc:
-        raise HTTPException(status_code=403, detail="Parent must stay within working directory") from exc
+        raise HTTPException(
+            status_code=403, detail="Parent must stay within working directory"
+        ) from exc
     if not resolved.is_dir():
         raise HTTPException(status_code=422, detail="Parent is not a directory")
     normalized = resolved.relative_to(root).as_posix()

--- a/src/openakita/api/server.py
+++ b/src/openakita/api/server.py
@@ -50,6 +50,7 @@ from .routes import (
     mcp,
     memory,
     memory_repair,
+    optional_features,
     orgs_v2,
     orgs_v2_runtime,
     orgs_v2_stream,
@@ -1120,6 +1121,7 @@ def create_app(
     app.include_router(memory_repair.router, tags=["记忆修复"])
     app.include_router(scheduler.router, tags=["定时任务"])
     app.include_router(pending_approvals.router, tags=["待审批"])
+    app.include_router(optional_features.router, tags=["可选功能"])
     app.include_router(sessions.router, tags=["会话"])
     app.include_router(skills.router, tags=["技能"])
     app.include_router(skill_categories.router, tags=["技能分类"])

--- a/src/openakita/core/_reasoning_engine_legacy.py
+++ b/src/openakita/core/_reasoning_engine_legacy.py
@@ -3915,6 +3915,52 @@ class ReasoningEngine:
                                 result_text, _stream_hint = _unpack_tool_result(
                                     tool_exec_task.result()
                                 )
+                                from openakita.optional_features import (
+                                    create_install_request,
+                                    parse_optional_feature_marker,
+                                    wait_for_install_request,
+                                )
+
+                                _optional_request = parse_optional_feature_marker(result_text)
+                                if _optional_request is not None:
+                                    _install_request = create_install_request(
+                                        conversation_id,
+                                        visible=_optional_request.get("visible", True),
+                                    )
+                                    yield {
+                                        "type": "optional_feature_install",
+                                        **_install_request,
+                                    }
+                                    _install_result = await wait_for_install_request(
+                                        _install_request["request_id"]
+                                    )
+                                    if (
+                                        _install_result
+                                        and _install_result.get("status") == "installed"
+                                    ):
+                                        _retry_raw = (
+                                            await self._tool_executor.execute_tool_with_policy(
+                                                tool_name=tool_name,
+                                                tool_input=(
+                                                    tool_args if isinstance(tool_args, dict) else {}
+                                                ),
+                                                policy_result=_pr,
+                                                session_id=conversation_id,
+                                            )
+                                        )
+                                        result_text, _stream_hint = _unpack_tool_result(_retry_raw)
+                                    elif (
+                                        _install_result
+                                        and _install_result.get("status") == "failed"
+                                    ):
+                                        result_text = "浏览器自动化组件安装失败：" + str(
+                                            _install_result.get("message") or "未知错误"
+                                        )
+                                    else:
+                                        result_text = (
+                                            "浏览器自动化组件尚未安装。安装卡片已保留在会话中，"
+                                            "用户稍后仍可直接点击安装。"
+                                        )
                                 self._remember_readonly_tool_result(
                                     tool_name,
                                     tool_args,

--- a/src/openakita/optional_assets.py
+++ b/src/openakita/optional_assets.py
@@ -1,0 +1,106 @@
+"""Resolve accelerated download sources for optional OpenAkita features.
+
+The public manifest is deliberately declarative: it may select a mirror for a
+locally-known installer strategy, but it cannot supply commands for OpenAkita
+to execute.  New optional features can reuse this resolver while keeping their
+installation logic in the owning module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from dataclasses import dataclass
+from functools import lru_cache
+from urllib.parse import urljoin, urlparse
+
+DEFAULT_OPTIONAL_ASSET_MANIFEST = "https://dl-openakita.fzstack.com/api/optional-assets.json"
+_MANIFEST_TIMEOUT_SECONDS = 5
+
+
+@dataclass(frozen=True)
+class OptionalAssetMirror:
+    feature_id: str
+    strategy: str
+    base_url: str
+
+
+def _valid_base_url(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip().rstrip("/")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return value
+
+
+@lru_cache(maxsize=4)
+def _fetch_manifest(url: str) -> dict:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "OpenAkita optional-assets"},
+    )
+    with urllib.request.urlopen(request, timeout=_MANIFEST_TIMEOUT_SECONDS) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("optional asset manifest must be a JSON object")
+    return payload
+
+
+def resolve_optional_asset_mirror(
+    feature_id: str,
+    *,
+    strategy: str,
+    mirror_path: str,
+) -> OptionalAssetMirror | None:
+    """Return the preferred mirror for a locally-known optional feature.
+
+    ``OPENAKITA_OPTIONAL_ASSET_MIRROR`` overrides the public manifest and is
+    interpreted as the root that contains ``mirror_path``.  The manifest URL
+    itself can be overridden with ``OPENAKITA_OPTIONAL_ASSET_MANIFEST``.
+    Resolution failures are intentionally non-fatal so callers can use their
+    upstream source.
+    """
+
+    override_root = _valid_base_url(os.environ.get("OPENAKITA_OPTIONAL_ASSET_MIRROR"))
+    if override_root:
+        base_url = urljoin(f"{override_root}/", mirror_path.strip("/"))
+        return OptionalAssetMirror(feature_id, strategy, base_url.rstrip("/"))
+
+    manifest_url = os.environ.get(
+        "OPENAKITA_OPTIONAL_ASSET_MANIFEST", DEFAULT_OPTIONAL_ASSET_MANIFEST
+    ).strip()
+    if not _valid_base_url(manifest_url):
+        return None
+    try:
+        manifest = _fetch_manifest(manifest_url)
+    except Exception:
+        return None
+
+    features = manifest.get("features")
+    feature = features.get(feature_id) if isinstance(features, dict) else None
+    if not isinstance(feature, dict) or feature.get("strategy") != strategy:
+        return None
+    base_url = _valid_base_url(feature.get("mirror_base_url"))
+    if not base_url:
+        return None
+    return OptionalAssetMirror(feature_id, strategy, base_url)
+
+
+def load_optional_asset_feature(feature_id: str) -> dict | None:
+    """Load one declarative feature entry from the optional asset manifest."""
+
+    manifest_url = os.environ.get(
+        "OPENAKITA_OPTIONAL_ASSET_MANIFEST", DEFAULT_OPTIONAL_ASSET_MANIFEST
+    ).strip()
+    if not _valid_base_url(manifest_url):
+        return None
+    try:
+        manifest = _fetch_manifest(manifest_url)
+    except Exception:
+        return None
+    features = manifest.get("features")
+    feature = features.get(feature_id) if isinstance(features, dict) else None
+    return dict(feature) if isinstance(feature, dict) else None

--- a/src/openakita/optional_features.py
+++ b/src/openakita/optional_features.py
@@ -1,0 +1,557 @@
+"""Durable optional-feature requests and browser runtime bootstrap."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import http.server
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import threading
+import urllib.request
+import uuid
+import zipfile
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from importlib.metadata import version as package_version
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from openakita.optional_assets import load_optional_asset_feature
+from openakita.utils.atomic_io import atomic_json_write, read_json_safe
+
+OPTIONAL_FEATURE_MARKER = "__OPENAKITA_OPTIONAL_FEATURE_INSTALL__"
+PLAYWRIGHT_RUNTIME_FEATURE = "browser.playwright-runtime"
+BROWSER_AUTOMATION_FEATURE = "browser.automation"
+_REQUEST_LOCK = threading.RLock()
+_REQUEST_EVENTS: dict[str, asyncio.Event] = {}
+_INSTALL_LOCKS: dict[str, asyncio.Lock] = {}
+_PLAYWRIGHT_HEADER = re.compile(r"^(.+?) \(playwright (.+?) v([^\)]+)\)$")
+_PLAYWRIGHT_URL = re.compile(r"^\s*Download (?:url|fallback \d+):\s+(https?://\S+)\s*$")
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def _openakita_root() -> Path:
+    configured = os.environ.get("OPENAKITA_ROOT", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".openakita"
+
+
+def _request_store_path() -> Path:
+    return _openakita_root() / "data" / "optional_feature_requests.json"
+
+
+def _load_requests() -> dict[str, dict]:
+    data = read_json_safe(_request_store_path()) or {}
+    requests = data.get("requests") if isinstance(data, dict) else None
+    return requests if isinstance(requests, dict) else {}
+
+
+def _save_requests(requests: dict[str, dict]) -> None:
+    atomic_json_write(
+        _request_store_path(),
+        {"schema_version": 1, "requests": requests},
+        backup=True,
+    )
+
+
+def create_install_request(conversation_id: str, *, visible: bool = True) -> dict:
+    request_id = uuid.uuid4().hex
+    now = datetime.now(UTC).isoformat()
+    request = {
+        "request_id": request_id,
+        "conversation_id": conversation_id,
+        "feature_id": BROWSER_AUTOMATION_FEATURE,
+        "title": "安装浏览器自动化组件",
+        "description": "包含 Playwright 运行时和 Chromium，安装后才能使用浏览器自动化。",
+        "components": [
+            {"id": PLAYWRIGHT_RUNTIME_FEATURE, "name": "Playwright driver + Node"},
+            {"id": "browser.chromium", "name": "Chromium + FFmpeg"},
+        ],
+        "estimated_download_mb": 450,
+        "estimated_disk_mb": 550,
+        "status": "pending",
+        "progress": 0,
+        "phase": "awaiting_confirmation",
+        "phase_progress": 0,
+        "downloaded_bytes": 0,
+        "total_bytes": 0,
+        "current_item": "",
+        "install_progress": 0,
+        "message": "等待用户确认",
+        "visible": bool(visible),
+        "created_at": now,
+        "updated_at": now,
+    }
+    with _REQUEST_LOCK:
+        requests = _load_requests()
+        requests[request_id] = request
+        _save_requests(requests)
+    _REQUEST_EVENTS.setdefault(request_id, asyncio.Event())
+    return dict(request)
+
+
+def get_install_request(request_id: str) -> dict | None:
+    with _REQUEST_LOCK:
+        request = _load_requests().get(request_id)
+    if not isinstance(request, dict):
+        return None
+    if request.get("status") == "installing":
+        active_lock = _INSTALL_LOCKS.get(request_id)
+        if active_lock is None or not active_lock.locked():
+            recovered = update_install_request(
+                request_id,
+                status="failed",
+                message="上次安装已中断，已下载内容会在重试时继续使用",
+            )
+            return recovered
+    return dict(request)
+
+
+def update_install_request(request_id: str, **changes: Any) -> dict | None:
+    with _REQUEST_LOCK:
+        requests = _load_requests()
+        request = requests.get(request_id)
+        if not isinstance(request, dict):
+            return None
+        request.update(changes)
+        request["updated_at"] = datetime.now(UTC).isoformat()
+        requests[request_id] = request
+        _save_requests(requests)
+    if request.get("status") in {"installed", "failed", "cancelled"}:
+        event = _REQUEST_EVENTS.get(request_id)
+        if event is not None:
+            event.set()
+    return dict(request)
+
+
+async def wait_for_install_request(request_id: str, timeout: float = 900) -> dict | None:
+    request = get_install_request(request_id)
+    if not request or request.get("status") in {"installed", "failed", "cancelled"}:
+        return request
+    event = _REQUEST_EVENTS.setdefault(request_id, asyncio.Event())
+    try:
+        await asyncio.wait_for(event.wait(), timeout=timeout)
+    except TimeoutError:
+        return get_install_request(request_id)
+    return get_install_request(request_id)
+
+
+def optional_feature_marker(*, visible: bool = True) -> str:
+    return OPTIONAL_FEATURE_MARKER + json.dumps({"visible": bool(visible)}, separators=(",", ":"))
+
+
+def parse_optional_feature_marker(value: object) -> dict | None:
+    if not isinstance(value, str) or OPTIONAL_FEATURE_MARKER not in value:
+        return None
+    raw = value.split(OPTIONAL_FEATURE_MARKER, 1)[1].strip()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _playwright_version() -> str:
+    return package_version("playwright")
+
+
+def _managed_driver_dir() -> Path:
+    return _openakita_root() / "modules" / "browser" / "playwright-driver" / _playwright_version()
+
+
+def _driver_paths(root: Path) -> tuple[Path, Path]:
+    node = root / ("node.exe" if os.name == "nt" else "node")
+    return node, root / "package" / "cli.js"
+
+
+def resolve_playwright_driver() -> tuple[str, str] | None:
+    import inspect
+
+    import playwright
+
+    bundled = Path(inspect.getfile(playwright)).parent / "driver"
+    for root in (bundled, _managed_driver_dir()):
+        node, cli = _driver_paths(root)
+        if node.is_file() and cli.is_file():
+            return str(node), str(cli)
+    return None
+
+
+def configure_playwright_driver() -> tuple[str, str] | None:
+    resolved = resolve_playwright_driver()
+    if resolved is None:
+        return None
+
+    from playwright._impl import _driver, _transport
+
+    def compute() -> tuple[str, str]:
+        return resolved
+
+    _driver.compute_driver_executable = compute
+    _transport.compute_driver_executable = compute
+    return resolved
+
+
+def _runtime_platform() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    arm = machine in {"arm64", "aarch64"}
+    if system == "Windows":
+        return "windows-arm64" if arm else "windows-x64"
+    if system == "Darwin":
+        return "macos-arm64" if arm else "macos-x64"
+    if system == "Linux":
+        return "linux-arm64" if arm else "linux-x64"
+    raise RuntimeError(f"Unsupported Playwright runtime platform: {system} {machine}")
+
+
+def _select_driver_artifact() -> dict:
+    feature = load_optional_asset_feature(PLAYWRIGHT_RUNTIME_FEATURE)
+    if not feature:
+        raise RuntimeError("Playwright runtime manifest is unavailable")
+    versions = feature.get("versions")
+    release = versions.get(_playwright_version()) if isinstance(versions, dict) else None
+    if not isinstance(release, dict):
+        raise RuntimeError(f"No mirrored Playwright runtime for version {_playwright_version()}")
+    target = _runtime_platform()
+    for artifact in release.get("artifacts", []):
+        if isinstance(artifact, dict) and artifact.get("platform") == target:
+            selected = dict(artifact)
+            mirror_root = os.environ.get("OPENAKITA_OPTIONAL_ASSET_MIRROR", "").strip()
+            mirror_path = str(selected.get("path") or "").lstrip("/")
+            if mirror_root and mirror_path:
+                selected["mirror_url"] = urljoin(f"{mirror_root.rstrip('/')}/", mirror_path)
+            return selected
+    raise RuntimeError(f"No Playwright runtime artifact for {target}")
+
+
+def _optional_asset_cache() -> Path:
+    return _openakita_root() / "cache" / "optional-assets"
+
+
+def _response_total(response: Any, offset: int) -> int:
+    content_range = response.headers.get("Content-Range", "")
+    if "/" in content_range:
+        try:
+            return int(content_range.rsplit("/", 1)[1])
+        except ValueError:
+            pass
+    try:
+        return offset + int(response.headers.get("Content-Length") or 0)
+    except ValueError:
+        return 0
+
+
+def _download_resumable(
+    sources: list[str],
+    destination: Path,
+    *,
+    expected_hash: str = "",
+    expected_size: int = 0,
+    progress: Any | None = None,
+) -> Path:
+    """Download into a persistent .part file and resume with HTTP Range."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_name(destination.name + ".part")
+    if destination.is_file():
+        if expected_hash and hashlib.sha256(destination.read_bytes()).hexdigest() != expected_hash:
+            destination.unlink()
+        elif not expected_size or destination.stat().st_size == expected_size:
+            if progress:
+                progress(destination.stat().st_size, expected_size or destination.stat().st_size)
+            return destination
+
+    last_error: Exception | None = None
+    for url in sources:
+        if not url:
+            continue
+        offset = partial.stat().st_size if partial.exists() else 0
+        headers = {"User-Agent": "OpenAkita optional-feature"}
+        if offset:
+            headers["Range"] = f"bytes={offset}-"
+        try:
+            request = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(request, timeout=60) as response:
+                resumed = offset > 0 and getattr(response, "status", None) == 206
+                if offset and not resumed:
+                    offset = 0
+                total = expected_size or _response_total(response, offset)
+                mode = "ab" if resumed else "wb"
+                downloaded = offset
+                if progress:
+                    progress(downloaded, total)
+                with open(partial, mode) as output:
+                    while chunk := response.read(_DOWNLOAD_CHUNK_SIZE):
+                        output.write(chunk)
+                        downloaded += len(chunk)
+                        if progress:
+                            progress(downloaded, total)
+            if expected_size and partial.stat().st_size != expected_size:
+                raise RuntimeError(
+                    f"download size mismatch: expected {expected_size}, got {partial.stat().st_size}"
+                )
+            if expected_hash:
+                digest = hashlib.sha256(partial.read_bytes()).hexdigest()
+                if digest != expected_hash:
+                    partial.unlink(missing_ok=True)
+                    raise RuntimeError("download SHA-256 mismatch")
+            partial.replace(destination)
+            return destination
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"download failed: {last_error}")
+
+
+def install_playwright_runtime(progress: Any | None = None) -> Path:
+    existing = configure_playwright_driver()
+    if existing is not None:
+        return _managed_driver_dir()
+
+    artifact = _select_driver_artifact()
+    sources = [artifact.get("mirror_url"), artifact.get("upstream_url")]
+    expected_hash = str(artifact.get("sha256") or "").lower()
+    if not expected_hash:
+        raise RuntimeError("Playwright runtime artifact has no SHA-256")
+
+    target = _managed_driver_dir()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    archive = (
+        _optional_asset_cache()
+        / "playwright"
+        / _playwright_version()
+        / str(artifact.get("name") or "playwright.whl")
+    )
+    if progress:
+        progress(0, int(artifact.get("size") or 0), "Playwright driver + Node")
+    _download_resumable(
+        [str(source) for source in sources if source],
+        archive,
+        expected_hash=expected_hash,
+        expected_size=int(artifact.get("size") or 0),
+        progress=(
+            (lambda downloaded, total: progress(downloaded, total, "Playwright driver + Node"))
+            if progress
+            else None
+        ),
+    )
+    with tempfile.TemporaryDirectory(prefix="openakita-playwright-") as temp_name:
+        temp = Path(temp_name)
+        extracted = temp / "driver"
+        prefix = "playwright/driver/"
+        with zipfile.ZipFile(archive) as wheel:
+            members = [name for name in wheel.namelist() if name.startswith(prefix)]
+            if not members:
+                raise RuntimeError("Playwright wheel does not contain driver files")
+            for name in members:
+                relative = name[len(prefix) :]
+                if not relative or relative.endswith("/"):
+                    continue
+                relative_path = Path(relative)
+                if relative_path.is_absolute() or ".." in relative_path.parts:
+                    raise RuntimeError("Playwright wheel contains an unsafe driver path")
+                output = extracted / relative_path
+                output.parent.mkdir(parents=True, exist_ok=True)
+                with wheel.open(name) as source, open(output, "wb") as destination:
+                    shutil.copyfileobj(source, destination)
+
+        node, cli = _driver_paths(extracted)
+        if not node.is_file() or not cli.is_file():
+            raise RuntimeError("Extracted Playwright driver is incomplete")
+        if os.name != "nt":
+            node.chmod(node.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        if target.exists():
+            shutil.rmtree(target)
+        extracted.replace(target)
+    configure_playwright_driver()
+    return target
+
+
+def _discover_chromium_downloads() -> list[dict]:
+    resolved = configure_playwright_driver()
+    if resolved is None:
+        raise RuntimeError("Playwright driver runtime is not installed")
+    node, cli = resolved
+    env = dict(os.environ)
+    env.pop("PLAYWRIGHT_DOWNLOAD_HOST", None)
+    result = subprocess.run(
+        [str(node), str(cli), "install", "--dry-run", "--no-shell", "chromium"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+    artifacts: list[dict] = []
+    current: dict | None = None
+    for line in result.stdout.splitlines():
+        header = _PLAYWRIGHT_HEADER.match(line.strip())
+        if header:
+            current = {"name": header.group(1), "sources": []}
+            continue
+        match = _PLAYWRIGHT_URL.match(line)
+        if not match or current is None:
+            continue
+        url = match.group(1)
+        current["sources"].append(url)
+        if len(current["sources"]) == 1:
+            path = urlparse(url).path
+            marker = "/builds/"
+            if marker not in path:
+                raise RuntimeError(f"Unsupported Playwright download URL: {url}")
+            current["path"] = "builds/" + path.split(marker, 1)[1]
+            artifacts.append(current)
+    if not artifacts:
+        raise RuntimeError("Playwright did not report Chromium download artifacts")
+    return artifacts
+
+
+def cache_chromium_downloads(progress: Any | None = None) -> Path:
+    from openakita.optional_assets import resolve_optional_asset_mirror
+
+    artifacts = _discover_chromium_downloads()
+    mirror = resolve_optional_asset_mirror(
+        "browser.chromium",
+        strategy="playwright_download_host",
+        mirror_path="optional/playwright",
+    )
+    cache_root = _optional_asset_cache() / "playwright"
+    for index, artifact in enumerate(artifacts):
+        sources = list(artifact["sources"])
+        if mirror is not None:
+            sources.insert(0, urljoin(f"{mirror.base_url}/", artifact["path"]))
+
+        def report(
+            downloaded: int,
+            total: int,
+            *,
+            _index: int = index,
+            _name: str = str(artifact["name"]),
+        ) -> None:
+            if progress:
+                progress(downloaded, total, _name, _index, len(artifacts))
+
+        _download_resumable(
+            sources,
+            cache_root / artifact["path"],
+            progress=report,
+        )
+    return cache_root
+
+
+class _QuietFileHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+@contextmanager
+def serve_optional_asset_cache(root: Path):
+    def handler(*args: Any, **kwargs: Any):
+        return _QuietFileHandler(*args, directory=str(root), **kwargs)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+async def install_browser_automation(request_id: str) -> dict:
+    lock = _INSTALL_LOCKS.setdefault(request_id, asyncio.Lock())
+    async with lock:
+        request = get_install_request(request_id)
+        if not request:
+            raise KeyError(request_id)
+        if request.get("status") == "installed":
+            return request
+
+        def download_progress(
+            downloaded: int,
+            total: int,
+            item: str,
+            index: int = 0,
+            count: int = 1,
+        ) -> None:
+            item_progress = int(downloaded * 100 / total) if total else 0
+            update_install_request(
+                request_id,
+                phase="downloading",
+                phase_progress=item_progress,
+                progress=min(80, 5 + int(((index + item_progress / 100) / count) * 75)),
+                downloaded_bytes=downloaded,
+                total_bytes=total,
+                current_item=item,
+                message=f"正在下载 {item}（{index + 1}/{count}）",
+            )
+
+        update_install_request(
+            request_id,
+            status="installing",
+            progress=1,
+            phase="downloading",
+            phase_progress=0,
+            install_progress=0,
+            message="准备下载",
+        )
+        try:
+            await asyncio.to_thread(install_playwright_runtime, download_progress)
+            from openakita.tools.browser.manager import (
+                _download_managed_chromium,
+                _managed_browsers_dir,
+            )
+
+            cache_root = await asyncio.to_thread(cache_chromium_downloads, download_progress)
+            update_install_request(
+                request_id,
+                phase="installing",
+                phase_progress=100,
+                install_progress=15,
+                progress=82,
+                current_item="Chromium",
+                message="正在安装 Chromium",
+            )
+            with serve_optional_asset_cache(cache_root) as local_host:
+                await _download_managed_chromium(
+                    _managed_browsers_dir(),
+                    download_host=local_host,
+                    progress=lambda value, message: update_install_request(
+                        request_id,
+                        install_progress=value,
+                        progress=82 + int(value * 0.14),
+                        message=message,
+                    ),
+                )
+            update_install_request(
+                request_id,
+                install_progress=90,
+                progress=96,
+                message="正在验证浏览器组件",
+            )
+            return (
+                update_install_request(
+                    request_id,
+                    status="installed",
+                    progress=100,
+                    phase="complete",
+                    phase_progress=100,
+                    install_progress=100,
+                    message="浏览器自动化组件安装完成",
+                )
+                or {}
+            )
+        except Exception as exc:
+            update_install_request(request_id, status="failed", message=str(exc), progress=0)
+            raise

--- a/src/openakita/tools/browser/manager.py
+++ b/src/openakita/tools/browser/manager.py
@@ -16,6 +16,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from openakita.optional_assets import resolve_optional_asset_mirror
+
 logger = logging.getLogger(__name__)
 
 _IS_MAC = platform.system() == "Darwin"
@@ -160,51 +162,81 @@ def _has_managed_chromium(browsers_dir: Path) -> bool:
     return any(path.is_dir() for path in browsers_dir.glob("chromium-*"))
 
 
-async def _download_managed_chromium(browsers_dir: Path) -> None:
+async def _download_managed_chromium(
+    browsers_dir: Path,
+    *,
+    download_host: str | None = None,
+    progress: Any | None = None,
+) -> None:
     """Download the Chromium revision matching the bundled Playwright driver."""
-    from playwright._impl._driver import compute_driver_executable
+    from openakita.optional_features import configure_playwright_driver
 
-    node, cli = compute_driver_executable()
+    resolved_driver = configure_playwright_driver()
+    if resolved_driver is None:
+        raise RuntimeError("Playwright driver runtime is not installed")
+    node, cli = resolved_driver
     browsers_dir.mkdir(parents=True, exist_ok=True)
-    env = dict(os.environ)
-    env["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_dir)
-
     kwargs: dict[str, Any] = {}
     if platform.system() == "Windows":
         kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
-    logger.info("[Browser] Downloading Chromium after explicit user confirmation")
-    process = await asyncio.create_subprocess_exec(
-        str(node),
-        str(cli),
-        "install",
-        "--no-shell",
-        "chromium",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-        env=env,
-        **kwargs,
-    )
-    try:
-        output, _ = await asyncio.wait_for(
-            process.communicate(),
-            timeout=_CHROMIUM_INSTALL_TIMEOUT,
+    async def run_installer(download_host: str | None) -> tuple[int, str]:
+        if progress:
+            progress(25, "正在准备 Chromium 文件")
+        env = dict(os.environ)
+        env["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_dir)
+        if download_host:
+            env["PLAYWRIGHT_DOWNLOAD_HOST"] = download_host
+        else:
+            env.pop("PLAYWRIGHT_DOWNLOAD_HOST", None)
+        process = await asyncio.create_subprocess_exec(
+            str(node),
+            str(cli),
+            "install",
+            "--no-shell",
+            "chromium",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=env,
+            **kwargs,
         )
-    except asyncio.CancelledError:
-        process.kill()
-        await process.communicate()
-        raise
-    except TimeoutError as exc:
-        process.kill()
-        await process.communicate()
-        raise RuntimeError("Chromium download timed out after 15 minutes") from exc
+        try:
+            output, _ = await asyncio.wait_for(
+                process.communicate(), timeout=_CHROMIUM_INSTALL_TIMEOUT
+            )
+        except asyncio.CancelledError:
+            process.kill()
+            await process.communicate()
+            raise
+        except TimeoutError as exc:
+            process.kill()
+            await process.communicate()
+            raise RuntimeError("Chromium download timed out after 15 minutes") from exc
+        details = output.decode("utf-8", errors="replace").strip()
+        for line in details.splitlines():
+            logger.info("[Browser install] %s", line)
+        if process.returncode == 0 and progress:
+            progress(85, "Chromium 文件已解压")
+        return process.returncode or 0, details
 
-    details = output.decode("utf-8", errors="replace").strip()
-    for line in details.splitlines():
-        logger.info("[Browser install] %s", line)
-    if process.returncode != 0:
+    configured_host = download_host or os.environ.get("PLAYWRIGHT_DOWNLOAD_HOST", "").strip()
+    mirror = None
+    if not configured_host:
+        mirror = await asyncio.to_thread(
+            resolve_optional_asset_mirror,
+            "browser.chromium",
+            strategy="playwright_download_host",
+            mirror_path="optional/playwright",
+        )
+    preferred_host = configured_host or (mirror.base_url if mirror else None)
+    logger.info("[Browser] Downloading Chromium after explicit user confirmation")
+    returncode, details = await run_installer(preferred_host)
+    if returncode != 0 and mirror is not None and not configured_host:
+        logger.warning("[Browser] Optional asset mirror failed; retrying Playwright upstream")
+        returncode, details = await run_installer(None)
+    if returncode != 0:
         tail = details[-2000:] if details else "no installer output"
-        raise RuntimeError(f"Chromium download failed (exit {process.returncode}): {tail}")
+        raise RuntimeError(f"Chromium download failed (exit {returncode}): {tail}")
     if not _has_managed_chromium(browsers_dir):
         raise RuntimeError(
             f"Chromium installer succeeded but no runtime was found in {browsers_dir}"
@@ -418,6 +450,7 @@ class BrowserManager:
         self._chromium_install_error: str | None = None
         self._chromium_install_allowed = False
         self.chromium_install_required = False
+        self.optional_feature_install_required = False
         self._startup_lock = asyncio.Lock()
         self._is_server = _is_server_environment()
 
@@ -506,6 +539,7 @@ class BrowserManager:
             self._chromium_install_error = None
             self._chromium_install_allowed = install_chromium
             self.chromium_install_required = False
+            self.optional_feature_install_required = False
 
             headless = not visible
 
@@ -585,6 +619,13 @@ class BrowserManager:
 
     async def _start_playwright_driver(self) -> bool:
         """启动 Playwright driver 进程（最多重试 2 次），失败时返回 False。"""
+        from openakita.optional_features import configure_playwright_driver
+
+        if configure_playwright_driver() is None:
+            self.optional_feature_install_required = True
+            self.state = BrowserState.ERROR
+            self._startup_errors.append("Playwright driver runtime is not installed")
+            return False
         try:
             from playwright.async_api import async_playwright
         except ImportError:

--- a/src/openakita/tools/handlers/browser.py
+++ b/src/openakita/tools/handlers/browser.py
@@ -144,11 +144,11 @@ class BrowserHandler:
 
         result = await self._dispatch_with_lock(actual_tool_name, params)
 
-        if (
-            not result.get("success")
-            and getattr(self.agent.browser_manager, "chromium_install_required", False)
+        if not result.get("success") and (
+            getattr(self.agent.browser_manager, "chromium_install_required", False)
+            or getattr(self.agent.browser_manager, "optional_feature_install_required", False)
         ):
-            result = self._chromium_install_confirmation_result()
+            result = self._optional_feature_install_result()
 
         if actual_tool_name == "browser_get_content" and result.get("success"):
             output = self._format_get_content_result(result, params)
@@ -451,8 +451,10 @@ class BrowserHandler:
 
             return {"success": True, "result": result_data}
         else:
+            if getattr(manager, "optional_feature_install_required", False):
+                return self._optional_feature_install_result(visible=visible)
             if getattr(manager, "chromium_install_required", False):
-                return self._chromium_install_confirmation_result()
+                return self._optional_feature_install_result(visible=visible)
 
             hints: list[str] = []
             try:
@@ -509,17 +511,20 @@ class BrowserHandler:
             }
 
     @staticmethod
-    def _chromium_install_confirmation_result() -> dict:
+    def _optional_feature_install_result(*, visible: bool = True) -> dict:
+        from openakita.optional_features import optional_feature_marker
+
         return {
             "success": False,
             "result": {"is_open": False, "status": "install_confirmation_required"},
             "error": (
-                "未安装浏览器自动化所需的 Chromium（约 400 MB）。"
-                "本次不会自动下载。请先询问用户是否安装；只有用户明确确认后，"
-                "才能再次调用 "
-                'browser_open({"install_chromium": true})。'
+                "浏览器自动化可选组件尚未安装。系统已在会话中显示安装确认卡片，"
+                "请等待用户直接选择，不要调用 ask_user 重复询问。\n"
+                + optional_feature_marker(visible=visible)
             ),
         }
+
+    _chromium_install_confirmation_result = _optional_feature_install_result
 
     @staticmethod
     def _build_open_status_result(

--- a/tests/unit/test_browser_handler.py
+++ b/tests/unit/test_browser_handler.py
@@ -189,8 +189,8 @@ async def test_browser_open_reports_chromium_confirmation_requirement():
 
     result = await BrowserHandler(agent).handle("browser_open", {"visible": True})
 
-    assert "本次不会自动下载" in result
-    assert 'browser_open({"install_chromium": true})' in result
+    assert "会话中显示安装确认卡片" in result
+    assert "__OPENAKITA_OPTIONAL_FEATURE_INSTALL__" in result
 
 
 @pytest.mark.asyncio
@@ -245,8 +245,8 @@ async def test_implicit_browser_start_also_requests_install_confirmation():
         {"url": "https://example.com"},
     )
 
-    assert "本次不会自动下载" in result
-    assert 'browser_open({"install_chromium": true})' in result
+    assert "会话中显示安装确认卡片" in result
+    assert "__OPENAKITA_OPTIONAL_FEATURE_INSTALL__" in result
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_browser_runtime_install.py
+++ b/tests/unit/test_browser_runtime_install.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from openakita.optional_assets import OptionalAssetMirror
 from openakita.tools.browser import manager
 
 
@@ -44,10 +45,11 @@ async def test_download_managed_chromium_uses_bundled_driver_cli(
         return _InstallProcess(browsers_dir)
 
     monkeypatch.setattr(
-        "playwright._impl._driver.compute_driver_executable",
+        "openakita.optional_features.configure_playwright_driver",
         lambda: (tmp_path / "node", tmp_path / "cli.js"),
     )
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+    monkeypatch.setattr(manager, "resolve_optional_asset_mirror", lambda *args, **kwargs: None)
 
     await manager._download_managed_chromium(browsers_dir)
 
@@ -64,7 +66,7 @@ async def test_download_managed_chromium_reports_installer_failure(
     browsers_dir = tmp_path / "browsers"
 
     monkeypatch.setattr(
-        "playwright._impl._driver.compute_driver_executable",
+        "openakita.optional_features.configure_playwright_driver",
         lambda: (tmp_path / "node", tmp_path / "cli.js"),
     )
     monkeypatch.setattr(
@@ -72,9 +74,53 @@ async def test_download_managed_chromium_reports_installer_failure(
         "create_subprocess_exec",
         lambda *args, **kwargs: _async_value(_InstallProcess(browsers_dir, returncode=1)),
     )
+    monkeypatch.setattr(manager, "resolve_optional_asset_mirror", lambda *args, **kwargs: None)
 
     with pytest.raises(RuntimeError, match="Chromium download failed"):
         await manager._download_managed_chromium(browsers_dir)
+
+
+@pytest.mark.asyncio
+async def test_download_managed_chromium_prefers_mirror_then_falls_back(
+    tmp_path: Path, monkeypatch
+) -> None:
+    browsers_dir = tmp_path / "browsers"
+    calls = []
+    processes = iter(
+        (
+            _InstallProcess(browsers_dir, returncode=1),
+            _InstallProcess(browsers_dir, returncode=0),
+        )
+    )
+
+    async def fake_subprocess(*args, **kwargs):
+        calls.append((args, kwargs))
+        return next(processes)
+
+    monkeypatch.setattr(
+        "playwright._impl._driver.compute_driver_executable",
+        lambda: (tmp_path / "node", tmp_path / "cli.js"),
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+    monkeypatch.setattr(
+        manager,
+        "resolve_optional_asset_mirror",
+        lambda *args, **kwargs: OptionalAssetMirror(
+            "browser.chromium",
+            "playwright_download_host",
+            "https://mirror.example/optional/playwright",
+        ),
+    )
+    monkeypatch.delenv("PLAYWRIGHT_DOWNLOAD_HOST", raising=False)
+
+    await manager._download_managed_chromium(browsers_dir)
+
+    assert len(calls) == 2
+    assert (
+        calls[0][1]["env"]["PLAYWRIGHT_DOWNLOAD_HOST"]
+        == "https://mirror.example/optional/playwright"
+    )
+    assert "PLAYWRIGHT_DOWNLOAD_HOST" not in calls[1][1]["env"]
 
 
 async def _async_value(value):
@@ -140,12 +186,14 @@ async def test_missing_chromium_requires_confirmation_without_downloading(
     download.assert_not_awaited()
 
 
-def test_packaging_excludes_chromium_but_keeps_playwright_driver() -> None:
+def test_packaging_excludes_chromium_and_playwright_driver() -> None:
     root = Path(__file__).parents[2]
     spec = (root / "build" / "openakita.spec").read_text(encoding="utf-8")
     backend = (root / "build" / "build_backend.py").read_text(encoding="utf-8")
 
-    assert 'datas.append((str(_pw_driver_dir), "playwright/driver"))' in spec
+    assert "_pw_driver_dir" not in spec
+    assert '"playwright/driver"' not in spec
+    assert 'copy_metadata("playwright")' in spec
     assert "_pw_browser_dir" not in spec
     assert "Bundling Playwright Chromium" not in spec
     assert '".local-browsers" not in entry[0]' in spec

--- a/tests/unit/test_optional_assets.py
+++ b/tests/unit/test_optional_assets.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openakita import optional_assets
+from scripts.prepare_optional_assets import _python_wheel_artifacts, parse_playwright_dry_run
+
+
+def test_optional_asset_mirror_override_joins_feature_path(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAKITA_OPTIONAL_ASSET_MIRROR", "https://mirror.example/root/")
+
+    mirror = optional_assets.resolve_optional_asset_mirror(
+        "browser.chromium",
+        strategy="playwright_download_host",
+        mirror_path="optional/playwright",
+    )
+
+    assert mirror is not None
+    assert mirror.base_url == "https://mirror.example/root/optional/playwright"
+
+
+def test_optional_asset_mirror_uses_matching_manifest_entry(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAKITA_OPTIONAL_ASSET_MIRROR", raising=False)
+    monkeypatch.setenv("OPENAKITA_OPTIONAL_ASSET_MANIFEST", "https://assets.example/api.json")
+    monkeypatch.setattr(
+        optional_assets,
+        "_fetch_manifest",
+        lambda url: {
+            "features": {
+                "browser.chromium": {
+                    "strategy": "playwright_download_host",
+                    "mirror_base_url": "https://cdn.example/optional/playwright/",
+                }
+            }
+        },
+    )
+
+    mirror = optional_assets.resolve_optional_asset_mirror(
+        "browser.chromium",
+        strategy="playwright_download_host",
+        mirror_path="unused",
+    )
+
+    assert mirror is not None
+    assert mirror.base_url == "https://cdn.example/optional/playwright"
+
+
+def test_parse_playwright_dry_run_collects_primary_and_fallback_urls() -> None:
+    output = """Chrome for Testing 148.0 (playwright chromium v1223)
+  Install location: /tmp/chromium-1223
+  Download url:        https://cdn.playwright.dev/builds/cft/148.0/linux64/chrome.zip
+
+FFmpeg (playwright ffmpeg v1011)
+  Install location: /tmp/ffmpeg-1011
+  Download url:        https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+  Download fallback 1: https://playwright.download.prss.microsoft.com/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+
+Winldd (playwright winldd v1007)
+  Install location: /tmp/winldd-1007
+"""
+
+    artifacts = parse_playwright_dry_run(output)
+
+    assert [item["component"] for item in artifacts] == ["chromium", "ffmpeg"]
+    assert len(artifacts[1]["sources"]) == 2
+    assert artifacts[1]["revision"] == "1011"
+
+
+def test_python_wheel_provider_resolves_all_configured_platforms() -> None:
+    feature = {
+        "package": "playwright",
+        "mirror_path": "optional/python/playwright",
+        "platforms": {
+            "windows-x64": "win_amd64.whl",
+            "macos-arm64": "macosx_11_0_arm64.whl",
+            "linux-arm64": "manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+        },
+    }
+
+    provider_version, artifacts = _python_wheel_artifacts(
+        feature, Path(__file__).parents[2] / "uv.lock"
+    )
+
+    assert provider_version == "1.60.0"
+    assert {item["platform"] for item in artifacts} == set(feature["platforms"])
+    assert all(len(item["sha256"]) == 64 for item in artifacts)

--- a/tests/unit/test_optional_features.py
+++ b/tests/unit/test_optional_features.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import io
+import os
 import shutil
 import zipfile
 from pathlib import Path
@@ -95,8 +96,9 @@ async def test_install_request_completion_wakes_waiter(tmp_path: Path, monkeypat
 
 def test_playwright_runtime_extracts_only_driver(tmp_path: Path, monkeypatch) -> None:
     wheel = tmp_path / "playwright.whl"
+    node_name = "node.exe" if os.name == "nt" else "node"
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("playwright/driver/node.exe", b"node")
+        archive.writestr(f"playwright/driver/{node_name}", b"node")
         archive.writestr("playwright/driver/package/cli.js", b"cli")
         archive.writestr("playwright/async_api/__init__.py", b"ignored")
     digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
@@ -122,15 +124,16 @@ def test_playwright_runtime_extracts_only_driver(tmp_path: Path, monkeypatch) ->
 
     optional_features.install_playwright_runtime()
 
-    assert (managed / "node.exe").read_bytes() == b"node"
+    assert (managed / node_name).read_bytes() == b"node"
     assert (managed / "package" / "cli.js").read_bytes() == b"cli"
     assert not (managed / "async_api").exists()
 
 
 def test_playwright_runtime_rejects_unsafe_driver_path(tmp_path: Path, monkeypatch) -> None:
     wheel = tmp_path / "playwright.whl"
+    node_name = "node.exe" if os.name == "nt" else "node"
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("playwright/driver/node.exe", b"node")
+        archive.writestr(f"playwright/driver/{node_name}", b"node")
         archive.writestr("playwright/driver/package/cli.js", b"cli")
         archive.writestr("playwright/driver/../../outside.txt", b"unsafe")
     digest = hashlib.sha256(wheel.read_bytes()).hexdigest()

--- a/tests/unit/test_optional_features.py
+++ b/tests/unit/test_optional_features.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from openakita import optional_features
+from openakita.api.message_parts import build_message_parts
+
+
+class _DownloadResponse(io.BytesIO):
+    def __init__(self, value: bytes, *, status: int, headers: dict[str, str]) -> None:
+        super().__init__(value)
+        self.status = status
+        self.headers = headers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def test_resumable_download_appends_to_persistent_partial(tmp_path: Path, monkeypatch) -> None:
+    destination = tmp_path / "asset.zip"
+    partial = tmp_path / "asset.zip.part"
+    partial.write_bytes(b"first-")
+    seen_headers: dict[str, str] = {}
+
+    def urlopen(request, timeout):
+        seen_headers.update(dict(request.headers))
+        return _DownloadResponse(
+            b"second",
+            status=206,
+            headers={"Content-Range": "bytes 6-11/12", "Content-Length": "6"},
+        )
+
+    monkeypatch.setattr(optional_features.urllib.request, "urlopen", urlopen)
+
+    optional_features._download_resumable(
+        ["https://assets.example/asset.zip"], destination, expected_size=12
+    )
+
+    assert seen_headers["Range"] == "bytes=6-"
+    assert destination.read_bytes() == b"first-second"
+    assert not partial.exists()
+
+
+def test_install_request_survives_in_memory_reset(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OPENAKITA_ROOT", str(tmp_path))
+    optional_features._REQUEST_EVENTS.clear()
+
+    created = optional_features.create_install_request("conversation-1")
+    optional_features._REQUEST_EVENTS.clear()
+    restored = optional_features.get_install_request(created["request_id"])
+
+    assert restored is not None
+    assert restored["conversation_id"] == "conversation-1"
+    assert restored["status"] == "pending"
+
+
+def test_interrupted_install_becomes_retryable_after_restart(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OPENAKITA_ROOT", str(tmp_path))
+    optional_features._REQUEST_EVENTS.clear()
+    optional_features._INSTALL_LOCKS.clear()
+    created = optional_features.create_install_request("conversation-restart")
+    optional_features.update_install_request(created["request_id"], status="installing")
+
+    restored = optional_features.get_install_request(created["request_id"])
+
+    assert restored is not None
+    assert restored["status"] == "failed"
+    assert "重试" in restored["message"]
+
+
+@pytest.mark.asyncio
+async def test_install_request_completion_wakes_waiter(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OPENAKITA_ROOT", str(tmp_path))
+    optional_features._REQUEST_EVENTS.clear()
+    created = optional_features.create_install_request("conversation-2")
+
+    waiter = asyncio.create_task(
+        optional_features.wait_for_install_request(created["request_id"], timeout=2)
+    )
+    await asyncio.sleep(0)
+    optional_features.update_install_request(created["request_id"], status="installed")
+
+    assert (await waiter)["status"] == "installed"
+
+
+def test_playwright_runtime_extracts_only_driver(tmp_path: Path, monkeypatch) -> None:
+    wheel = tmp_path / "playwright.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("playwright/driver/node.exe", b"node")
+        archive.writestr("playwright/driver/package/cli.js", b"cli")
+        archive.writestr("playwright/async_api/__init__.py", b"ignored")
+    digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    managed = tmp_path / "managed-driver"
+
+    monkeypatch.setattr(optional_features, "configure_playwright_driver", lambda: None)
+    monkeypatch.setattr(optional_features, "_managed_driver_dir", lambda: managed)
+    monkeypatch.setattr(
+        optional_features,
+        "_select_driver_artifact",
+        lambda: {
+            "mirror_url": "https://mirror.example/playwright.whl",
+            "upstream_url": "https://upstream.example/playwright.whl",
+            "sha256": digest,
+        },
+    )
+
+    def download(sources, destination, **kwargs):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        return Path(shutil.copyfile(wheel, destination))
+
+    monkeypatch.setattr(optional_features, "_download_resumable", download)
+
+    optional_features.install_playwright_runtime()
+
+    assert (managed / "node.exe").read_bytes() == b"node"
+    assert (managed / "package" / "cli.js").read_bytes() == b"cli"
+    assert not (managed / "async_api").exists()
+
+
+def test_playwright_runtime_rejects_unsafe_driver_path(tmp_path: Path, monkeypatch) -> None:
+    wheel = tmp_path / "playwright.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("playwright/driver/node.exe", b"node")
+        archive.writestr("playwright/driver/package/cli.js", b"cli")
+        archive.writestr("playwright/driver/../../outside.txt", b"unsafe")
+    digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+
+    monkeypatch.setattr(optional_features, "configure_playwright_driver", lambda: None)
+    monkeypatch.setattr(optional_features, "_managed_driver_dir", lambda: tmp_path / "managed")
+    monkeypatch.setattr(
+        optional_features,
+        "_select_driver_artifact",
+        lambda: {"mirror_url": "https://mirror.example/playwright.whl", "sha256": digest},
+    )
+
+    def download(sources, destination, **kwargs):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        return Path(shutil.copyfile(wheel, destination))
+
+    monkeypatch.setattr(optional_features, "_download_resumable", download)
+
+    with pytest.raises(RuntimeError, match="unsafe driver path"):
+        optional_features.install_playwright_runtime()
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
+def test_optional_feature_message_part_is_persistable() -> None:
+    request = {
+        "request_id": "req-1",
+        "feature_id": "browser.automation",
+        "status": "pending",
+    }
+
+    parts = build_message_parts(
+        {
+            "role": "assistant",
+            "content": "fallback text",
+            "optional_feature_install": request,
+        }
+    )
+
+    assert parts == [
+        {
+            "kind": "optional_feature_install",
+            "id": "optional_feature_install:req-1",
+            "request": request,
+        }
+    ]

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -9,6 +9,7 @@ DRY_RUN = ROOT / ".github" / "workflows" / "release-dryrun.yml"
 MOBILE = ROOT / ".github" / "workflows" / "mobile.yml"
 PREPARE = ROOT / ".github" / "actions" / "desktop-build-prepare" / "action.yml"
 CI = ROOT / ".github" / "workflows" / "ci.yml"
+PUBLISH = ROOT / ".github" / "workflows" / "publish-release.yml"
 TAURI_CONFIG = ROOT / "apps" / "setup-center" / "src-tauri" / "tauri.conf.json"
 FULL_BUILD_SCRIPTS = (ROOT / "build" / "build_full.ps1", ROOT / "build" / "build_full.sh")
 
@@ -158,6 +159,24 @@ def test_pyinstaller_analysis_reports_are_uploaded() -> None:
         assert "xref-*.html" in source
 
 
+def test_publish_release_mirrors_optional_assets_before_publishing() -> None:
+    source = PUBLISH.read_text(encoding="utf-8")
+    mirror_step = source.index("Mirror optional feature assets to Aliyun OSS")
+    publish_step = source.index("- name: Publish release")
+
+    assert mirror_step < publish_step
+    assert "scripts/prepare_optional_assets.py" in source
+    assert "ossutil stat" in source
+    assert "optional-assets-inventory.json" in source
+    assert "api/optional-assets.json" in source
+    assert '"playwright==${PLAYWRIGHT_VERSION}"' in source
+    assert "sha256sum --check" in source
+    assert "--existing-manifest" in source
+
+    catalog = (ROOT / ".github" / "optional-assets.json").read_text(encoding="utf-8")
+    assert '"browser.playwright-runtime"' in catalog
+
+
 def test_changed_workflow_yaml_is_valid() -> None:
     paths = (
         RELEASE,
@@ -165,6 +184,7 @@ def test_changed_workflow_yaml_is_valid() -> None:
         DRY_RUN,
         ROOT / ".github" / "workflows" / "ci.yml",
         PREPARE,
+        PUBLISH,
     )
     for path in paths:
         assert yaml.safe_load(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- add a declarative optional-asset catalog and release workflow that mirrors missing Playwright runtime and Chromium artifacts to OSS before publishing
- remove Playwright driver and Node from the core desktop package, then install browser automation components only after direct user confirmation with OSS-first fallback
- persist installation cards and status in conversation history, with resumable downloads and separate download/install progress across desktop restarts

## Tests

- `uv run --no-sync pytest tests/unit/test_optional_features.py tests/unit/test_optional_assets.py tests/unit/test_browser_runtime_install.py tests/unit/test_browser_handler.py tests/unit/test_release_workflow_contract.py tests/unit/test_release_contract.py tests/api/test_server_app_wiring.py -q` (49 passed)
- `npx vitest run src/views/chat/utils/__tests__/messageParts.test.ts` (4 passed)
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `uv run --no-sync ruff check` on all changed Python files
