### PR TITLE
Prevent plugin reload races during asynchronous initialization

### DIFF
--- a/plugins/happyhorse-video/happyhorse_task_manager.py
+++ b/plugins/happyhorse-video/happyhorse_task_manager.py
@@ -35,6 +35,7 @@ row; ``id`` / ``created_at`` are non-writable.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -309,6 +310,7 @@ class HappyhorseTaskManager:
     def __init__(self, db_path: Path) -> None:
         self._db_path = Path(db_path)
         self._db: aiosqlite.Connection | None = None
+        self._lifecycle_lock = asyncio.Lock()
 
     # ── Lifecycle ──────────────────────────────────────────────────────
 
@@ -325,24 +327,33 @@ class HappyhorseTaskManager:
         await self.close()
 
     async def init(self) -> None:
-        if self._db is not None:
-            return
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._db = await aiosqlite.connect(str(self._db_path))
-        self._db.row_factory = aiosqlite.Row
-        await self._db.execute("PRAGMA journal_mode=WAL")
-        await self._db.execute("PRAGMA synchronous=NORMAL")
-        await self._db.execute("PRAGMA foreign_keys=ON")
-        await self._db.executescript(SCHEMA_SQL)
-        await self._init_default_config()
-        await self._db.commit()
+        async with self._lifecycle_lock:
+            if self._db is not None:
+                return
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            connection: aiosqlite.Connection | None = None
+            try:
+                connection = await aiosqlite.connect(str(self._db_path))
+                connection.row_factory = aiosqlite.Row
+                await connection.execute("PRAGMA journal_mode=WAL")
+                await connection.execute("PRAGMA synchronous=NORMAL")
+                await connection.execute("PRAGMA foreign_keys=ON")
+                await connection.executescript(SCHEMA_SQL)
+                await self._init_default_config(connection)
+                await connection.commit()
+            except BaseException:
+                if connection is not None:
+                    await asyncio.shield(connection.close())
+                raise
+            # Readers only ever observe a fully initialized connection.
+            self._db = connection
 
     async def close(self) -> None:
-        if self._db is not None:
-            try:
-                await self._db.close()
-            finally:
-                self._db = None
+        async with self._lifecycle_lock:
+            connection = self._db
+            self._db = None
+            if connection is not None:
+                await connection.close()
 
     @property
     def _conn(self) -> aiosqlite.Connection:
@@ -350,9 +361,9 @@ class HappyhorseTaskManager:
             raise RuntimeError("HappyhorseTaskManager.init() must be called first")
         return self._db
 
-    async def _init_default_config(self) -> None:
+    async def _init_default_config(self, connection: aiosqlite.Connection) -> None:
         for key, val in DEFAULT_CONFIG.items():
-            await self._conn.execute(
+            await connection.execute(
                 "INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)",
                 (key, val),
             )

--- a/plugins/happyhorse-video/plugin.py
+++ b/plugins/happyhorse-video/plugin.py
@@ -59,7 +59,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from pydantic import BaseModel, Field, ValidationError
 
 PLUGIN_DIR = Path(__file__).resolve().parent
@@ -495,13 +495,19 @@ class Plugin(PluginBase):
         """Report local prerequisites required by organization workbench nodes."""
 
         missing: list[str] = []
+        lifecycle_status, lifecycle_error = self._lifecycle_status()
+        if lifecycle_status != "ready":
+            missing.append(f"plugin_{lifecycle_status}")
         if not self._client.has_api_key():
             missing.append("dashscope_api_key")
         if not self._oss.is_configured():
             missing.append("oss")
         if not ffmpeg_available():
             missing.append("ffmpeg")
-        return {"ready": not missing, "missing_requirements": missing}
+        result: dict[str, Any] = {"ready": not missing, "missing_requirements": missing}
+        if lifecycle_error:
+            result["initialization_error"] = lifecycle_error
+        return result
 
     def on_load(self, api: PluginAPI) -> None:
         self._api = api
@@ -518,6 +524,9 @@ class Plugin(PluginBase):
         self._storyboard_decompose_lock = asyncio.Lock()
         self._storyboard_decompose_running = False
         self._sse_subscribers: list[asyncio.Queue[dict[str, Any]]] = []
+        self._ready_event = asyncio.Event()
+        self._init_error: str | None = None
+        self._stopping = False
 
         # Lazy preinstall — non-fatal if it fails (install on first use).
         try:
@@ -537,21 +546,58 @@ class Plugin(PluginBase):
             )
 
         router = APIRouter()
