### PR TITLE
reduce desktop installer file count by archiving lark_oapi

### DIFF
--- a/build/build_backend.py
+++ b/build/build_backend.py
@@ -136,6 +136,57 @@ def verify_bundled_python_contract(output_dir: Path) -> None:
     print(f"  [OK] Bundled Python pip check passed (pip {pip_ver})")
 
 
+def prune_loose_python_bytecode(output_dir: Path) -> tuple[int, int]:
+    """Remove runtime-generated caches from the final onedir artifact."""
+    removed_files = 0
+    removed_dirs = 0
+
+    cache_dirs = sorted(
+        (path for path in output_dir.rglob("__pycache__") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for cache_dir in cache_dirs:
+        removed_files += sum(1 for path in cache_dir.rglob("*") if path.is_file())
+        shutil.rmtree(cache_dir)
+        removed_dirs += 1
+
+    for pyc_file in output_dir.rglob("*.pyc"):
+        pyc_file.unlink()
+        removed_files += 1
+
+    return removed_files, removed_dirs
+
+
+def verify_python_archive_layout(output_dir: Path, work_dir: Path) -> None:
+    """Require lark_oapi in PYZ and reject loose bytecode in release output."""
+    internal_dir = output_dir / "_internal"
+    loose_lark = internal_dir / "lark_oapi"
+    if loose_lark.exists():
+        raise RuntimeError(f"lark_oapi must be stored in PYZ, found loose package: {loose_lark}")
+
+    loose_bytecode = next(output_dir.rglob("*.pyc"), None)
+    if loose_bytecode is not None:
+        raise RuntimeError(f"loose Python bytecode found in packaged output: {loose_bytecode}")
+    cache_dir = next(
+        (path for path in output_dir.rglob("__pycache__") if path.is_dir()),
+        None,
+    )
+    if cache_dir is not None:
+        raise RuntimeError(f"Python cache directory found in packaged output: {cache_dir}")
+
+    pyz_toc = work_dir / "openakita" / "PYZ-00.toc"
+    if not pyz_toc.exists():
+        raise RuntimeError(f"PyInstaller PYZ manifest not found: {pyz_toc}")
+    pyz_manifest = pyz_toc.read_text(encoding="utf-8")
+    required_modules = ("lark_oapi", "lark_oapi.api", "lark_oapi.ws")
+    missing = [name for name in required_modules if f"('{name}'," not in pyz_manifest]
+    if missing:
+        raise RuntimeError(f"lark_oapi modules missing from PYZ: {', '.join(missing)}")
+
+    print("  [OK] lark_oapi is archived in PYZ; no loose bytecode remains")
+
+
 def create_stdlib_zip(output_dir: Path) -> Path | None:
     """Create python3XX.zip containing stdlib for the standalone interpreter.
 
@@ -393,10 +444,20 @@ def build_backend(mode: str, fast: bool = False, skip_web_build: bool = False):
     else:
         print("  [WARN] Web frontend not found after build attempt")
 
+    removed_files, removed_dirs = prune_loose_python_bytecode(OUTPUT_DIR)
+    print(
+        f"  [OK] Removed {removed_files} loose bytecode files "
+        f"from {removed_dirs} cache directories"
+    )
+    verify_python_archive_layout(
+        OUTPUT_DIR,
+        PROJECT_ROOT / "build" / "pyinstaller_work",
+    )
+
     # Calculate size
     total_size = sum(f.stat().st_size for f in OUTPUT_DIR.rglob("*") if f.is_file())
     size_mb = total_size / (1024 * 1024)
-    print(f"\n  Build completed!")
+    print("\n  Build completed!")
     print(f"  Output directory: {OUTPUT_DIR}")
     print(f"  Total size: {size_mb:.1f} MB")
     print(f"  Mode: {mode.upper()}")

--- a/build/openakita.spec
+++ b/build/openakita.spec
@@ -6,6 +6,7 @@ Usage:
   pyinstaller build/openakita.spec
 """
 
+import importlib.util
 import os
 import shutil
 import sys
@@ -235,9 +236,8 @@ hidden_imports_core = [
     "telegram.request",         # HTTPXRequest (自定义超时配置)
     "telegram.constants",       # Telegram API 常量
     "telegram.error",           # Telegram 异常类
-    # lark_oapi: 10K+ 自动生成的 API 文件，hidden_imports 无法完整收集
-    # (wildcard imports: from .api import * 等)。改为在 datas 中直接复制整包目录，
-    # 确保飞书 IM 通道开箱即用，不再依赖运行时自动安装。
+    # lark_oapi modules are added to hidden_imports below so their bytecode is
+    # stored in the PYZ instead of copied as thousands of loose data files.
     "requests",                 # lark_oapi 依赖: HTTP 客户端
     "requests.adapters",
     "requests.auth",
@@ -397,10 +397,42 @@ print(f"[spec] Auto-collected {len(_stdlib_modules)} stdlib modules")
 
 hidden_imports = hidden_imports_core + _stdlib_modules
 
+
+def _collect_package_modules(package_name):
+    """Enumerate package modules without importing the package itself."""
+    package_spec = importlib.util.find_spec(package_name)
+    if package_spec is None or not package_spec.submodule_search_locations:
+        print(f"[spec] WARNING: {package_name} not installed")
+        return []
+
+    modules = {package_name}
+    for package_root_value in package_spec.submodule_search_locations:
+        package_root = Path(package_root_value)
+        for source_file in package_root.rglob("*.py"):
+            relative = source_file.relative_to(package_root)
+            if "__pycache__" in relative.parts:
+                continue
+            module_parts = list(relative.with_suffix("").parts)
+            if module_parts[-1] == "__init__":
+                module_parts.pop()
+            if not all(part.isidentifier() for part in module_parts):
+                continue
+            module_name = ".".join([package_name, *module_parts])
+            modules.add(module_name.rstrip("."))
+
+    collected = sorted(modules)
+    print(f"[spec] Collected {len(collected)} {package_name} modules for PYZ")
+    return collected
+
 # Collect all OpenAkita LLM submodules to prevent regressions when adding
 # new files (e.g. openakita.llm.cache/retry/sse) that may be imported
 # transitively but missed by static analysis in frozen builds.
 hidden_imports += collect_submodules("openakita.llm")
+
+# lark_oapi contains more than 10K generated API modules and uses wildcard
+# imports extensively. Filesystem enumeration is deterministic and avoids
+# executing its expensive package __init__ during the build.
+hidden_imports += _collect_package_modules("lark_oapi")
 
 # ============== Excludes ==============
 
@@ -554,18 +586,6 @@ if _pyproject_path.exists():
     _version_file.write_text(build_version_string(), encoding="utf-8")
     datas.append((str(_version_file), "openakita"))
 
-# lark_oapi (飞书 SDK): 10K+ 自动生成的 API 文件，PyInstaller hidden_imports 无法
-# 完整收集 (wildcard imports: from .api import *)。直接复制整包目录作为 data files，
-# 确保飞书 IM 通道开箱即用，不再依赖运行时自动安装 (运行时安装需要独立 Python
-# 解释器，在打包环境中不可靠)。
-try:
-    import lark_oapi as _lark
-    _lark_dir = str(Path(_lark.__file__).parent)
-    datas.append((_lark_dir, "lark_oapi"))
-    print(f"[spec] Bundling lark_oapi: {_lark_dir}")
-except ImportError:
-    print("[spec] WARNING: lark_oapi not installed, feishu channel will need runtime install")
-
 # requests_toolbelt (lark_oapi 依赖): 同样直接复制，避免 PyInstaller 遗漏
 try:
     import requests_toolbelt as _rt
@@ -686,6 +706,8 @@ a.datas = [
     for entry in a.datas
     if ".local-browsers" not in entry[0].replace("\\", "/")
     and not entry[0].replace("\\", "/").startswith("playwright-browsers/")
+    and "__pycache__" not in entry[0].replace("\\", "/").split("/")
+    and not entry[0].lower().endswith(".pyc")
 ]
 
 # Add importable source for bridge subprocesses, but keep the build-owned
@@ -696,7 +718,7 @@ if _openakita_src.exists():
     a.datas += Tree(
         str(_openakita_src),
         prefix="openakita",
-        excludes=["_bundled_version.txt"],
+        excludes=["_bundled_version.txt", "__pycache__", "*.pyc"],
     )
 
 pyz = PYZ(a.pure)

--- a/build/prepare_bootstrap_resources.py
+++ b/build/prepare_bootstrap_resources.py
@@ -578,8 +578,27 @@ def _seed_binary_path(python_root: Path, target_platform: str) -> Path:
     return python_root / "bin" / f"python{major_minor}"
 
 
+def _prune_python_bytecode(python_root: Path) -> tuple[int, int]:
+    """Remove cache directories and loose bytecode from a staged Python tree."""
+    removed_files = 0
+    removed_dirs = 0
+    cache_dirs = sorted(
+        (path for path in python_root.rglob("__pycache__") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for cache_dir in cache_dirs:
+        removed_files += sum(1 for path in cache_dir.rglob("*") if path.is_file())
+        shutil.rmtree(cache_dir)
+        removed_dirs += 1
+    for pyc_file in python_root.rglob("*.pyc"):
+        pyc_file.unlink()
+        removed_files += 1
+    return removed_files, removed_dirs
+
+
 def _slim_python_seed(python_root: Path, target_platform: str) -> None:
-    """Remove docs/tests/IDLE/tkinter/turtledemo + __pycache__ to shave size."""
+    """Remove development-only files from the staged Python seed."""
     if target_platform.startswith("win"):
         lib_roots = [python_root / "Lib"]
     else:
@@ -590,8 +609,7 @@ def _slim_python_seed(python_root: Path, target_platform: str) -> None:
             target = lib_root / sub
             if target.exists():
                 shutil.rmtree(target, ignore_errors=True)
-    for cache_dir in python_root.rglob("__pycache__"):
-        shutil.rmtree(cache_dir, ignore_errors=True)
+    _prune_python_bytecode(python_root)
     if not target_platform.startswith("win"):
         for sub in ("share/man", "share/doc"):
             target = python_root / sub
@@ -727,6 +745,16 @@ def prepare_python_seed(
         print(
             f"[INFO] skipping seed smoke test: host {platform.system()}/{platform.machine()} "
             f"cannot execute target {target_platform!r}"
+        )
+
+    # The smoke test imports stdlib modules and recreates __pycache__. The
+    # staged tree is immutable after this point, so remove those build-only
+    # caches before Tauri collects the bootstrap resources.
+    removed_files, removed_dirs = _prune_python_bytecode(python_root)
+    if removed_files or removed_dirs:
+        print(
+            f"[INFO] removed {removed_files} smoke-test bytecode files "
+            f"from {removed_dirs} cache directories"
         )
 
     rel_path = seed_python.relative_to(bootstrap_dir).as_posix()

--- a/tests/unit/test_build_backend_layout.py
+++ b/tests/unit/test_build_backend_layout.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[2] / "build" / "build_backend.py"
+_SPEC = importlib.util.spec_from_file_location("build_backend", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+_BOOTSTRAP_SCRIPT = Path(__file__).parents[2] / "build" / "prepare_bootstrap_resources.py"
+_BOOTSTRAP_SPEC = importlib.util.spec_from_file_location(
+    "prepare_bootstrap_resources",
+    _BOOTSTRAP_SCRIPT,
+)
+assert _BOOTSTRAP_SPEC is not None and _BOOTSTRAP_SPEC.loader is not None
+_BOOTSTRAP_MODULE = importlib.util.module_from_spec(_BOOTSTRAP_SPEC)
+_BOOTSTRAP_SPEC.loader.exec_module(_BOOTSTRAP_MODULE)
+
+prune_loose_python_bytecode = _MODULE.prune_loose_python_bytecode
+verify_python_archive_layout = _MODULE.verify_python_archive_layout
+prune_seed_bytecode = _BOOTSTRAP_MODULE._prune_python_bytecode
+
+
+def test_prune_loose_python_bytecode_removes_cache_and_orphan_pyc(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "package" / "__pycache__"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "module.cpython-311.pyc").write_bytes(b"cache")
+    orphan = tmp_path / "legacy.pyc"
+    orphan.write_bytes(b"cache")
+    source = tmp_path / "package" / "module.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+
+    removed_files, removed_dirs = prune_loose_python_bytecode(tmp_path)
+
+    assert (removed_files, removed_dirs) == (2, 1)
+    assert not cache_dir.exists()
+    assert not orphan.exists()
+    assert source.exists()
+
+
+def test_prune_seed_bytecode_removes_smoke_test_caches(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "Lib" / "json" / "__pycache__"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "decoder.cpython-311.pyc").write_bytes(b"cache")
+    orphan = tmp_path / "Lib" / "legacy.pyc"
+    orphan.write_bytes(b"cache")
+
+    removed_files, removed_dirs = prune_seed_bytecode(tmp_path)
+
+    assert (removed_files, removed_dirs) == (2, 1)
+    assert not cache_dir.exists()
+    assert not orphan.exists()
+
+
+def test_verify_python_archive_layout_accepts_lark_in_pyz(tmp_path: Path) -> None:
+    output_dir = tmp_path / "dist" / "openakita-server"
+    (output_dir / "_internal").mkdir(parents=True)
+    work_dir = tmp_path / "work"
+    pyz_toc = work_dir / "openakita" / "PYZ-00.toc"
+    pyz_toc.parent.mkdir(parents=True)
+    pyz_toc.write_text(
+        "[('lark_oapi', 'a', 'PYMODULE'),\n"
+        " ('lark_oapi.api', 'b', 'PYMODULE'),\n"
+        " ('lark_oapi.ws', 'c', 'PYMODULE')]\n",
+        encoding="utf-8",
+    )
+
+    verify_python_archive_layout(output_dir, work_dir)
+
+
+@pytest.mark.parametrize("relative_path", ["_internal/lark_oapi/__init__.py", "module.pyc"])
+def test_verify_python_archive_layout_rejects_loose_python_artifacts(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    output_dir = tmp_path / "dist" / "openakita-server"
+    artifact = output_dir / relative_path
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"artifact")
+    work_dir = tmp_path / "work"
+
+    with pytest.raises(RuntimeError):
+        verify_python_archive_layout(output_dir, work_dir)

--- a/tests/unit/test_bundled_python_contract.py
+++ b/tests/unit/test_bundled_python_contract.py
@@ -45,8 +45,17 @@ def test_bundled_chat_smoke_checks_loose_toolbelt_import() -> None:
 def test_pyinstaller_source_tree_excludes_build_owned_version_file() -> None:
     spec_source = (Path("build") / "openakita.spec").read_text(encoding="utf-8")
 
-    assert 'excludes=["_bundled_version.txt"]' in spec_source
+    assert 'excludes=["_bundled_version.txt", "__pycache__", "*.pyc"]' in spec_source
     assert 'datas.append((str(_openakita_src), "openakita"))' not in spec_source
+
+
+def test_pyinstaller_archives_lark_oapi_without_copying_loose_package() -> None:
+    spec_source = (Path("build") / "openakita.spec").read_text(encoding="utf-8")
+
+    assert 'hidden_imports += _collect_package_modules("lark_oapi")' in spec_source
+    assert 'datas.append((_lark_dir, "lark_oapi"))' not in spec_source
+    assert "import lark_oapi as _lark" not in spec_source
+    assert 'and not entry[0].lower().endswith(".pyc")' in spec_source
 
 
 def test_pyinstaller_does_not_analyze_loose_requests_toolbelt_copy_twice() -> None:


### PR DESCRIPTION
## Summary

- Archive all `lark_oapi` pure Python modules in the PyInstaller PYZ instead of copying more than 20,000 loose source and cache files.
- Remove build-generated bytecode from backend and bootstrap resources, and enforce the archive layout with packaging contract tests.

## Tests

- `uv run --no-sync ruff check build/build_backend.py build/prepare_bootstrap_resources.py tests/unit/test_build_backend_layout.py tests/unit/test_bundled_python_contract.py`
- `uv run --no-sync pytest tests/unit/test_build_backend_layout.py tests/unit/test_bundled_python_contract.py tests/unit/test_browser_runtime_install.py tests/unit/test_runtime_channel_deps.py tests/unit/channels/test_feishu_cardkit.py tests/api/test_im_channel_status_error.py -q`
- `uv run --no-sync python build/build_backend.py --fast --skip-web-build`
- Frozen `openakita-server.exe --help` smoke test
- Windows bootstrap staging with zero `.pyc` files and zero `__pycache__` directories
