### PR TITLE
Fix desktop drag-and-drop attachment uploads

### DIFF
--- a/apps/setup-center/src-tauri/Cargo.lock
+++ b/apps/setup-center/src-tauri/Cargo.lock
@@ -2505,6 +2505,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3755,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -5538,6 +5549,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/apps/setup-center/src-tauri/Cargo.toml
+++ b/apps/setup-center/src-tauri/Cargo.toml
@@ -24,7 +24,7 @@ tauri-plugin-http = { version = "2", default-features = false, features = ["rust
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs-next = "2.0.0"
-reqwest = { version = "0.12.12", features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12.12", features = ["blocking", "json", "multipart", "rustls-tls"] }
 flate2 = "1.0.35"
 tar = "0.4.41"
 zip = "2.2.2"

--- a/apps/setup-center/src-tauri/src/commands.rs
+++ b/apps/setup-center/src-tauri/src/commands.rs
@@ -73,6 +73,7 @@ pub(crate) fn invoke_handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> boo
         backend_fetch,
         backend_fetch_cancel,
         get_local_file_info,
+        upload_local_file,
         read_file_base64,
         download_file,
         copy_file_to_downloads,

--- a/apps/setup-center/src-tauri/src/network.rs
+++ b/apps/setup-center/src-tauri/src/network.rs
@@ -467,6 +467,41 @@ pub(crate) struct LocalFileReadProgress {
     total: u64,
 }
 
+struct ProgressReader<R, F> {
+    inner: R,
+    loaded: u64,
+    total: u64,
+    on_progress: F,
+}
+
+impl<R, F> ProgressReader<R, F> {
+    fn new(inner: R, total: u64, on_progress: F) -> Self {
+        Self {
+            inner,
+            loaded: 0,
+            total,
+            on_progress,
+        }
+    }
+}
+
+impl<R: Read, F: FnMut(u64, u64)> Read for ProgressReader<R, F> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.inner.read(buf)?;
+        if read > 0 {
+            self.loaded = self.loaded.saturating_add(read as u64);
+            (self.on_progress)(self.loaded, self.total);
+        }
+        Ok(read)
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct LocalFileUploadResponse {
+    status: u16,
+    body: String,
+}
+
 /// Return local file metadata without reading the file contents.
 /// Used by drag/drop handling to reject or route large files before they can
 /// exhaust WebView memory.
@@ -479,6 +514,78 @@ pub(crate) fn get_local_file_info(path: String) -> Result<LocalFileInfo, String>
         is_file: meta.is_file(),
         is_directory: meta.is_dir(),
     })
+}
+
+/// Stream a Tauri-native dropped path to the regular upload endpoint.
+///
+/// Browser and mobile callers already receive a `File` and use multipart fetch
+/// directly. Native drag/drop only provides a filesystem path, so this adapter
+/// keeps bytes out of the WebView while preserving the same `/api/upload`
+/// response contract for the shared chat UI.
+#[tauri::command]
+pub(crate) async fn upload_local_file(
+    path: String,
+    url: String,
+    filename: String,
+    mime_type: Option<String>,
+    authorization: Option<String>,
+    on_progress: tauri::ipc::Channel<LocalFileReadProgress>,
+) -> Result<LocalFileUploadResponse, String> {
+    spawn_blocking_result(move || {
+        let parsed_url =
+            reqwest::Url::parse(&url).map_err(|e| format!("Invalid upload URL: {e}"))?;
+        if !matches!(parsed_url.scheme(), "http" | "https") {
+            return Err("Upload URL must use HTTP or HTTPS".to_string());
+        }
+
+        let file_path = PathBuf::from(&path);
+        let metadata = fs::metadata(&file_path)
+            .map_err(|e| format!("Failed to stat {}: {e}", file_path.display()))?;
+        if !metadata.is_file() {
+            return Err(format!("Not a file: {}", file_path.display()));
+        }
+        let total = metadata.len();
+        let file = fs::File::open(&file_path)
+            .map_err(|e| format!("Failed to open {}: {e}", file_path.display()))?;
+        let progress_channel = on_progress.clone();
+        let _ = on_progress.send(LocalFileReadProgress { loaded: 0, total });
+        let reader = ProgressReader::new(file, total, move |loaded, total| {
+            let _ = progress_channel.send(LocalFileReadProgress { loaded, total });
+        });
+
+        let mut part = reqwest::blocking::multipart::Part::reader_with_length(reader, total)
+            .file_name(filename);
+        if let Some(candidate) = mime_type.filter(|value| !value.trim().is_empty()) {
+            part = part
+                .mime_str(&candidate)
+                .map_err(|e| format!("Invalid attachment MIME type: {e}"))?;
+        }
+        let form = reqwest::blocking::multipart::Form::new().part("file", part);
+
+        let host = parsed_url.host_str().unwrap_or_default();
+        let mut client_builder = reqwest::blocking::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(15 * 60));
+        if matches!(host, "localhost" | "127.0.0.1" | "::1") {
+            client_builder = client_builder.no_proxy();
+        }
+        let client = client_builder
+            .build()
+            .map_err(|e| format!("HTTP client error: {e}"))?;
+        let mut request = client.post(parsed_url).multipart(form);
+        if let Some(token) = authorization.filter(|value| !value.trim().is_empty()) {
+            request = request.bearer_auth(token);
+        }
+        let response = request
+            .send()
+            .map_err(|e| format!("Local file upload failed: {e}"))?;
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .map_err(|e| format!("Failed to read upload response: {e}"))?;
+        Ok(LocalFileUploadResponse { status, body })
+    })
+    .await
 }
 
 /// Read a file from disk and return its contents as a base64 data-URL.