-        add_upload_preview_route(router, base_dir=self._uploads_dir)
-        self._register_routes(router)
+        self._register_lifecycle_routes(router)
+        ready_router = APIRouter(dependencies=[Depends(self._require_ready)])
+        add_upload_preview_route(ready_router, base_dir=self._uploads_dir)
+        self._register_routes(ready_router)
+        router.include_router(ready_router)
         api.register_api_routes(router)
         api.register_tools(self._tool_definitions(), handler=self._handle_tool)
 
-        api.spawn_task(self._async_init(), name=f"{PLUGIN_ID}:init")
+        api.spawn_task(self._run_initialization(), name=f"{PLUGIN_ID}:init")
         registered_tools = len(self._tool_definitions())
         api.log(
             f"happyhorse-video loaded — Studio modes (video + image), "
             f"{registered_tools} tools, single DashScope backend",
         )
 
+    def _lifecycle_status(self) -> tuple[str, str | None]:
+        if self._stopping:
+            return "stopping", None
+        if not self._ready_event.is_set():
+            return "initializing", None
+        if self._init_error:
+            return "failed", self._init_error
+        return "ready", None
+
+    async def _require_ready(self) -> None:
+        status, error = self._lifecycle_status()
+        if status == "ready":
+            return
+        detail = f"happyhorse-video is {status}"
+        if error:
+            detail = f"{detail}: {error}"
+        raise HTTPException(
+            status_code=503,
+            detail=detail,
+            headers={"Retry-After": "1"},
+        )
+
+    async def _run_initialization(self) -> None:
+        try:
+            await self._async_init()
+        except asyncio.CancelledError:
+            self._stopping = True
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self._init_error = f"{type(exc).__name__}: {exc}"
+            logger.exception("happyhorse-video initialization failed")
+        finally:
+            self._ready_event.set()
+
     async def _async_init(self) -> None:
         await self._tm.init()
-        await self._reload_settings_cache()
+        await self._reload_settings_cache(strict=True)
         try:
             stale = await self._tm.list_tasks(status="running", limit=200)
             for row in stale:
@@ -605,6 +651,8 @@ class Plugin(PluginBase):
             )
 
     async def on_unload(self) -> None:
+        self._stopping = True
+        self._ready_event.set()
         for tid, t in list(self._poll_tasks.items()):
             if not t.done():
                 t.cancel()
@@ -775,12 +823,14 @@ class Plugin(PluginBase):
             return str(spec.to_dict().get("dashscope_voice_id") or vid)
         return vid
 
-    async def _reload_settings_cache(self) -> None:
+    async def _reload_settings_cache(self, *, strict: bool = False) -> None:
         try:
             self._settings_cache = await self._tm.get_all_config()
         except Exception as exc:  # noqa: BLE001
             logger.warning("happyhorse-video: settings reload error: %s", exc)
             self._settings_cache = {}
+            if strict:
+                raise
 
     # ── Workbench protocol contract ────────────────────────────────────
 
@@ -2511,6 +2561,20 @@ class Plugin(PluginBase):
     # ── LLM tool dispatch ──────────────────────────────────────────────
 
     async def _handle_tool(self, tool_name: str, args: dict[str, Any]) -> str:
+        status, error = self._lifecycle_status()
+        if status != "ready":
+            return json.dumps(
+                {
+                    "ok": False,
+                    "terminal": False,
+                    "status": "unavailable",
+                    "error_kind": "plugin_not_ready",
+                    "error_message": (
+                        f"happyhorse-video is {status}" + (f": {error}" if error else "")
+                    ),
+                },
+                ensure_ascii=False,
+            )
         if tool_name == "hh_status":
             return await self._tool_status(args)
         if tool_name == "hh_list":
@@ -4224,17 +4288,7 @@ class Plugin(PluginBase):
             removed = await self._tm.cleanup_expired(retention_days=retention_days)
             return {"ok": True, "removed": removed}
 
-        # Health + python-deps ------------------------------------------
-        @router.get("/healthz")
-        async def healthz() -> dict:
-            return {
-                "ok": True,
-                "version": "1.0.0",
-                "has_api_key": self._client.has_api_key(),
-                "oss_configured": self._oss.is_configured(),
-                "ffmpeg_available": ffmpeg_available(),
-            }
-
+        # Python dependencies ------------------------------------------
         @router.get("/python-deps/status")
         async def deps_status() -> dict:
             try:
@@ -4486,6 +4540,24 @@ class Plugin(PluginBase):
                 return self._sysdeps.status(dep_id)
             except ValueError as exc:
                 raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    def _register_lifecycle_routes(self, router: APIRouter) -> None:
