### PR TITLE
Fix draft release lookup by database ID

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -11,6 +11,10 @@ on:
         description: "Commit, branch, or tag to build."
         required: true
         type: string
+      release_id:
+        description: "Numeric GitHub Release ID to validate and receive mobile assets."
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -19,6 +23,10 @@ on:
         default: ""
       ref:
         description: "Commit, branch, or tag to build. Leave empty to use the tag or current ref."
+        required: false
+        default: ""
+      release_id:
+        description: "Numeric GitHub Release ID. Required when tag starts with v."
         required: false
         default: ""
 
@@ -45,6 +53,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Require release ID for release builds
+        if: startsWith(env.RELEASE_TAG, 'v') && inputs.release_id == ''
+        run: |
+          echo "A numeric release_id is required for release builds" >&2
+          exit 1
+
       - name: Verify immutable mobile assets and tag provenance
         if: startsWith(env.RELEASE_TAG, 'v')
         env:
@@ -54,10 +68,10 @@ jobs:
           --repo "${{ github.repository }}"
           --tag "${{ env.RELEASE_TAG }}"
           --expected-commit "$(git rev-parse HEAD)"
+          --release-id "${{ inputs.release_id }}"
           --asset-name "OpenAkita-${{ env.RELEASE_TAG }}-android.apk"
           --asset-name "OpenAkita-${{ env.RELEASE_TAG }}-ios.ipa"
           --require-release
-          --wait-seconds 180
 
   # ── Android APK ──
   android:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      release_id: ${{ steps.gh_release.outputs.id }}
+      release_id: ${{ steps.resolve_release.outputs.release_id }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -89,8 +89,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+          if release_id="$(gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" --json databaseId --jq .databaseId 2>/dev/null)"; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "release_id=${release_id}" >> "$GITHUB_OUTPUT"
             echo "Release ${{ env.RELEASE_TAG }} already exists and passed the empty-asset contract"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -106,6 +107,19 @@ jobs:
           draft: true
           generate_release_notes: true
 
+      - name: Resolve release ID
+        id: resolve_release
+        env:
+          CREATED_RELEASE_ID: ${{ steps.gh_release.outputs.id }}
+          EXISTING_RELEASE_ID: ${{ steps.check_release.outputs.release_id }}
+        run: |
+          release_id="${CREATED_RELEASE_ID:-${EXISTING_RELEASE_ID}}"
+          if ! [[ "$release_id" =~ ^[0-9]+$ ]]; then
+            echo "Unable to resolve numeric release ID for ${{ env.RELEASE_TAG }}" >&2
+            exit 1
+          fi
+          echo "release_id=${release_id}" >> "$GITHUB_OUTPUT"
+
   # Mobile must start after the draft exists; independent tag workflows can race in runner queues.
   mobile_release:
     needs: [create_release]
@@ -116,6 +130,7 @@ jobs:
     with:
       tag: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
       ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.ref != '' && inputs.ref) || (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag) || github.ref_name }}
+      release_id: ${{ needs.create_release.outputs.release_id }}
     secrets: inherit
 
   # ── Job 2a: Python 包发布 ──