@@ -834,5 +941,34 @@ mod tests {
         let mut buf = vec![0xE4, 0xBB];
         assert_eq!(take_valid_utf8_prefix(&mut buf), "");
         assert_eq!(String::from_utf8_lossy(&buf), "\u{FFFD}");
+    }
+
+    #[test]
+    fn progress_reader_streams_bytes_and_reports_cumulative_progress() {
+        let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = updates.clone();
+        let input = b"streamed attachment".to_vec();
+        let total = input.len() as u64;
+        let mut reader = ProgressReader::new(
+            std::io::Cursor::new(input.clone()),
+            total,
+            move |loaded, total| {
+                captured.lock().unwrap().push((loaded, total));
+            },
+        );
+        let mut output = Vec::new();
+        let mut chunk = [0_u8; 4];
+        loop {
+            let read = reader.read(&mut chunk).unwrap();
+            if read == 0 {
+                break;
+            }
+            output.extend_from_slice(&chunk[..read]);
+        }
+
+        assert_eq!(output, input);
+        let updates = updates.lock().unwrap();
+        assert!(updates.len() > 1);
+        assert_eq!(updates.last(), Some(&(total, total)));
     }
 }

--- a/apps/setup-center/src/__tests__/providers.safeFetch.test.ts
+++ b/apps/setup-center/src/__tests__/providers.safeFetch.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("../platform", () => ({
+  IS_TAURI: false,
+  proxyFetch: vi.fn(),
+}));
+vi.mock("../platform/auth", () => ({
+  authFetch,
+  isTauriRemoteMode: () => false,
+}));
+
+import { safeFetch, safeFetchResponse } from "../providers";
+
+describe("safeFetchResponse", () => {
+  beforeEach(() => authFetch.mockReset());
+
+  it("preserves validation responses for callers that classify HTTP errors", async () => {
+    authFetch.mockResolvedValue(new Response(JSON.stringify({
+      error: "unverified attachment local_path",
+      message: "unverified attachment local_path",
+    }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const response = await safeFetchResponse("http://127.0.0.1:18900/api/chat");
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: "unverified attachment local_path",
+    });
+  });
+
+  it("keeps the existing throwing safeFetch contract", async () => {
+    authFetch.mockResolvedValue(new Response(JSON.stringify({ detail: "forbidden" }), {
+      status: 403,
+    }));
+
+    await expect(safeFetch("http://127.0.0.1:18900/api/chat")).rejects.toThrow("forbidden");
+  });
+});

--- a/apps/setup-center/src/platform/__tests__/localFileUpload.test.ts
+++ b/apps/setup-center/src/platform/__tests__/localFileUpload.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class Channel<T> {
+    onmessage: (payload: T) => void = () => {};
+  }
+  return {
+    Channel,
+    invoke: vi.fn(),
+  };
+});
+
+vi.mock("../detect", () => ({
+  IS_TAURI: true,
+  IS_WEB: false,
+  IS_CAPACITOR: false,
+  IS_LOCAL_WEB: false,
+  IS_MOBILE_BROWSER: false,
+}));
+vi.mock("../auth", () => ({ getAccessToken: () => "desktop-remote-token" }));
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: mocks.Channel,
+  invoke: mocks.invoke,
+}));
+
+import { uploadLocalFile } from "../index";
+
+describe("uploadLocalFile", () => {
+  beforeEach(() => mocks.invoke.mockReset());
+
+  it("returns the regular backend upload contract", async () => {
+    mocks.invoke.mockResolvedValue({
+      status: 200,
+      body: JSON.stringify({
+        url: "/api/uploads/staged.pdf",
+        upload_id: "staged.pdf",
+        local_path: "C:/openakita/uploads/staged.pdf",
+        size: 42,
+        mime_type: "application/pdf",
+      }),
+    });
+
+    const uploaded = await uploadLocalFile(
+      "D:/docs/report.pdf",
+      "http://127.0.0.1:18900/api/upload",
+      "report.pdf",
+      "application/pdf",
+    );
+
+    expect(uploaded).toEqual({
+      url: "/api/uploads/staged.pdf",
+      uploadId: "staged.pdf",
+      localPath: "C:/openakita/uploads/staged.pdf",
+      size: 42,
+      mimeType: "application/pdf",
+    });
+    expect(mocks.invoke).toHaveBeenCalledWith("upload_local_file", expect.objectContaining({
+      path: "D:/docs/report.pdf",
+      authorization: "desktop-remote-token",
+    }));
+  });
+
+  it("surfaces structured backend upload failures", async () => {
+    mocks.invoke.mockResolvedValue({
+      status: 413,
+      body: JSON.stringify({ detail: "referenced file exceeds 50 MB" }),
+    });
+
+    await expect(uploadLocalFile(
+      "D:/docs/large.pdf",
+      "http://127.0.0.1:18900/api/upload",
+      "large.pdf",
+    )).rejects.toThrow("referenced file exceeds 50 MB");
+  });
+});