+        """Expose readiness independently from routes that require SQLite."""
+
+        @router.get("/healthz")
+        async def healthz() -> dict:
+            status, error = self._lifecycle_status()
+            result = {
+                "ok": status == "ready",
+                "status": status,
+                "version": "1.0.0",
+                "has_api_key": self._client.has_api_key(),
+                "oss_configured": self._oss.is_configured(),
+                "ffmpeg_available": ffmpeg_available(),
+            }
+            if error:
+                result["initialization_error"] = error
+            return result
 
     # ── /upload handler (factored out so tests can target it) ─────────
 

--- a/plugins/happyhorse-video/tests/test_happyhorse_workbench_protocol.py
+++ b/plugins/happyhorse-video/tests/test_happyhorse_workbench_protocol.py
@@ -19,6 +19,7 @@ The two contracts that must remain stable across versions:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -43,6 +44,10 @@ def test_image_and_video_tool_schemas_expose_segment_id():
 
 def test_org_readiness_reports_local_prerequisites(monkeypatch: pytest.MonkeyPatch):
     plugin = HappyhorsePlugin.__new__(HappyhorsePlugin)
+    plugin._ready_event = asyncio.Event()
+    plugin._ready_event.set()
+    plugin._init_error = None
+    plugin._stopping = False
     plugin._client = SimpleNamespace(has_api_key=lambda: False)
     plugin._oss = SimpleNamespace(is_configured=lambda: False)
     monkeypatch.setattr(_HH, "ffmpeg_available", lambda: False)
@@ -57,6 +62,10 @@ def test_org_readiness_passes_when_local_prerequisites_exist(
     monkeypatch: pytest.MonkeyPatch,
 ):
     plugin = HappyhorsePlugin.__new__(HappyhorsePlugin)
+    plugin._ready_event = asyncio.Event()
+    plugin._ready_event.set()
+    plugin._init_error = None
+    plugin._stopping = False
     plugin._client = SimpleNamespace(has_api_key=lambda: True)
     plugin._oss = SimpleNamespace(is_configured=lambda: True)
     monkeypatch.setattr(_HH, "ffmpeg_available", lambda: True)

--- a/plugins/happyhorse-video/tests/test_plugin.py
+++ b/plugins/happyhorse-video/tests/test_plugin.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from _plugin_loader import load_happyhorse_plugin
+from fastapi import APIRouter, Depends, FastAPI
 
 _HH = load_happyhorse_plugin()
 HappyhorsePlugin = _HH.Plugin
@@ -35,6 +39,62 @@ EXPECTED_TOOLS = {
     "hh_storyboard_decompose",
     "hh_video_concat",
 }
+
+
+def _plugin_with_lifecycle_state(*, ready: bool, error: str | None = None):
+    plugin = HappyhorsePlugin.__new__(HappyhorsePlugin)
+    plugin._ready_event = asyncio.Event()
+    if ready:
+        plugin._ready_event.set()
+    plugin._init_error = error
+    plugin._stopping = False
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_settings_route_returns_503_until_plugin_is_ready():
+    plugin = _plugin_with_lifecycle_state(ready=False)
+    plugin._tm = SimpleNamespace(
+        get_all_config=lambda: pytest.fail("route ran before readiness dependency")
+    )
+    router = APIRouter(dependencies=[Depends(plugin._require_ready)])
+    plugin._register_routes(router)
+    app = FastAPI()
+    app.include_router(router)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/settings")
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "1"
+    assert "initializing" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_initialization_failure_is_retained_for_routes_and_tools():
+    plugin = _plugin_with_lifecycle_state(ready=False)
+
+    async def fail_init():
+        raise RuntimeError("database unavailable")
+
+    plugin._async_init = fail_init
+    await plugin._run_initialization()
+
+    assert plugin._lifecycle_status() == (
+        "failed",
+        "RuntimeError: database unavailable",
+    )
+    with pytest.raises(_HH.HTTPException) as exc_info:
+        await plugin._require_ready()
+    assert exc_info.value.status_code == 503
+    assert "database unavailable" in str(exc_info.value.detail)
+
+    payload = json.loads(await plugin._handle_tool("hh_status", {}))
+    assert payload["error_kind"] == "plugin_not_ready"
+    assert "database unavailable" in payload["error_message"]
 
 
 def test_plugin_registers_video_and_image_tools():