--- a/scripts/release_contract.py
+++ b/scripts/release_contract.py
@@ -56,6 +56,7 @@ def check_release_contract(
     repo: str,
     tag: str,
     expected_commit: str,
+    release_id: int | None = None,
     asset_names: Sequence[str] = (),
     require_release: bool = False,
     wait_seconds: int = 0,
@@ -70,14 +71,26 @@ def check_release_contract(
             f"tag {tag!r} points to {tag_commit}, but the build checkout is {expected_commit}"
         )
 
-    encoded_tag = quote(tag, safe="")
-    deadline = time.monotonic() + max(0, wait_seconds)
     release: dict[str, Any] | None
-    while True:
-        release = fetch_json(f"repos/{repo}/releases/tags/{encoded_tag}", True)
-        if release is not None or not require_release or time.monotonic() >= deadline:
-            break
-        time.sleep(2)
+    if release_id is not None:
+        if release_id <= 0:
+            raise RuntimeError(f"release ID must be positive, got {release_id}")
+        release = fetch_json(f"repos/{repo}/releases/{release_id}", False)
+        if release is None:
+            raise RuntimeError(f"release ID {release_id} does not exist")
+        release_tag = str(release.get("tag_name") or "")
+        if release_tag != tag:
+            raise RuntimeError(
+                f"release ID {release_id} belongs to tag {release_tag!r}, expected {tag!r}"
+            )
+    else:
+        encoded_tag = quote(tag, safe="")
+        deadline = time.monotonic() + max(0, wait_seconds)
+        while True:
+            release = fetch_json(f"repos/{repo}/releases/tags/{encoded_tag}", True)
+            if release is not None or not require_release or time.monotonic() >= deadline:
+                break
+            time.sleep(2)
 
     if release is None:
         if require_release:
@@ -99,6 +112,7 @@ def main() -> int:
     parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
     parser.add_argument("--tag", required=True, help="Release tag to validate")
     parser.add_argument("--expected-commit", required=True, help="Full checkout commit SHA")
+    parser.add_argument("--release-id", type=int, help="Numeric GitHub Release ID")
     parser.add_argument(
         "--asset-name",
         action="append",
@@ -114,6 +128,7 @@ def main() -> int:
             repo=args.repo,
             tag=args.tag,
             expected_commit=args.expected_commit,
+            release_id=args.release_id,
             asset_names=args.asset_name,
             require_release=args.require_release,
             wait_seconds=args.wait_seconds,

--- a/tests/unit/test_release_contract.py
+++ b/tests/unit/test_release_contract.py
@@ -58,6 +58,59 @@ def test_release_contract_resolves_annotated_tag() -> None:
     )
 
 
+def test_release_contract_loads_draft_by_numeric_release_id() -> None:
+    commit = "a" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/123": {
+                "id": 123,
+                "tag_name": "v1.2.3",
+                "draft": True,
+                "assets": [],
+            },
+        }
+    )
+
+    check_release_contract(
+        repo="openakita/openakita",
+        tag="v1.2.3",
+        expected_commit=commit,
+        release_id=123,
+        require_release=True,
+        fetch_json=fetcher,
+    )
+
+
+def test_release_contract_rejects_release_id_for_another_tag() -> None:
+    commit = "a" * 40
+    fetcher = _Fetcher(
+        {
+            "repos/openakita/openakita/git/ref/tags/v1.2.3": {
+                "object": {"type": "commit", "sha": commit}
+            },
+            "repos/openakita/openakita/releases/123": {
+                "id": 123,
+                "tag_name": "v9.9.9",
+                "draft": True,
+                "assets": [],
+            },
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="belongs to tag"):
+        check_release_contract(
+            repo="openakita/openakita",
+            tag="v1.2.3",
+            expected_commit=commit,
+            release_id=123,
+            require_release=True,
+            fetch_json=fetcher,
+        )
+
+
 def test_release_contract_rejects_commit_mismatch() -> None:
     fetcher = _Fetcher(
         {

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -46,9 +46,29 @@ def test_mobile_release_waits_for_draft_creation_without_an_independent_tag_trig
     assert mobile_job["uses"] == "./.github/workflows/mobile.yml"
     assert mobile_job["secrets"] == "inherit"
     assert "github.event_name == 'push'" in mobile_job["if"]
+    assert mobile_job["with"]["release_id"] == "${{ needs.create_release.outputs.release_id }}"
+
+    create_release_job = release_workflow["jobs"]["create_release"]
+    assert create_release_job["outputs"]["release_id"] == (
+        "${{ steps.resolve_release.outputs.release_id }}"
+    )
 
     release_contract_job = mobile_workflow["jobs"]["release_contract"]
     assert release_contract_job["permissions"] == {"contents": "write"}
+    workflow_call_inputs = mobile_workflow["on"]["workflow_call"]["inputs"]
+    assert workflow_call_inputs["release_id"] == {
+        "description": ("Numeric GitHub Release ID to validate and receive mobile assets."),
+        "required": "true",
+        "type": "string",
+    }
+
+    release_contract_run = next(
+        step["run"]
+        for step in release_contract_job["steps"]
+        if step.get("name") == "Verify immutable mobile assets and tag provenance"
+    )
+    assert '--release-id "${{ inputs.release_id }}"' in release_contract_run
+    assert "--wait-seconds" not in release_contract_run
 
 
 def test_packaging_verifies_checkout_identity_and_chat_api() -> None:


### PR DESCRIPTION
## Summary

- Resolve draft releases by their numeric GitHub Release ID instead of the tag endpoint that excludes drafts.
- Pass the resolved release ID into mobile builds and validate that it belongs to the expected tag.

## Tests

- `uv run --no-sync pytest tests/unit/test_release_contract.py tests/unit/test_release_workflow_contract.py -q`
- `uv run --no-sync ruff check scripts/release_contract.py tests/unit/test_release_contract.py tests/unit/test_release_workflow_contract.py`
- `uv run --no-sync ruff format --check scripts/release_contract.py tests/unit/test_release_contract.py tests/unit/test_release_workflow_contract.py`