--- a/apps/setup-center/src/platform/index.ts
+++ b/apps/setup-center/src/platform/index.ts
@@ -4,6 +4,7 @@
 // bundled into the web build and never evaluated when running in a browser.
 
 import { IS_TAURI, IS_WEB, IS_CAPACITOR, IS_LOCAL_WEB, IS_MOBILE_BROWSER } from "./detect";
+import { getAccessToken } from "./auth";
 export { IS_TAURI, IS_WEB, IS_CAPACITOR, IS_LOCAL_WEB, IS_MOBILE_BROWSER };
 
 // ---------------------------------------------------------------------------
@@ -187,6 +188,78 @@ export async function getLocalFileInfo(path: string): Promise<LocalFileInfo> {
     size: info.size,
     isFile: info.is_file,
     isDirectory: info.is_directory,
+  };
+}
+
+export type StagedAttachmentUpload = {
+  url: string;
+  localPath?: string;
+  uploadId: string;
+  size?: number;
+  mimeType?: string;
+};
+
+/**
+ * Stream a Tauri-native filesystem path to the normal backend upload route.
+ * Web and mobile callers already have File/Blob objects and should keep using
+ * multipart fetch directly.
+ */
+export async function uploadLocalFile(
+  path: string,
+  url: string,
+  filename: string,
+  mimeType?: string,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<StagedAttachmentUpload> {
+  if (!IS_TAURI)
+    throw new Error("uploadLocalFile is only available in Tauri");
+  const { Channel, invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+  const progress = new Channel<{
+    loaded: number;
+    total: number;
+  }>();
+  progress.onmessage = onProgress
+    ? (payload) => onProgress(payload.loaded, payload.total)
+    : () => {};
+  const response = await tauriInvoke<{ status: number; body: string }>("upload_local_file", {
+    path,
+    url,
+    filename,
+    mimeType,
+    authorization: getAccessToken(),
+    onProgress: progress,
+  });
+
+  let payload: Record<string, unknown> | null = null;
+  try {
+    payload = JSON.parse(response.body) as Record<string, unknown>;
+  } catch {
+    // Preserve the response text below when the backend did not return JSON.
+  }
+  if (response.status < 200 || response.status >= 300) {
+    const detail = payload?.detail;
+    const message = typeof detail === "string"
+      ? detail
+      : typeof payload?.message === "string"
+        ? payload.message
+        : typeof payload?.error === "string"
+          ? payload.error
+          : response.body.slice(0, 200) || `Upload failed: ${response.status}`;
+    throw new Error(message);
+  }
+  if (!payload || typeof payload.url !== "string" || typeof payload.upload_id !== "string") {
+    throw new Error("Upload response is missing url or upload_id");
+  }
+  return {
+    url: payload.url,
+    localPath: typeof payload.local_path === "string" ? payload.local_path : undefined,
+    uploadId: payload.upload_id,
+    size: typeof payload.size === "number" ? payload.size : undefined,
+    mimeType: typeof payload.mime_type === "string"
+      ? payload.mime_type
+      : typeof payload.content_type === "string"
+        ? payload.content_type
+        : undefined,
   };
 }
 

--- a/apps/setup-center/src/providers.ts
+++ b/apps/setup-center/src/providers.ts
@@ -322,12 +322,8 @@ export async function fetchModelsDirectly(params: {
   return [...routerModels, ...apiModels];
 }
 
-/**
- * fetch wrapper: 在 HTTP 4xx/5xx 时自动抛异常（原生 fetch 只在网络错误时才抛）。
- * 所有对后端 API 的调用都应使用此函数，以确保错误被正确捕获。
- * Web 模式下自动携带 JWT token 并支持静默续期。
- */
-export async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
+/** Auth-aware fetch that preserves HTTP error responses for status-aware callers. */
+export async function safeFetchResponse(url: string, init?: RequestInit): Promise<Response> {
   const effectiveInit = init?.signal ? init : { ...init, signal: AbortSignal.timeout(10_000) };
   const useAuth = !IS_TAURI || isTauriRemoteMode();
   let apiBase = "";
@@ -367,6 +363,12 @@ export async function safeFetch(url: string, init?: RequestInit): Promise<Respon
       throw err;
     }
   }
+  return res;
+}
+
+/** Auth-aware fetch that converts HTTP error responses into exceptions. */
+export async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
+  const res = await safeFetchResponse(url, init);
   if (!res.ok) {
     let userMessage = res.statusText;
     try {

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -15,8 +15,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { toast } from "sonner";
 import { setThemePref } from "../theme";
 import type { Theme } from "../theme";
-import { downloadFile, showInFolder, readFileBase64, getLocalFileInfo, onDragDrop, openFileDialog, IS_TAURI, IS_WEB, IS_MOBILE_BROWSER, onWsEvent, logger } from "../platform";
-import { safeFetch } from "../providers";
+import { downloadFile, showInFolder, getLocalFileInfo, uploadLocalFile, onDragDrop, openFileDialog, IS_TAURI, IS_WEB, IS_MOBILE_BROWSER, onWsEvent, logger } from "../platform";
+import { safeFetch, safeFetchResponse } from "../providers";
 import type {
   ChatMessage,
   ChatErrorInfo,
@@ -85,6 +85,10 @@ import {
   messageHistoryRichness,
   shouldRenderConversationMessages,
 } from "./chat/utils/chatHelpers";
+import {
+  isAttachmentStillPreparing,
+  toChatAttachmentRequest,
+} from "./chat/utils/attachmentStaging";
 import { useMdModules } from "./chat/hooks/useMdModules";
 import { useMessageReducer, useConversationReducer } from "./chat/hooks/useMessages";
 import { useQueryGuard } from "./chat/hooks/useQueryGuard";
@@ -936,12 +940,6 @@ function formatAttachmentSize(bytes: number | null | undefined): string {
   if (n >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
   if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`;
   return `${Math.round(n)}B`;
-}
-
-function isAttachmentStillPreparing(att: ChatAttachment): boolean {
-  if (att.source === "working_directory" && att.relativePath) return false;
-  if (att.uploadStatus === "uploading") return true;
-  return !att.url && !att.localPath;
 }
 
 function workingDirectoryName(path?: string): string {
@@ -3843,17 +3841,7 @@ export function ChatView({
 
       // 附件信息
       if (attachmentsToSend.length > 0) {
-        body.attachments = attachmentsToSend.map((a) => ({
-          type: a.type,
-          source: a.source || "upload",
-          relativePath: a.relativePath,
-          name: a.name,
-          url: a.url,
-          local_path: a.localPath,
-          upload_id: a.uploadId,
-          size: a.size,
-          mime_type: a.mimeType,
-        }));
+        body.attachments = attachmentsToSend.map(toChatAttachmentRequest);
       }
 
       resetIdleTimer(); // Start idle timer before fetch
@@ -3910,7 +3898,7 @@ export function ChatView({
             method: "GET",
             signal: abort.signal,
           })
-        : await safeFetch(`${apiBase}/api/chat`, {
+        : await safeFetchResponse(`${apiBase}/api/chat`, {
             method: "POST",
             headers: _headers,
             body: requestBody,
@@ -3940,7 +3928,7 @@ export function ChatView({
           const sinceSeq = thisConvId ? (lastSeqByConv.current.get(thisConvId) ?? 0) : 0;
           const resumeUrl =
             `${apiBase}/api/chat/resume?conversation_id=${encodeURIComponent(thisConvId)}&since_seq=${sinceSeq}`;
-          response = await safeFetch(resumeUrl, { method: "GET", signal: abort.signal });
+          response = await safeFetchResponse(resumeUrl, { method: "GET", signal: abort.signal });
           if (!response.ok) {
             // 后端没有可恢复的流。两种情况，必须区分，否则会话状态会卡住：
             //   1) 任务仍在跑，只是没有可挂载的 SSE writer（少见）→ 保持 running。
@@ -3975,7 +3963,7 @@ export function ChatView({
           // response 现在是 resume 的 SSE 流 → 落入下方 reader 循环正常处理续写。
         } else {
           // steer_failed：作为全新消息重发一次（此时旧任务已结束，应能正常开流）。
-           response = await safeFetch(`${apiBase}/api/chat`, {
+           response = await safeFetchResponse(`${apiBase}/api/chat`, {
              method: "POST",
              headers: _headers,
              body: requestBody,
@@ -6393,64 +6381,76 @@ export function ChatView({
           return;
         }
 
-        const uploadId = genId();
-        setPendingAttachments((prev) => [...prev, {
-          type: isImage ? "image" : "video",
+      }
+
+      const uploadId = genId();
+      const attachmentType: ChatAttachment["type"] = isImage
+        ? "image"
+        : isVideo
+          ? "video"
+          : isAudio
+            ? "voice"
+            : isPdf
+              ? "document"
+              : "file";
+      const att: ChatAttachment = {
+        type: attachmentType,
+        name,
+        localPath: filePath,
+        size: info.size,
+        mimeType,
+        uploadStatus: "uploading",
+        uploadProgress: 0,
+        _uploadId: uploadId,
+      };
+      setPendingAttachments((prev) => [...prev, att]);
+      try {
+        const uploadBase = apiBaseRef.current.replace(/\/+$/, "");
+        const uploaded = await uploadLocalFile(
+          filePath,
+          `${uploadBase}/api/upload`,
           name,
-          localPath: filePath,
-          size: info.size,
           mimeType,
-          uploadStatus: "uploading",
-          uploadProgress: 0,
-          _uploadId: uploadId,
-        }]);
-        try {
-          const dataUrl = await readFileBase64(filePath, (loaded, total) => {
+          (loaded, total) => {
             if (total <= 0) return;
             const progress = Math.max(0, Math.min(0.98, loaded / total));
             setPendingAttachments((prev) => prev.map((a) =>
               a._uploadId === uploadId ? { ...a, uploadProgress: progress } : a
             ));
-          });
-          if (cancelled) return;
-          setPendingAttachments((prev) => prev.map((a) =>
-            a._uploadId === uploadId
-              ? {
-                ...a,
-                previewUrl: isImage ? dataUrl : undefined,
-                url: dataUrl,
-                uploadStatus: "uploaded",
-                uploadProgress: undefined,
-                uploadError: undefined,
-              }
-              : a
-          ));
-        } catch (err) {
-          if (!cancelled) notifyError(`文件读取失败: ${name}`);
-          logger.error("Chat", "DragDrop read_file_base64 failed", { name, error: String(err) });
-          setPendingAttachments((prev) => prev.map((a) =>
-            a._uploadId === uploadId
-              ? { ...a, uploadStatus: "failed", uploadProgress: undefined, uploadError: "文件读取失败" }
-              : a
-          ));
-        }
-        return;
+          },
+        );
+        if (cancelled) return;
+        const uploadedUrl = uploaded.url.startsWith("http")
+          ? uploaded.url
+          : `${uploadBase}${uploaded.url}`;
+        setPendingAttachments((prev) => prev.map((a) =>
+          a._uploadId === uploadId
+            ? {
+              ...a,
+              url: uploadedUrl,
+              localPath: uploaded.localPath,
+              uploadId: uploaded.uploadId,
+              size: uploaded.size ?? a.size,
+              mimeType: uploaded.mimeType ?? a.mimeType,
+              uploadStatus: "uploaded",
+              uploadProgress: undefined,
+              uploadError: undefined,
+            }
+            : a
+        ));
+        logger.info("Chat.Upload", "DragDrop native upload completed", {
+          name,
+          size: uploaded.size ?? info.size,
+        });
+      } catch (err) {
+        if (!cancelled) notifyError(`文件上传失败: ${name}`);
+        logger.error("Chat", "DragDrop native upload failed", { name, error: String(err) });
+        setPendingAttachments((prev) => prev.map((a) =>
+          a._uploadId === uploadId
+            ? { ...a, uploadStatus: "failed", uploadProgress: undefined, uploadError: String(err) }
+            : a
+        ));
       }
-
-      const att: ChatAttachment = {
-        type: isAudio ? "voice" : isPdf ? "document" : "file",
-        name,
-        localPath: filePath,
-        size: info.size,
-        mimeType,
-        uploadStatus: "uploaded",
-      };
-      setPendingAttachments((prev) => [...prev, att]);
-      logger.info("Chat.Upload", "DragDrop staged local file attachment", {
-        name,
-        size: info.size,
-        localOnly: true,
-      });
     };
 
     const handleDroppedPaths = (paths: string[]) => {

--- a/apps/setup-center/src/views/chat/utils/__tests__/attachmentStaging.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/attachmentStaging.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatAttachment } from "../chatTypes";
+import {
+  isAttachmentStillPreparing,
+  toChatAttachmentRequest,
+} from "../attachmentStaging";
+
+function attachment(overrides: Partial<ChatAttachment> = {}): ChatAttachment {
+  return {
+    type: "document",
+    name: "report.pdf",
+    ...overrides,
+  };
+}
+
+describe("attachment staging contract", () => {
+  it("does not treat an unverified local path as a sendable upload", () => {
+    expect(isAttachmentStillPreparing(attachment({
+      localPath: "D:/files/report.pdf",
+      uploadStatus: "uploaded",
+    }))).toBe(true);
+  });
+
+  it("accepts server upload and working-directory references", () => {
+    expect(isAttachmentStillPreparing(attachment({ uploadId: "upload-1" }))).toBe(false);
+    expect(isAttachmentStillPreparing(attachment({
+      source: "working_directory",
+      relativePath: "docs/report.pdf",
+    }))).toBe(false);
+  });
+
+  it("omits client local paths from chat request payloads", () => {
+    const payload = toChatAttachmentRequest(attachment({
+      localPath: "D:/files/report.pdf",
+      uploadId: "upload-1",
+      url: "/api/uploads/upload-1.pdf",
+    }));
+
+    expect(payload).toMatchObject({
+      source: "upload",
+      upload_id: "upload-1",
+      url: "/api/uploads/upload-1.pdf",
+    });
+    expect(payload).not.toHaveProperty("local_path");
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/attachmentStaging.ts
+++ b/apps/setup-center/src/views/chat/utils/attachmentStaging.ts
@@ -1,0 +1,32 @@
+import type { ChatAttachment } from "./chatTypes";
+
+export type ChatAttachmentRequest = {
+  type: ChatAttachment["type"];
+  source: "upload" | "working_directory";
+  relativePath?: string;
+  name: string;
+  url?: string;
+  upload_id?: string;
+  size?: number;
+  mime_type?: string;
+};
+
+export function isAttachmentStillPreparing(att: ChatAttachment): boolean {
+  if (att.source === "working_directory") return !att.relativePath;
+  if (att.uploadStatus === "uploading") return true;
+  return !att.url && !att.uploadId;
+}
+
+/** Serialize only server-verifiable attachment references into chat requests. */
+export function toChatAttachmentRequest(att: ChatAttachment): ChatAttachmentRequest {
+  return {
+    type: att.type,
+    source: att.source || "upload",
+    relativePath: att.relativePath,
+    name: att.name,
+    url: att.url,
+    upload_id: att.uploadId,
+    size: att.size,
+    mime_type: att.mimeType,
+  };
+}

--- a/tests/test_module_deps.py
+++ b/tests/test_module_deps.py
@@ -22,6 +22,15 @@ import pytest
 # 添加项目路径
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+TAURI_RUST_SRC = Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src"
+
+
+def _read_tauri_rust_source(relative_path: str) -> str:
+    source_path = TAURI_RUST_SRC / relative_path
+    if not source_path.exists():
+        pytest.skip(f"Tauri Rust source not found: {relative_path}")
+    return source_path.read_text(encoding="utf-8")
+
 
 # ─────────────────────────────────────────────
 # 1. runtime_env 模块路径注入
@@ -304,7 +313,7 @@ class TestPlaywrightBrowsersPath:
 
 
 class TestBundleModulesConsistency:
-    """确保 bundle_modules.py 的模块定义与 main.rs 一致"""
+    """确保 bundle_modules.py 的模块定义与 Tauri 模块配置一致"""
 
     def test_bundle_script_defines_all_modules(self):
         """bundle_modules.py 应包含所有四个可选模块"""
@@ -327,8 +336,8 @@ class TestBundleModulesConsistency:
             f"多余 {actual_modules - expected_modules}"
         )
 
-    def test_bundle_packages_match_main_rs(self):
-        """bundle_modules.py 的包列表应与 main.rs module_definitions 一致"""
+    def test_bundle_packages_match_tauri_modules(self):
+        """bundle_modules.py 的包列表应与 Tauri module_definitions 一致"""
         import importlib.util
 
         script_path = Path(__file__).parent.parent / "build" / "bundle_modules.py"
@@ -339,21 +348,21 @@ class TestBundleModulesConsistency:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 
-        # main.rs / bundle_modules.py 中的包定义（手动提取，保持同步）
-        main_rs_packages = {
+        # Tauri environment.rs / bundle_modules.py 中的包定义（手动提取，保持同步）
+        tauri_module_packages = {
             "vector-memory": ["sentence-transformers", "chromadb"],
             "whisper": ["openai-whisper", "static-ffmpeg"],
             "orchestration": ["pyzmq"],
         }
 
-        for module_id, expected_pkgs in main_rs_packages.items():
+        for module_id, expected_pkgs in tauri_module_packages.items():
             bundle_pkgs = mod.MODULE_DEFS[module_id]["packages"]
             # bundle_modules.py 的包名可能带版本约束，只比较基础名
             bundle_base_names = [p.split(">=")[0].split("==")[0].split("<")[0] for p in bundle_pkgs]
 
             for pkg in expected_pkgs:
                 assert pkg in bundle_base_names, (
-                    f"模块 {module_id}: main.rs 要求 {pkg} 但 bundle_modules.py 中缺失"
+                    f"模块 {module_id}: Tauri 配置要求 {pkg} 但 bundle_modules.py 中缺失"
                 )
 
     def test_bundle_default_mirror_is_domestic(self):
@@ -376,30 +385,30 @@ class TestBundleModulesConsistency:
 class TestMirrorConsistency:
     """验证所有 pip 源/下载源配置的一致性"""
 
-    def test_no_dead_mirrors_in_main_rs(self):
-        """main.rs 中不应包含已知失效的镜像"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
-        )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
+    def test_no_dead_mirrors_in_tauri_sources(self):
+        """Tauri Rust 源码中不应包含已知失效的镜像"""
+        if not TAURI_RUST_SRC.exists():
+            pytest.skip("Tauri Rust source directory not found")
 
         dead_mirrors = [
             "mirror.ghproxy.com",  # 已被 GFW 封锁 (2024年末)
             "ghproxy.net",  # 已关停
         ]
 
-        for mirror in dead_mirrors:
-            # 允许在注释中提到，但不应在实际 URL 中使用
-            lines = content.split("\n")
-            for i, line in enumerate(lines, 1):
-                stripped = line.strip()
-                if stripped.startswith("//"):
-                    continue  # 跳过注释行
-                if mirror in stripped and "http" in stripped:
-                    pytest.fail(f"main.rs 第 {i} 行使用了已失效的镜像 {mirror}: {stripped[:100]}")
+        for source_path in sorted(TAURI_RUST_SRC.rglob("*.rs")):
+            content = source_path.read_text(encoding="utf-8")
+            for mirror in dead_mirrors:
+                # 允许在注释中提到，但不应在实际 URL 中使用
+                for i, line in enumerate(content.splitlines(), 1):
+                    stripped = line.strip()
+                    if stripped.startswith("//"):
+                        continue  # 跳过注释行
+                    if mirror in stripped and "http" in stripped:
+                        relative_path = source_path.relative_to(TAURI_RUST_SRC)
+                        pytest.fail(
+                            f"{relative_path} 第 {i} 行使用了已失效的镜像 "
+                            f"{mirror}: {stripped[:100]}"
+                        )
 
     def test_pip_presets_default_to_domestic(self):
         """前端 PIP_INDEX_PRESETS 默认应选中国内源"""
@@ -441,15 +450,14 @@ class TestMirrorConsistency:
                 break
         assert found, "未找到 official preset 数据行"
 
-    def test_managed_python_contract_in_main_rs(self):
+    def test_managed_python_contract_in_tauri_modules(self):
         """契约A：运行时应使用 bootstrap seed 创建持久化托管环境"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
+        content = "\n".join(
+            (
+                _read_tauri_rust_source("python/pip.rs"),
+                _read_tauri_rust_source("runtime.rs"),
+            )
         )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
 
         assert "install_bundled_python_sync" in content, (
             "应存在 install_bundled_python_sync 作为内置 Python 校验入口"
@@ -459,15 +467,9 @@ class TestMirrorConsistency:
         assert 'bootstrap_resource_dir().join("python")' in content
         assert "ensure_app_venv" in content
 
-    def test_python_diagnostic_contract_model_in_main_rs(self):
+    def test_python_diagnostic_contract_model_in_tauri_module(self):
         """Python 诊断应使用契约化模型（生产级：可扩展/可导出/可修复）"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
-        )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
+        content = _read_tauri_rust_source("python/diagnostics.rs")
 
         # 新模型核心字段
         assert "summary: String" in content
@@ -488,13 +490,7 @@ class TestMirrorConsistency:
 
     def test_fetch_pypi_versions_has_fallback(self):
         """fetch_pypi_versions 应有多源回退（阿里云不支持 JSON API）"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
-        )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
+        content = _read_tauri_rust_source("network.rs")
 
         # 应包含清华 JSON API 回退
         assert "pypi.tuna.tsinghua.edu.cn/pypi" in content
@@ -503,13 +499,7 @@ class TestMirrorConsistency:
 
     def test_pip_install_has_default_mirror(self):
         """pip_install 无 index_url 时应有默认国内镜像"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
-        )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
+        content = _read_tauri_rust_source("python/pip.rs")
 
         # pip_install 函数中应有 unwrap_or 默认值
         assert 'unwrap_or("https://mirrors.aliyun.com/pypi/simple/")' in content, (
@@ -527,13 +517,7 @@ class TestPostInstallHooks:
 
     def test_playwright_browsers_path_set_at_launch(self):
         """Tauri 启动后端时应设置 PLAYWRIGHT_BROWSERS_PATH"""
-        main_rs_path = (
-            Path(__file__).parent.parent / "apps" / "setup-center" / "src-tauri" / "src" / "main.rs"
-        )
-        if not main_rs_path.exists():
-            pytest.skip("main.rs not found")
-
-        content = main_rs_path.read_text(encoding="utf-8")
+        content = _read_tauri_rust_source("backend/service.rs")
 
         assert content.count('"PLAYWRIGHT_BROWSERS_PATH"') >= 1, (
             "PLAYWRIGHT_BROWSERS_PATH 应至少出现 1 次（启动后端时兜底设置）"

--- a/tests/unit/test_session_working_directory.py
+++ b/tests/unit/test_session_working_directory.py
@@ -342,6 +342,27 @@ def test_working_directory_attachment_rejects_escape_and_forged_local_path(tmp_p
     assert getattr(local_path.value, "status_code", None) == 403
 
 
+def test_uploaded_attachment_resolves_server_path_without_client_local_path(tmp_path, monkeypatch):
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    uploaded = upload_dir / "upload-1_report.pdf"
+    uploaded.write_bytes(b"pdf")
+    monkeypatch.setattr("openakita.api.routes.upload.UPLOAD_DIR", upload_dir)
+    session = Session.create(
+        "desktop", "attachments", "desktop_user", working_directory=str(tmp_path)
+    )
+    attachment = AttachmentInfo(
+        type="document",
+        name="report.pdf",
+        upload_id=uploaded.name,
+        url=f"/api/uploads/{uploaded.name}",
+    )
+
+    resolve_chat_attachments([attachment], session)
+
+    assert attachment.local_path == str(uploaded.resolve())
+
+
 @pytest.mark.asyncio
 async def test_contextvar_keeps_concurrent_working_directories_isolated(tmp_path):
     roots = [tmp_path / "one", tmp_path / "two"]

--- a/tests/unit/test_upload_audio_attachments.py
+++ b/tests/unit/test_upload_audio_attachments.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from openakita.api.routes import upload
-from openakita.core._agent_runtime import _format_desktop_attachment_reference
+from openakita.runtime.desktop.attachments import format_desktop_attachment_reference
 
 
 def _client(tmp_path, monkeypatch) -> TestClient:
@@ -48,7 +48,7 @@ def test_desktop_uploaded_audio_reference_includes_local_path(tmp_path, monkeypa
     saved = tmp_path / "123_meeting.wav"
     saved.write_bytes(b"voice")
 
-    text = _format_desktop_attachment_reference(
+    text = format_desktop_attachment_reference(
         att_type="voice",
         att_name="meeting.wav",
         att_mime="audio/wav",


### PR DESCRIPTION
## Summary

- Stream Tauri-native drag-and-drop files through the existing backend upload endpoint before chat submission.
- Keep browser and mobile uploads on their existing `File`/`Blob` path while sending only server-verifiable attachment references.
- Preserve backend HTTP validation responses in chat and fix audio attachment test collection after the agent module split.

## Tests

- `npm run test:run`
- `npm run build`
- `cargo test`
- `uv run --no-sync pytest tests/unit/test_session_working_directory.py tests/unit/test_upload_audio_attachments.py tests/integration/test_api_endpoints.py -q`

Fixes #797