--- a/plugins/happyhorse-video/tests/test_task_manager.py
+++ b/plugins/happyhorse-video/tests/test_task_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -136,3 +137,57 @@ async def test_count_tasks(tm: HappyhorseTaskManager):
     await tm.create_task(mode="t2v")
     await tm.create_task(mode="i2v")
     assert await tm.count_tasks() == 3
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_initialization_and_leaves_manager_reusable(tmp_path: Path):
+    mgr = HappyhorseTaskManager(tmp_path / "lifecycle.db")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original = mgr._init_default_config
+
+    async def paused_init(connection):
+        entered.set()
+        await release.wait()
+        await original(connection)
+
+    mgr._init_default_config = paused_init
+    init_task = asyncio.create_task(mgr.init())
+    await entered.wait()
+    close_task = asyncio.create_task(mgr.close())
+    await asyncio.sleep(0)
+    assert not close_task.done()
+
+    release.set()
+    await asyncio.gather(init_task, close_task)
+    assert mgr._db is None
+
+    mgr._init_default_config = original
+    await mgr.init()
+    await mgr.set_config("api_key", "sk-recovered")
+    assert (await mgr.get_all_config())["api_key"] == "sk-recovered"
+    await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_initialization_closes_private_connection_and_can_retry(tmp_path: Path):
+    mgr = HappyhorseTaskManager(tmp_path / "cancelled-init.db")
+    entered = asyncio.Event()
+    original = mgr._init_default_config
+
+    async def blocked_init(connection):
+        entered.set()
+        await asyncio.Event().wait()
+
+    mgr._init_default_config = blocked_init
+    init_task = asyncio.create_task(mgr.init())
+    await entered.wait()
+    init_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await init_task
+    assert mgr._db is None
+
+    mgr._init_default_config = original
+    await mgr.init()
+    assert await mgr.get_all_config()
+    await mgr.close()

--- a/src/openakita/api/routes/plugins.py
+++ b/src/openakita/api/routes/plugins.py
@@ -379,7 +379,8 @@ async def list_plugins(request: Request) -> dict[str, Any]:
         # before install_source was tracked. Cheap (just a dir scan) and
         # idempotent — entries that already have install_source are skipped.
         _backfill_install_source_from_symlink(pm, plugins_dir)
-        await _sync_new_plugins(pm, plugins_dir)
+        async with _plugin_op_lock:
+            await _sync_new_plugins(pm, plugins_dir)
         plugins, failed = _build_plugin_list(pm, plugins_dir)
         return {"ok": True, "data": {"plugins": plugins, "failed": failed}}
     except Exception as e:
@@ -1239,10 +1240,11 @@ async def grant_permissions(
 ) -> dict[str, Any]:
     """Grant permissions to a plugin and optionally reload it."""
     _check_plugin_id(plugin_id)
