### PR TITLE
Fix organization media delivery across IM channels

### DIFF
--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -3974,7 +3974,13 @@ class MessageGateway:
                         error = item.get("error")
                         attachments: list[dict] = []
                         if isinstance(result, dict):
-                            final_text = str(result.get("result") or result.get("error") or result)
+                            final_text = str(
+                                result.get("result")
+                                or result.get("deliverable")
+                                or result.get("final_message")
+                                or result.get("error")
+                                or ""
+                            )
                             attachments = self._extract_org_result_attachments(result)
                         else:
                             final_text = str(error or result or "组织命令已完成")
@@ -5774,8 +5780,8 @@ class MessageGateway:
                             metadata=outgoing_meta,
                         )
 
+        all_files = list(media_result.files) + list(media_result.videos)
         if adapter.has_capability("send_file"):
-            all_files = list(media_result.files) + list(media_result.videos)
             for file in all_files:
                 if file.is_url:
                     continue
@@ -5795,6 +5801,16 @@ class MessageGateway:
                             reply_to=reply_to,
                             metadata=outgoing_meta,
                         )
+        elif all_files:
+            names = [Path(file.path).name or "file" for file in all_files if not file.is_url]
+            if names:
+                with contextlib.suppress(Exception):
+                    await adapter.send_text(
+                        original.chat_id,
+                        "附件已生成，但当前通道不支持文件发送：" + "、".join(names),
+                        reply_to=reply_to,
+                        metadata=outgoing_meta,
+                    )
 
         if adapter.has_capability("send_voice"):
             for audio in media_result.audios:

--- a/src/openakita/orgs/command_service.py
+++ b/src/openakita/orgs/command_service.py
@@ -45,6 +45,7 @@ import logging
 import time
 from contextlib import suppress
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from .command_models import (
@@ -172,6 +173,94 @@ def delivery_language_directive(text: str) -> str:
         "and folder in English and write their contents in English to match the "
         "user's language."
     )
