### PR TITLE
localize the organization template picker so its controls follow the selected interface language

### DIFF
--- a/apps/setup-center/src/components/TemplatePickerDialog.tsx
+++ b/apps/setup-center/src/components/TemplatePickerDialog.tsx
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import {
   Dialog,
@@ -61,6 +62,7 @@ export function TemplatePickerDialog({
   onCreated,
   children,
 }: TemplatePickerDialogProps) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [templates, setTemplates] = useState<TemplateWire[]>([]);
   const [loading, setLoading] = useState(false);
@@ -97,11 +99,11 @@ export function TemplatePickerDialog({
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      setError(`无法加载组织模板：${msg}（灰度未启用时是正常的）`);
+      setError(t("org.templatePicker.loadError", { error: msg }));
     } finally {
       setLoading(false);
     }
-  }, [apiBase, selectedId]);
+  }, [apiBase, selectedId, t]);
 
   useEffect(() => {
     if (open) {
@@ -126,22 +128,22 @@ export function TemplatePickerDialog({
       setName("");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      setError(`实例化失败：${msg}`);
+      setError(t("org.templatePicker.createError", { error: msg }));
     } finally {
       setSubmitting(false);
     }
-  }, [apiBase, selectedId, name, onCreated]);
+  }, [apiBase, selectedId, name, onCreated, t]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        {children ?? <Button variant="outline">新建组织</Button>}
+        {children ?? <Button variant="outline">{t("org.templatePicker.trigger")}</Button>}
       </DialogTrigger>
       <DialogContent className="sm:max-w-[560px]" data-testid="v2-template-dialog">
         <DialogHeader>
-          <DialogTitle>选择组织模板</DialogTitle>
+          <DialogTitle>{t("org.templatePicker.title")}</DialogTitle>
           <DialogDescription>
-            从内置模板克隆一份新的组织。点选模板，输入组织名称后即可创建。
+            {t("org.templatePicker.description")}
           </DialogDescription>
         </DialogHeader>
 
@@ -149,7 +151,7 @@ export function TemplatePickerDialog({
           {loading && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
-              <span>加载模板中…</span>
+              <span>{t("org.templatePicker.loading")}</span>
             </div>
           )}
 
@@ -164,7 +166,7 @@ export function TemplatePickerDialog({
 
           {!loading && templates.length === 0 && !error && (
             <div className="text-sm text-muted-foreground">
-              暂无可用模板。请确认后端已启用 ``settings.runtime_v2_enabled``。
+              {t("org.templatePicker.empty")}
             </div>
           )}
 
@@ -173,14 +175,14 @@ export function TemplatePickerDialog({
               className="space-y-2 max-h-[42vh] overflow-y-auto px-1 py-1"
               data-testid="v2-template-dialog-list"
             >
-              {templates.map((t) => {
-                const isSelected = selectedId === t.id;
+              {templates.map((template) => {
+                const isSelected = selectedId === template.id;
                 return (
-                  <li key={t.id}>
+                  <li key={template.id}>
                     <button
                       type="button"
-                      onClick={() => setSelectedId(t.id)}
-                      data-testid={`v2-template-card-${t.id}`}
+                      onClick={() => setSelectedId(template.id)}
+                      data-testid={`v2-template-card-${template.id}`}
                       data-selected={isSelected ? "true" : "false"}
                       className={
                         "w-full text-left rounded-md border px-3 py-2 transition " +
@@ -190,20 +192,20 @@ export function TemplatePickerDialog({
                       }
                     >
                       <div className="font-medium text-sm flex items-center gap-2">
-                        <span>{t.name || t.id}</span>
+                        <span>{template.name || template.id}</span>
                         {isSelected && (
                           <span className="text-[10px] font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
-                            已选中
+                            {t("org.templatePicker.selected")}
                           </span>
                         )}
                       </div>
-                      {t.description && (
+                      {template.description && (
                         <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                          {t.description}
+                          {template.description}
                         </div>
                       )}
                       <div className="text-[11px] text-muted-foreground mt-1">
-                        节点 {t.node_count}
+                        {t("org.templatePicker.nodeCount", { count: template.node_count })}
                       </div>
                     </button>
                   </li>
@@ -214,14 +216,14 @@ export function TemplatePickerDialog({
 
           <div className="space-y-1">
             <label className="text-xs font-medium" htmlFor="tpd-org-name">
-              新组织名称
+              {t("org.templatePicker.nameLabel")}
             </label>
             <input
               id="tpd-org-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="例如：Acme 编辑部"
+              placeholder={t("org.templatePicker.namePlaceholder")}
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
@@ -230,7 +232,7 @@ export function TemplatePickerDialog({
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="ghost" disabled={submitting}>
-              取消
+              {t("common.cancel")}
             </Button>
           </DialogClose>
           <Button
@@ -239,7 +241,7 @@ export function TemplatePickerDialog({
             data-testid="v2-template-dialog-create"
           >
             {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            创建组织
+            {t("org.templatePicker.create")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/setup-center/src/components/__tests__/TemplatePickerDialog.test.tsx
+++ b/apps/setup-center/src/components/__tests__/TemplatePickerDialog.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, act, fireEvent } from "@testing-library/react";
+import i18n from "../../i18n";
 
 // Mock the API module so the dialog never hits the network. The
 // mocked listTemplates returns 2 templates; instantiateTemplate
@@ -44,6 +45,10 @@ import * as orgsApi from "../../api/orgs";
 import { TemplatePickerDialog } from "../TemplatePickerDialog";
 
 describe("TemplatePickerDialog", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
   it("opens, lists templates, and POSTs on create", async () => {
     const onCreated = vi.fn();
     render(
@@ -53,7 +58,7 @@ describe("TemplatePickerDialog", () => {
     );
 
     // 1. Modal is closed initially — no template list.
-    expect(screen.queryByText(/选择 v2 组织模板/)).toBeNull();
+    expect(screen.queryByText("Choose an org template")).toBeNull();
 
     // 2. Click trigger → modal opens, listTemplates called.
     await act(async () => {
@@ -64,6 +69,9 @@ describe("TemplatePickerDialog", () => {
     await act(async () => {
       await Promise.resolve();
     });
+    expect(screen.getByText("Choose an org template")).toBeInTheDocument();
+    expect(screen.getByText("Selected")).toBeInTheDocument();
+    expect(screen.getByText("2 nodes")).toBeInTheDocument();
     expect(screen.getByText("Newsroom")).toBeInTheDocument();
     expect(screen.getByText("Solo Writer")).toBeInTheDocument();
 
@@ -78,11 +86,11 @@ describe("TemplatePickerDialog", () => {
     expect(screen.getByTestId("v2-template-card-tpl_b").getAttribute("data-selected")).toBe("true");
     expect(screen.getByTestId("v2-template-card-tpl_a").getAttribute("data-selected")).toBe("false");
 
-    // 5. Switch back to tpl_a, then type name and click “创建组织”.
+    // 5. Switch back to tpl_a, then type a name and create the org.
     await act(async () => {
       fireEvent.click(screen.getByTestId("v2-template-card-tpl_a"));
     });
-    const input = screen.getByLabelText(/新组织名称/) as HTMLInputElement;
+    const input = screen.getByLabelText("New org name") as HTMLInputElement;
     await act(async () => {
       fireEvent.change(input, { target: { value: "试验编辑部" } });
     });
@@ -121,5 +129,29 @@ describe("TemplatePickerDialog", () => {
     const createBtn = screen.getByTestId("v2-template-dialog-create") as HTMLButtonElement;
     // Auto-selected first template, but name empty → still disabled.
     expect(createBtn.disabled).toBe(true);
+  });
+
+  it("renders the dialog chrome in Chinese when Chinese is selected", async () => {
+    await i18n.changeLanguage("zh");
+    render(
+      <TemplatePickerDialog apiBase="http://test" onCreated={() => {}}>
+        <button data-testid="trigger-zh">open</button>
+      </TemplatePickerDialog>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-zh"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("选择组织模板")).toBeInTheDocument();
+    expect(screen.getByText("已选中")).toBeInTheDocument();
+    expect(screen.getByText("2 个节点")).toBeInTheDocument();
+    expect(screen.getByLabelText("新组织名称")).toHaveAttribute(
+      "placeholder",
+      "例如：Acme 编辑部",
+    );
+    expect(screen.getByRole("button", { name: "取消" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "创建组织" })).toBeInTheDocument();
   });
 });

--- a/apps/setup-center/src/i18n/en.json
+++ b/apps/setup-center/src/i18n/en.json
@@ -2944,6 +2944,20 @@
     "llmEndpointsDesc": "Model endpoint status and health checks"
   },
   "org": {
+    "templatePicker": {
+      "trigger": "New org",
+      "title": "Choose an org template",
+      "description": "Create a new org from a built-in template. Select a template and enter an org name to continue.",
+      "loading": "Loading templates…",
+      "loadError": "Unable to load org templates: {{error}}",
+      "createError": "Unable to create org: {{error}}",
+      "empty": "No org templates are available.",
+      "selected": "Selected",
+      "nodeCount": "{{count}} nodes",
+      "nameLabel": "New org name",
+      "namePlaceholder": "For example: Acme Editorial",
+      "create": "Create org"
+    },
     "taskStatus": {
       "todo": "To Do",
       "inProgress": "In Progress",

--- a/apps/setup-center/src/i18n/zh.json
+++ b/apps/setup-center/src/i18n/zh.json
@@ -2944,6 +2944,20 @@
     "llmEndpointsDesc": "模型端点状态与健康检查"
   },
   "org": {
+    "templatePicker": {
+      "trigger": "新建组织",
+      "title": "选择组织模板",
+      "description": "从内置模板创建一个新组织。选择模板并输入组织名称后即可继续。",
+      "loading": "加载模板中…",
+      "loadError": "无法加载组织模板：{{error}}",
+      "createError": "无法创建组织：{{error}}",
+      "empty": "暂无可用的组织模板。",
+      "selected": "已选中",
+      "nodeCount": "{{count}} 个节点",
+      "nameLabel": "新组织名称",
+      "namePlaceholder": "例如：Acme 编辑部",
+      "create": "创建组织"
+    },
     "taskStatus": {
       "todo": "待办",
       "inProgress": "进行中",


### PR DESCRIPTION
## Summary

- Localize all user-facing controls and status messages in the organization template picker.
- Add English and Chinese coverage so the dialog follows the selected interface language.

## Tests

- `npm run test:run -- src/components/__tests__/TemplatePickerDialog.test.tsx`
- `npm run build`
- `git diff --check`