-    pm = _require_manager(request)
-    pm.approve_permissions(plugin_id, body.permissions)
-    if body.reload:
-        await pm.reload_plugin(plugin_id)
+    async with _plugin_op_lock:
+        pm = _require_manager(request)
+        pm.approve_permissions(plugin_id, body.permissions)
+        if body.reload:
+            await pm.reload_plugin(plugin_id)
     from openakita.runtime_config_coordinator import get_runtime_config_coordinator
 
     runtime = get_runtime_config_coordinator(request).plugin_changed(
@@ -1263,10 +1265,11 @@ async def revoke_permissions(
 ) -> dict[str, Any]:
     """Revoke permissions from a plugin and optionally reload it."""
     _check_plugin_id(plugin_id)
-    pm = _require_manager(request)
-    pm.revoke_permissions(plugin_id, body.permissions)
-    if body.reload:
-        await pm.reload_plugin(plugin_id)
+    async with _plugin_op_lock:
+        pm = _require_manager(request)
+        pm.revoke_permissions(plugin_id, body.permissions)
+        if body.reload:
+            await pm.reload_plugin(plugin_id)
     from openakita.runtime_config_coordinator import get_runtime_config_coordinator
 
     runtime = get_runtime_config_coordinator(request).plugin_changed(

--- a/src/openakita/plugins/api.py
+++ b/src/openakita/plugins/api.py
@@ -1146,6 +1146,21 @@ class PluginAPI:
         except Exception as e:
             logger.debug("Plugin '%s' background task cancel error: %s", self._plugin_id, e)
 
+    async def stop_background_tasks(self) -> None:
+        """Stop framework-tracked tasks before plugin-owned resources are closed.
+
+        Plugin ``on_unload`` hooks commonly close SQLite connections and HTTP
+        clients used by tasks created through :meth:`spawn_task`.  Keeping this
+        phase separate from capability cleanup lets ``PluginManager`` establish
+        the required teardown order without removing routes or tools too early.
+        The operation is intentionally idempotent so :meth:`aclose` remains a
+        safe standalone cleanup entry point.
+        """
+        try:
+            await self._cancel_spawned_tasks()
+        except Exception as e:
+            logger.debug("Plugin '%s' task cancel error: %s", self._plugin_id, e)
+
     def list_spawned_tasks(self) -> list[dict[str, Any]]:
         """Diagnostics helper: snapshot of background tasks for this plugin."""
         out: list[dict[str, Any]] = []
@@ -1172,10 +1187,7 @@ class PluginAPI:
           2. Gracefully disconnect MCP subprocess (if any).
           3. Run the synchronous ``_cleanup`` for routes/tools/hooks/channels.
         """
-        try:
-            await self._cancel_spawned_tasks()
-        except Exception as e:
-            logger.debug("Plugin '%s' task cancel error: %s", self._plugin_id, e)
+        await self.stop_background_tasks()
         try:
             await self._aclose_mcp()
         except Exception as e:

--- a/src/openakita/plugins/manager.py
+++ b/src/openakita/plugins/manager.py
@@ -181,6 +181,16 @@ class PluginManager:
         # 问题崩溃，每次 load_all/auto-restart 都打一行长 traceback）。
         # 用户主动 ``reload_plugin`` 会重置该时间戳。
         self._failed_at: dict[str, float] = {}
+        # Lifecycle operations are serialized per plugin. Different plugins
+        # can still load/unload concurrently during startup and shutdown.
+        self._operation_locks: dict[str, asyncio.Lock] = {}
+
+    def _operation_lock(self, plugin_id: str) -> asyncio.Lock:
+        lock = self._operation_locks.get(plugin_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._operation_locks[plugin_id] = lock
+        return lock
 
     @staticmethod
     def _filter_host_refs(host_refs: dict[str, Any]) -> dict[str, Any]:
@@ -1306,12 +1316,13 @@ class PluginManager:
         collect_garbage: bool = True,
     ) -> bool:
         """Unload a plugin and invalidate policy classification when tools changed."""
-        changed, runtime_changed = await self._unload_plugin_runtime(
-            plugin_id,
-            collect_garbage=collect_garbage,
-        )
-        if runtime_changed:
-            self._invalidate_policy_classifier_cache(plugin_id)
+        async with self._operation_lock(plugin_id):
+            changed, runtime_changed = await self._unload_plugin_runtime(
+                plugin_id,
+                collect_garbage=collect_garbage,
+            )
+            if runtime_changed:
+                self._invalidate_policy_classifier_cache(plugin_id)
         return changed
 
     async def _unload_plugin_runtime(
@@ -1337,21 +1348,30 @@ class PluginManager:
             # let the caller know the operation actually changed state.
             return had_failure, False
 
-        # 1. Plugin's own on_unload — best effort, never blocks the rest.
+        # 1. Stop tracked tasks before the plugin closes their SQLite/HTTP
+        #    resources in on_unload. This ordering prevents an in-flight
+        #    initialization task from resuming against a closed connection.
+        try:
+            await loaded.api.stop_background_tasks()
+        except Exception as e:
+            logger.warning("Plugin '%s' background task stop error: %s", plugin_id, e)
+
+        # 2. Plugin's own on_unload — best effort, never blocks the rest.
         try:
             if loaded.instance:
                 await self._invoke_on_unload(loaded.instance, plugin_id)
         except (TimeoutError, Exception) as e:
             logger.warning("Plugin '%s' on_unload error: %s", plugin_id, e)
 
-        # 2. Cancel framework-tracked background tasks, then run async/sync
-        #    capability cleanup (routes, hooks, MCP, etc.) on the main loop.
+        # 3. Run remaining async/sync capability cleanup (routes, hooks, MCP,
+        #    etc.) on the main loop. Task stopping is idempotently repeated by
+        #    aclose for callers that use PluginAPI directly.
         try:
             await loaded.api.aclose()
         except Exception as e:
             logger.warning("Plugin '%s' aclose error: %s", plugin_id, e)
 
-        # 2b. Sweep up "stray" tasks the plugin scheduled itself — e.g.
+        # 4. Sweep up "stray" tasks the plugin scheduled itself — e.g.
         #     ``asyncio.get_event_loop().create_task(self._poll_loop())`` from
         #     on_load, which never went through ``api.spawn_task`` and is
         #     therefore invisible to ``_cancel_spawned_tasks``. We identify
@@ -1472,19 +1492,26 @@ class PluginManager:
             logger.debug("Plugin '%s' awaiting stray task cancellation: %s", plugin_id, e)
 
     async def disable_plugin(self, plugin_id: str, reason: str = "user") -> None:
-        self._state.disable(plugin_id, reason)
-        await self.unload_plugin(plugin_id)
-        self._save_state()
+        async with self._operation_lock(plugin_id):
+            self._state.disable(plugin_id, reason)
+            changed, runtime_changed = await self._unload_plugin_runtime(
+                plugin_id,
+                collect_garbage=True,
+            )
+            if changed and runtime_changed:
+                self._invalidate_policy_classifier_cache(plugin_id)
+            self._save_state()
 
     async def enable_plugin(self, plugin_id: str) -> None:
-        self._state.enable(plugin_id)
-        self._error_tracker.reset(plugin_id)
-        self._save_state()
-        if plugin_id not in self._loaded:
-            try:
-                await self.reload_plugin(plugin_id)
-            except Exception as e:
-                logger.warning("Failed to auto-reload plugin '%s' on enable: %s", plugin_id, e)
+        async with self._operation_lock(plugin_id):
+            self._state.enable(plugin_id)
+            self._error_tracker.reset(plugin_id)
+            self._save_state()
+            if plugin_id not in self._loaded:
+                try:
+                    await self._reload_plugin_runtime(plugin_id)
+                except Exception as e:
+                    logger.warning("Failed to auto-reload plugin '%s' on enable: %s", plugin_id, e)
 
     def _on_plugin_auto_disabled(self, plugin_id: str) -> None:
         """Callback when PluginErrorTracker auto-disables a plugin.
@@ -1613,6 +1640,11 @@ class PluginManager:
 
     async def reload_plugin(self, plugin_id: str) -> None:
         """Unload then re-load a plugin (e.g. after granting new permissions)."""
+        async with self._operation_lock(plugin_id):
+            await self._reload_plugin_runtime(plugin_id)
+
+    async def _reload_plugin_runtime(self, plugin_id: str) -> None:
+        """Reload one plugin while its per-plugin operation lock is held."""
         loaded = self._loaded.get(plugin_id)
         if loaded is not None:
             plugin_dir = loaded.plugin_dir
@@ -1788,9 +1820,7 @@ class PluginManager:
                     )
                     return False
                 except Exception as exc:  # noqa: BLE001 -- shutdown must never raise
-                    logger.warning(
-                        "[Shutdown] Plugin '%s' unload failed: %s", pid, exc
-                    )
+                    logger.warning("[Shutdown] Plugin '%s' unload failed: %s", pid, exc)
                     return False
 
         results = await asyncio.gather(*[_one(pid) for pid in plugin_ids])
@@ -1836,7 +1866,6 @@ class PluginManager:
         all_lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
         tail = all_lines[-lines:]
         return "\n".join(tail)
-
 
     def _maybe_warn_on_source_drift(self) -> None:
         """Emit WARN logs if ``plugins/`` is newer than ``data/plugins/``.

--- a/src/openakita/plugins/manager.py
+++ b/src/openakita/plugins/manager.py
@@ -1509,7 +1509,9 @@ class PluginManager:
             self._save_state()
             if plugin_id not in self._loaded:
                 try:
-                    await self._reload_plugin_runtime(plugin_id)
+                    runtime_changed = await self._reload_plugin_runtime(plugin_id)
+                    if runtime_changed:
+                        self._invalidate_policy_classifier_cache(plugin_id)
                 except Exception as e:
                     logger.warning("Failed to auto-reload plugin '%s' on enable: %s", plugin_id, e)
 
@@ -1641,9 +1643,11 @@ class PluginManager:
     async def reload_plugin(self, plugin_id: str) -> None:
         """Unload then re-load a plugin (e.g. after granting new permissions)."""
         async with self._operation_lock(plugin_id):
-            await self._reload_plugin_runtime(plugin_id)
+            runtime_changed = await self._reload_plugin_runtime(plugin_id)
+            if runtime_changed:
+                self._invalidate_policy_classifier_cache(plugin_id)
 
-    async def _reload_plugin_runtime(self, plugin_id: str) -> None:
+    async def _reload_plugin_runtime(self, plugin_id: str) -> bool:
         """Reload one plugin while its per-plugin operation lock is held."""
         loaded = self._loaded.get(plugin_id)
         if loaded is not None:
@@ -1654,12 +1658,12 @@ class PluginManager:
             plugin_dir = self._find_plugin_dir(plugin_id)
             if plugin_dir is None:
                 logger.warning("Cannot reload '%s': plugin dir not found", plugin_id)
-                return
+                return False
             try:
                 manifest = parse_manifest(plugin_dir)
             except ManifestError as e:
                 logger.error("Cannot reload '%s': %s", plugin_id, e)
-                return
+                return False
 
         self._failed.pop(plugin_id, None)
         # 用户主动 reload 视作"想再试一次"，清除失败冷却时间戳。
@@ -1675,10 +1679,8 @@ class PluginManager:
             logger.error("Plugin '%s' reload failed: %s", plugin_id, msg)
             self._failed[plugin_id] = msg
             self._failed_at[plugin_id] = time.monotonic()
-        # One invalidation covers both removal of the old registrations and
-        # publication of the new ones, including a failed reload.
-        self._invalidate_policy_classifier_cache(plugin_id)
         self._save_state()
+        return True
 
     def _unmount_plugin_ui(self, plugin_id: str) -> None:
         """Remove the plugin UI static-file mount from the FastAPI app."""

--- a/src/openakita/runtime_config_coordinator.py
+++ b/src/openakita/runtime_config_coordinator.py
@@ -84,12 +84,31 @@ class RuntimeConfigCoordinator:
     def __init__(self, app_state: Any):
         self._state = app_state
 
-    def _agent_pools(self) -> list[tuple[str, Any]]:
+    @staticmethod
+    def _supports_pool_invalidation(pool: Any, *, profile_id: str | None) -> bool:
+        if profile_id is not None and hasattr(pool, "invalidate_profile"):
+            return True
+        return hasattr(pool, "notify_runtime_config_changed") or hasattr(
+            pool, "notify_skills_changed"
+        )
+
+    def _agent_pools(self, *, profile_id: str | None = None) -> list[tuple[str, Any]]:
         pools: list[tuple[str, Any]] = []
         seen: set[int] = set()
         for name in ("agent_pool", "orchestrator"):
             owner = getattr(self._state, name, None)
-            pool = getattr(owner, "_pool", owner)
+            if owner is None:
+                continue
+
+            if self._supports_pool_invalidation(owner, profile_id=profile_id):
+                pool = owner
+            elif hasattr(owner, "_pool"):
+                pool = owner._pool
+                if pool is None:
+                    # Lazy pool owners have no cached agent instances before initialization.
+                    continue
+            else:
+                pool = owner
             if pool is None or id(pool) in seen:
                 continue
             seen.add(id(pool))
@@ -121,7 +140,7 @@ class RuntimeConfigCoordinator:
         names: set[str] | None = None,
     ) -> RuntimeApplyResult:
         result = RuntimeApplyResult(apply_mode=ConfigApplyMode.NEXT_TASK)
-        for name, pool in self._agent_pools():
+        for name, pool in self._agent_pools(profile_id=profile_id):
             if names is not None and name not in names:
                 continue
             try:

--- a/tests/unit/test_plugins/test_manager.py
+++ b/tests/unit/test_plugins/test_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import textwrap
 
@@ -239,6 +240,87 @@ class TestUnload:
         mgr = PluginManager(plugins_dir, state_path=tmp_path / "state.json")
         result = await mgr.unload_plugin("ghost")
         assert result is False
+
+    async def test_unload_stops_spawned_tasks_before_on_unload(self, tmp_path):
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        plugin_dir = _make_plugin_dir(plugins_dir, "ordered-unload")
+        (plugin_dir / "plugin.py").write_text(
+            textwrap.dedent("""\
+                import asyncio
+                from openakita.plugins.api import PluginAPI, PluginBase
+
+                class Plugin(PluginBase):
+                    def on_load(self, api: PluginAPI) -> None:
+                        self.worker_cancelled = False
+                        self.unload_saw_cancelled = False
+                        api.spawn_task(self._initialize(), name="ordered-unload:init")
+
+                    async def _initialize(self) -> None:
+                        try:
+                            await asyncio.sleep(60)
+                        except asyncio.CancelledError:
+                            self.worker_cancelled = True
+                            raise
+
+                    async def on_unload(self) -> None:
+                        self.unload_saw_cancelled = self.worker_cancelled
+            """),
+            encoding="utf-8",
+        )
+        mgr = PluginManager(plugins_dir, state_path=tmp_path / "state.json")
+        await mgr.load_all()
+        loaded = mgr.get_loaded("ordered-unload")
+        assert loaded is not None
+        await asyncio.sleep(0)
+
+        await mgr.unload_plugin("ordered-unload")
+
+        assert loaded.instance is not None
+        assert loaded.instance.unload_saw_cancelled is True
+
+
+class TestOperationSerialization:
+    async def test_concurrent_reloads_of_same_plugin_are_serialized(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        mgr = PluginManager(plugins_dir, state_path=tmp_path / "state.json")
+        active = 0
+        maximum = 0
+
+        async def fake_reload(plugin_id: str) -> None:
+            nonlocal active, maximum
+            assert plugin_id == "demo"
+            active += 1
+            maximum = max(maximum, active)
+            await asyncio.sleep(0.02)
+            active -= 1
+
+        monkeypatch.setattr(mgr, "_reload_plugin_runtime", fake_reload)
+
+        await asyncio.gather(mgr.reload_plugin("demo"), mgr.reload_plugin("demo"))
+
+        assert maximum == 1
+
+    async def test_different_plugins_do_not_share_lifecycle_lock(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        mgr = PluginManager(plugins_dir, state_path=tmp_path / "state.json")
+        both_running = asyncio.Event()
+        active: set[str] = set()
+
+        async def fake_reload(plugin_id: str) -> None:
+            active.add(plugin_id)
+            if len(active) == 2:
+                both_running.set()
+            await asyncio.wait_for(both_running.wait(), timeout=1)
+            active.remove(plugin_id)
+
+        monkeypatch.setattr(mgr, "_reload_plugin_runtime", fake_reload)
+
+        await asyncio.gather(mgr.reload_plugin("one"), mgr.reload_plugin("two"))
+
+        assert both_running.is_set()
 
 
 # ---------- disable ----------

--- a/tests/unit/test_runtime_config_coordinator.py
+++ b/tests/unit/test_runtime_config_coordinator.py
@@ -37,6 +37,48 @@ def test_invalidate_agent_pools_covers_desktop_and_orchestrator() -> None:
     assert orchestrator.reasons == ["identity"]
 
 
+def test_real_agent_pool_is_not_unwrapped_to_its_internal_entry_dict() -> None:
+    from openakita.agents.factory import AgentInstancePool
+    from openakita.runtime_config_coordinator import RuntimeConfigCoordinator
+
+    pool = AgentInstancePool()
+    assert isinstance(pool._pool, dict)
+
+    result = RuntimeConfigCoordinator(SimpleNamespace(agent_pool=pool)).plugin_changed(
+        "demo",
+        "installed",
+    )
+
+    assert result.warnings == []
+    assert result.invalidated == ["agent_pool"]
+    assert pool._runtime_config_version == 1
+
+
+def test_uninitialized_lazy_orchestrator_pool_is_skipped_without_warning() -> None:
+    from openakita.runtime_config_coordinator import RuntimeConfigCoordinator
+
+    state = SimpleNamespace(
+        agent_pool=_Pool(),
+        orchestrator=SimpleNamespace(_pool=None),
+    )
+
+    result = RuntimeConfigCoordinator(state).plugin_changed("demo", "installed")
+
+    assert result.warnings == []
+    assert result.invalidated == ["agent_pool"]
+
+
+def test_initialized_unsupported_orchestrator_pool_still_warns() -> None:
+    from openakita.runtime_config_coordinator import RuntimeConfigCoordinator
+
+    state = SimpleNamespace(orchestrator=SimpleNamespace(_pool=object()))
+
+    result = RuntimeConfigCoordinator(state).plugin_changed("demo", "installed")
+
+    assert result.warnings == ["orchestrator: pool invalidation is not supported"]
+    assert result.invalidated == []
+
+
 def test_pool_invalidation_runs_in_registered_engine_thread() -> None:
     from openakita.core import engine_bridge
     from openakita.runtime_config_coordinator import RuntimeConfigCoordinator


### PR DESCRIPTION
## Summary

- Stop framework-tracked plugin tasks before plugin-owned teardown and serialize lifecycle operations per plugin.
- Make HappyHorse initialization cancellation-safe, expose readiness to routes and tools, and report initialization failures consistently.
- Resolve runtime agent pool invalidation by capability while skipping uninitialized lazy pools.

## Tests

- `uv run --no-sync pytest -q tests/unit/test_plugins plugins/happyhorse-video/tests tests/unit/test_plugin_config_lifecycle.py tests/unit/test_plugin_health.py tests/unit/test_plugin_manifest_capability.py tests/unit/test_plugin_open_folder_route.py tests/unit/test_plugin_reseed.py tests/unit/test_api_config_runtime_state.py tests/unit/test_agent_instance_pool_runtime_config.py tests/unit/test_agent_profile_runtime_lifecycle.py tests/unit/test_mcp_config_lifecycle.py tests/unit/test_runtime_config_coordinator.py tests/unit/test_runtime_operation_response.py tests/unit/test_policy_v2_c10_mutates_audit.py` (`552 passed, 1 skipped`)
- Ruff lint and format checks passed for all changed files.
- `git diff --check`

Fixes #792