+
+
+def _project_manifest_file_attachments(
+    delivery_manifest: dict[str, Any] | None,
+    artifact_records: tuple[Any, ...],
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Hydrate declared deliverables with their runtime-registered local files.
+
+    Nodes commonly submit only ``asset_ids`` / ``task_ids`` in the final
+    manifest. The artifact ledger is the authoritative mapping from those IDs
+    to downloaded files, so terminal consumers should not need to repeat that
+    lookup independently.
+    """
+    if delivery_manifest is None:
+        return None, []
+
+    projected = dict(delivery_manifest)
+    raw_artifacts = delivery_manifest.get("artifacts")
+    if not isinstance(raw_artifacts, list):
+        return projected, []
+
+    attachments: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    projected_artifacts: list[Any] = []
+
+    def string_values(raw: Any) -> list[str]:
+        values = [raw] if isinstance(raw, str) else raw
+        if not isinstance(values, (list, tuple, set)):
+            return []
+        return [str(value).strip() for value in values if str(value).strip()]
+
+    for raw_artifact in raw_artifacts:
+        if not isinstance(raw_artifact, dict):
+            projected_artifacts.append(raw_artifact)
+            continue
+
+        artifact = dict(raw_artifact)
+        kind = str(artifact.get("kind") or "").strip().lower()
+        asset_ids = set(string_values(artifact.get("asset_ids")))
+        task_ids = set(string_values(artifact.get("task_ids")))
+        paths = string_values(artifact.get("paths"))
+
+        for record in artifact_records:
+            record_kinds = {str(value).strip().lower() for value in record.asset_kinds}
+            if kind and kind not in record_kinds:
+                continue
+            if not (
+                asset_ids.intersection(record.asset_ids) or task_ids.intersection(record.task_ids)
+            ):
+                continue
+            registered = (
+                (*record.registered_video_paths, *record.registered_paths)
+                if kind == "video"
+                else record.registered_paths
+            )
+            paths.extend(str(value).strip() for value in registered if str(value).strip())
+
+        unique_paths: list[str] = []
+        artifact_seen: set[str] = set()
+        for file_path in paths:
+            key = file_path.lower().replace("\\", "/")
+            if key in artifact_seen:
+                continue
+            artifact_seen.add(key)
+            unique_paths.append(file_path)
+            if key in seen_paths:
+                continue
+            seen_paths.add(key)
+            path = Path(file_path)
+            try:
+                file_size = path.stat().st_size if path.is_file() else 0
+            except OSError:
+                file_size = 0
+            attachments.append(
+                {
+                    "filename": path.name or str(artifact.get("name") or "file"),
+                    "file_path": file_path,
+                    "file_size": file_size,
+                    "kind": kind or None,
+                    "name": artifact.get("name"),
+                }
+            )
+
+        artifact["paths"] = unique_paths
+        projected_artifacts.append(artifact)
+
+    projected["artifacts"] = projected_artifacts
+    return projected, attachments
 
 
 def _headline(text: str, limit: int) -> str:
@@ -2844,6 +2933,7 @@ class OrgCommandService:
         delivery_manifest = getattr(outcome, "delivery_manifest", None)
         if not isinstance(delivery_manifest, dict):
             delivery_manifest = None
+        artifact_records: tuple[Any, ...] = ()
         manifest_media_failures: list[dict[str, Any]] = []
         if delivery_manifest is not None:
             from ._runtime_artifact_flow import artifact_ledger
@@ -2856,6 +2946,7 @@ class OrgCommandService:
             command = self._commands.get(command_id, {})
             org_id = str(command.get("org_id") or "")
             root_node_id = str(command.get("root_node_id") or "")
+            artifact_records = artifact_ledger.get(org_id, command_id)
             try:
                 reflected_manifest = DeliveryManifest.from_mapping(
                     delivery_manifest,
@@ -2867,7 +2958,7 @@ class OrgCommandService:
                 )
                 manifest_media_failures = validate_manifest_media_delivery(
                     reflected_manifest,
-                    artifact_records=artifact_ledger.get(org_id, command_id),
+                    artifact_records=artifact_records,
                 )
             except DeliveryManifestError as exc:
                 manifest_media_failures = [
@@ -2877,6 +2968,11 @@ class OrgCommandService:
                         "reworkable": True,
                     }
                 ]
+
+        delivery_manifest, file_attachments = _project_manifest_file_attachments(
+            delivery_manifest,
+            artifact_records,
+        )
 
         # test16 semantic root-cause: OUT_OF_TURNS / REPLAN_BUDGET_EXHAUSTED /
         # FAILED (the hard-ceiling synthesises FAILED) are *limit* exits, not
@@ -2957,6 +3053,8 @@ class OrgCommandService:
             "outcome": result_outcome,
             "delivery_manifest": delivery_manifest,
         }
+        if file_attachments:
+            result_payload["file_attachments"] = file_attachments
         if manifest_media_failures:
             result_payload["media_quality_failures"] = manifest_media_failures
         # Traceability: keep the raw supervisor verdict alongside the honest

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -149,6 +149,34 @@ class TestExtractedMediaDelivery:
         assert adapter.sent_files == [("chat-1", str(video_path))]
         assert adapter.fallback_texts == []
 
+    @pytest.mark.asyncio
+    async def test_adapter_without_file_capability_receives_explicit_notice(self, tmp_path):
+        from openakita.channels.media_parser import parse_media_from_text
+
+        video_path = tmp_path / "preview.mp4"
+        video_path.write_bytes(b"video")
+
+        class TextOnlyAdapter:
+            def __init__(self):
+                self.sent_texts: list[str] = []
+
+            @staticmethod
+            def has_capability(_name: str) -> bool:
+                return False
+
+            async def send_text(self, chat_id: str, text: str, **_kwargs) -> str:
+                self.sent_texts.append(text)
+                return "notice-message-id"
+
+        gateway = MessageGateway(session_manager=MagicMock())
+        adapter = TextOnlyAdapter()
+        original = create_channel_message(channel="wework_bot:test", chat_id="chat-1")
+        media_result = parse_media_from_text(f"MEDIA: {video_path}")
+
+        await gateway._send_extracted_media(adapter, original, media_result, {})
+
+        assert adapter.sent_texts == ["附件已生成，但当前通道不支持文件发送：preview.mp4"]
+
 
 class TestMessageGatewayBroadcast:
     @pytest.mark.asyncio

--- a/tests/integration/test_gateway_org_control.py
+++ b/tests/integration/test_gateway_org_control.py
@@ -342,7 +342,8 @@ class TestOrgCommandsDoNotStartTyping:
             {
                 "type": "org_command_done",
                 "result": {
-                    "result": "组织任务完成",
+                    "final_message": "supervisor finished",
+                    "deliverable": "组织任务完成",
                     "file_attachments": [{"file_path": image_path}],
                     "delivery_manifest": {
                         "artifacts": [

--- a/tests/perf/test_org_manager_perf.py
+++ b/tests/perf/test_org_manager_perf.py
@@ -1,0 +1,25 @@
+"""Opt-in performance baselines for filesystem-backed organization storage."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from openakita.orgs.manager import OrgManager
+
+
+@pytest.mark.perf
+def test_100_blob_create_and_list_performance(tmp_path: Path) -> None:
+    """Create and list 100 organizations within the established budget."""
+    manager = OrgManager(tmp_path)
+
+    started_at = time.perf_counter()
+    for i in range(100):
+        manager.create({"name": f"blob_{i:03d}"})
+    items = manager.list_orgs()
+    elapsed = time.perf_counter() - started_at
+
+    assert len(items) == 100
+    assert elapsed < 5.0, f"100-blob stress took {elapsed:.2f}s (> 5s budget)"

--- a/tests/runtime/orgs/test_manager_contract.py
+++ b/tests/runtime/orgs/test_manager_contract.py
@@ -22,13 +22,12 @@ Case axes:
 * dir layout invariants -- 2 (12 org subdirs + README; per-node files)
 * concurrent ops -- 2 (4x25 thread storm; name-conflict serialisation)
 * malformed input -- 2 (path traversal; update missing)
-* 100-blob stress -- 1 (create + reload + list)
+* 100-blob round trip -- 1 (create + reload + list)
 """
 
 from __future__ import annotations
 
 import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -260,25 +259,21 @@ def test_update_on_missing_org_raises(manager: OrgManager) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 100-blob stress smoke
+# 100-blob round trip
 # ---------------------------------------------------------------------------
 
 
-def test_100_blob_stress_smoke(manager: OrgManager, tmp_path: Path) -> None:
-    """100 sequential creates + list complete fast.
+def test_100_blob_round_trip(manager: OrgManager, tmp_path: Path) -> None:
+    """100 sequential creates survive a cache-bypass reload.
 
     Mirrors the parity 100-blob fixture but on a fresh manager
-    so we also exercise per-create _init_dirs cost. Wall-clock
-    target: < 5 s on commodity hardware (the v1 test_manager.py
-    parity expectations are looser; this is just a smoke).
+    so we also exercise per-create _init_dirs behavior. Performance
+    is covered separately by the opt-in perf suite.
     """
-    t0 = time.perf_counter()
     for i in range(100):
         manager.create({"name": f"blob_{i:03d}"})
     items = manager.list_orgs()
-    elapsed = time.perf_counter() - t0
     assert len(items) == 100
-    assert elapsed < 5.0, f"100-blob stress took {elapsed:.2f}s (> 5s budget)"
     # Reload via fresh OrgManager to exercise cache-bypass read
     fresh = OrgManager(tmp_path)
     items2 = fresh.list_orgs()

--- a/tests/unit/test_org_terminal_file_attachments.py
+++ b/tests/unit/test_org_terminal_file_attachments.py
@@ -1,0 +1,191 @@
+"""Organization terminal results expose registered deliverable files uniformly."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from openakita.orgs._runtime_artifact_flow import ArtifactRecord, artifact_ledger
+from openakita.orgs.command_service import (
+    OrgCommandService,
+    _project_manifest_file_attachments,
+)
+from openakita.runtime.supervisor import FinalOutcome
+
+
+def test_manifest_ids_are_hydrated_from_artifact_ledger(tmp_path: Path) -> None:
+    image_path = tmp_path / "key-frame.png"
+    video_path = tmp_path / "preview.mp4"
+    image_path.write_bytes(b"image")
+    video_path.write_bytes(b"video")
+    manifest = {
+        "state": "complete",
+        "final": True,
+        "artifacts": [
+            {
+                "kind": "image",
+                "status": "ready",
+                "name": "key frame",
+                "asset_ids": ["image-asset"],
+                "task_ids": ["image-task"],
+                "paths": [],
+            },
+            {
+                "kind": "video",
+                "status": "ready",
+                "name": "preview",
+                "asset_ids": ["video-asset"],
+                "task_ids": ["video-task"],
+                "paths": [],
+            },
+        ],
+    }
+    records = (
+        ArtifactRecord(
+            org_id="org-1",
+            command_id="cmd-1",
+            source_node_id="image-worker",
+            tool_name="image_create",
+            asset_ids=("image-asset",),
+            task_ids=("image-task",),
+            asset_kinds=("image",),
+            registered_paths=(str(image_path),),
+        ),
+        ArtifactRecord(
+            org_id="org-1",
+            command_id="cmd-1",
+            source_node_id="video-worker",
+            tool_name="video_create",
+            asset_ids=("video-asset",),
+            task_ids=("video-task",),
+            asset_kinds=("video",),
+            registered_paths=(str(video_path),),
+            registered_video_paths=(str(video_path),),
+            media_validation_passed=True,
+        ),
+    )
+
+    projected, attachments = _project_manifest_file_attachments(manifest, records)
+
+    assert projected is not None
+    assert projected["artifacts"][0]["paths"] == [str(image_path)]
+    assert projected["artifacts"][1]["paths"] == [str(video_path)]
+    assert [(item["kind"], item["file_path"]) for item in attachments] == [
+        ("image", str(image_path)),
+        ("video", str(video_path)),
+    ]
+    assert attachments[1]["file_size"] == len(b"video")
+
+
+def test_manifest_projection_does_not_leak_unclaimed_intermediate_files(tmp_path: Path) -> None:
+    final_path = tmp_path / "final.mp4"
+    intermediate_path = tmp_path / "intermediate.mp4"
+    final_path.write_bytes(b"final")
+    intermediate_path.write_bytes(b"intermediate")
+    manifest = {
+        "artifacts": [
+            {
+                "kind": "video",
+                "asset_ids": ["final-asset"],
+                "task_ids": [],
+                "paths": [],
+            }
+        ]
+    }
+    records = (
+        ArtifactRecord(
+            org_id="org-1",
+            command_id="cmd-1",
+            source_node_id="video-worker",
+            tool_name="video_create",
+            asset_ids=("final-asset",),
+            asset_kinds=("video",),
+            registered_video_paths=(str(final_path),),
+        ),
+        ArtifactRecord(
+            org_id="org-1",
+            command_id="cmd-1",
+            source_node_id="video-worker",
+            tool_name="video_create",
+            asset_ids=("intermediate-asset",),
+            asset_kinds=("video",),
+            registered_video_paths=(str(intermediate_path),),
+        ),
+    )
+
+    projected, attachments = _project_manifest_file_attachments(manifest, records)
+
+    assert projected is not None
+    assert projected["artifacts"][0]["paths"] == [str(final_path)]
+    assert [item["file_path"] for item in attachments] == [str(final_path)]
+
+
+def test_supervisor_terminal_result_exposes_hydrated_file_attachments(tmp_path: Path) -> None:
+    video_path = tmp_path / "preview.mp4"
+    video_path.write_bytes(b"video")
+    record = ArtifactRecord(
+        org_id="org-1",
+        command_id="cmd-1",
+        source_node_id="video-worker",
+        tool_name="video_create",
+        asset_ids=("video-asset",),
+        task_ids=("video-task",),
+        asset_kinds=("video",),
+        registered_paths=(str(video_path),),
+        registered_video_paths=(str(video_path),),
+        media_validation_passed=True,
+    )
+    artifact_ledger.clear()
+    artifact_ledger.append(record)
+    service = object.__new__(OrgCommandService)
+    service._commands = {
+        "cmd-1": {
+            "org_id": "org-1",
+            "root_node_id": "producer",
+            "source": "im",
+            "origin_surface": "feishu",
+        }
+    }
+    service._command_outcomes = {}
+    service._runtime = MagicMock()
+    service._runtime.finalize_command_project = None
+    service._update_command_state = MagicMock()
+    service._bridge_persist_result = MagicMock()
+    outcome = SimpleNamespace(
+        outcome=FinalOutcome.DONE,
+        final_message="组织任务完成",
+        deliverable="组织任务完成",
+        n_turns=2,
+        n_replans=0,
+        final_checkpoint_id="cp-1",
+        delivery_manifest={
+            "state": "complete",
+            "final": True,
+            "artifacts": [
+                {
+                    "kind": "video",
+                    "status": "ready",
+                    "name": "preview",
+                    "asset_ids": ["video-asset"],
+                    "task_ids": ["video-task"],
+                    "paths": [],
+                }
+            ],
+        },
+    )
+
+    try:
+        service._reflect_supervisor_outcome("cmd-1", MagicMock(), outcome)
+    finally:
+        artifact_ledger.clear()
+
+    result = service._update_command_state.call_args.kwargs["result"]
+    assert result["delivery_manifest"]["artifacts"][0]["paths"] == [str(video_path)]
+    assert result["file_attachments"] == [
+        {
+            "filename": "preview.mp4",
+            "file_path": str(video_path),
+            "file_size": len(b"video"),
+            "kind": "video",
+            "name": "preview",
+        }
+    ]


### PR DESCRIPTION
## Summary

- Resolve declared organization deliverables through the runtime artifact ledger so generated media reaches every file-capable IM channel.
- Prefer structured terminal messages and notify users explicitly when a channel cannot upload files.
- Keep the 100-organization round-trip contract deterministic and move its wall-clock budget to the opt-in performance suite.

## Tests

- `uv run --no-sync pytest tests/unit/test_org_terminal_file_attachments.py tests/integration/test_gateway.py tests/integration/test_gateway_org_control.py tests/runtime/orgs/test_delivery_manifest.py tests/runtime/orgs/test_artifact_flow.py tests/runtime/orgs/test_command_service_contract.py tests/runtime/orgs/test_manager_contract.py` (`130 passed`)
- `uv run --no-sync pytest tests/perf/test_org_manager_perf.py -m perf -v` (`1 passed`)
- `uv run --no-sync ruff check tests/runtime/orgs/test_manager_contract.py tests/perf/test_org_manager_perf.py`

Fixes #793
