### PR TITLE
Restore desktop sessions only after backend readiness

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -89,6 +89,10 @@ import {
   isAttachmentStillPreparing,
   toChatAttachmentRequest,
 } from "./chat/utils/attachmentStaging";
+import {
+  restoreSessionsUntilReady,
+  type SessionRestoreEvent,
+} from "./chat/utils/sessionRestore";
 import { useMdModules } from "./chat/hooks/useMdModules";
 import { useMessageReducer, useConversationReducer } from "./chat/hooks/useMessages";
 import { useQueryGuard } from "./chat/hooks/useQueryGuard";
@@ -2364,43 +2368,73 @@ export function ChatView({
     return () => document.removeEventListener("mousedown", handler);
   }, [agentMenuOpen]);
 
-  // 启动后后台对账会话列表：本地先展示，后端异步增量合并，避免"今天新会话缺失"
-  // 同时检测 data_epoch 是否变化（factory reset / 数据重置）
-  const sessionRestoreAttempted = useRef(false);
+  // 启动后后台对账会话列表：本地先展示，后端异步增量合并，避免"今天新会话缺失"。
+  // 只有 SessionManager 明确 ready 后才标记完成；进程存活或 HTTP 可达都不够。
+  const sessionRestoreCompletedScope = useRef<string | null>(null);
+  const sessionRestoreScope = `${apiBaseUrl}|${wsTag}`;
 
-  // 后端断开时重置对账标志，使重连后能重新对账 + 检测 epoch 变化
-  // （覆盖 factory reset 后不刷新页面的场景）
   useEffect(() => {
     if (!serviceRunning) {
-      sessionRestoreAttempted.current = false;
+      sessionRestoreCompletedScope.current = null;
+      return;
     }
-  }, [serviceRunning]);
+    if (sessionRestoreCompletedScope.current === sessionRestoreScope) return;
 
-  const sessionRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const controller = new AbortController();
 
-  useEffect(() => {
-    if (!serviceRunning || sessionRestoreAttempted.current) return;
-    sessionRestoreAttempted.current = true;
+    const logRestoreEvent = (event: SessionRestoreEvent) => {
+      const base = {
+        scope: sessionRestoreScope,
+        workspace: wsTag,
+        attempt: event.attempt,
+      };
+      if (event.type === "attempt") {
+        logger.info("Chat.SessionRestore", "attempt", base);
+      } else if (event.type === "not_ready") {
+        logger.info("Chat.SessionRestore", "session manager not ready; retrying", {
+          ...base,
+          delayMs: event.delayMs,
+        });
+      } else if (event.type === "error") {
+        logger.warn("Chat.SessionRestore", "request failed; retrying", {
+          ...base,
+          delayMs: event.delayMs,
+          error: String(event.error),
+        });
+      } else if (event.type === "cancelled") {
+        logger.info("Chat.SessionRestore", "cancelled", base);
+      }
+    };
 
-    let cancelled = false;
-    let attempt = 0;
-
-    const reconcile = async () => {
-      attempt++;
-      try {
-        const res = await safeFetch(`${apiBaseUrl}/api/sessions?channel=desktop`);
-        if (cancelled) return;
-        const data = await res.json();
-        if (cancelled) return;
-
-        // Backend still loading sessions — retry with backoff (max ~20s total)
-        if (data.ready === false && attempt < 6) {
-          const delay = Math.min(1000 * Math.pow(1.5, attempt - 1), 5000);
-          sessionRetryTimer.current = setTimeout(reconcile, delay);
-          return;
+    void restoreSessionsUntilReady<Record<string, unknown>>({
+      signal: controller.signal,
+      request: async (attempt) => {
+        const res = await safeFetchResponse(`${apiBaseUrl}/api/sessions?channel=desktop`, {
+          signal: controller.signal,
+        });
+        const data = await res.json() as Record<string, unknown>;
+        const responseDetails = {
+          scope: sessionRestoreScope,
+          workspace: wsTag,
+          attempt,
+          httpStatus: res.status,
+          ready: data.ready === true,
+          sessionCount: Array.isArray(data.sessions) ? data.sessions.length : 0,
+          epochPresent: typeof data.data_epoch === "string" && data.data_epoch.length > 0,
+        };
+        if (res.ok) {
+          logger.info("Chat.SessionRestore", "response", responseDetails);
+        } else {
+          logger.warn("Chat.SessionRestore", "response rejected", responseDetails);
+          throw new Error(`HTTP ${res.status}`);
         }
-
-        const backendSessions: ChatConversation[] = data.sessions || [];
+        return data;
+      },
+      isReady: (data) => data.ready === true,
+      reconcile: async (data) => {
+        const backendSessions = Array.isArray(data.sessions)
+          ? data.sessions as ChatConversation[]
+          : [];
 
         // ── Factory reset detection (epoch-based only) ──
         // Only clear local data when data_epoch actually changes, which signals
@@ -2429,6 +2463,10 @@ export function ChatView({
             });
             activateConversation(null);
             setMessages([]);
+            logger.warn("Chat.SessionRestore", "data epoch changed; cleared local conversations", {
+              scope: sessionRestoreScope,
+              workspace: wsTag,
+            });
             return;
           }
         }
@@ -2456,24 +2494,35 @@ export function ChatView({
         });
 
         // 没有活跃会话时，默认打开后端最新会话
-        if (!activeConvId) {
+        if (!activeConvIdRef.current) {
           activateConversation(restoredConvs[0].id);
         }
-      } catch {
-        // Network error — retry if backend might still be starting
-        if (!cancelled && attempt < 6) {
-          const delay = Math.min(1000 * Math.pow(1.5, attempt - 1), 5000);
-          sessionRetryTimer.current = setTimeout(reconcile, delay);
-        }
-      }
-    };
+      },
+      onEvent: logRestoreEvent,
+    }).then((result) => {
+      if (result.status !== "restored" || controller.signal.aborted) return;
+      sessionRestoreCompletedScope.current = sessionRestoreScope;
+      logger.info("Chat.SessionRestore", "completed", {
+        scope: sessionRestoreScope,
+        workspace: wsTag,
+        attempts: result.attempts,
+      });
+    });
 
-    reconcile();
     return () => {
-      cancelled = true;
-      if (sessionRetryTimer.current) clearTimeout(sessionRetryTimer.current);
+      controller.abort();
     };
-  }, [serviceRunning, apiBaseUrl, activeConvId, activateConversation]);
+  }, [
+    serviceRunning,
+    apiBaseUrl,
+    wsTag,
+    sessionRestoreScope,
+    STORAGE_KEY_DATA_EPOCH,
+    STORAGE_KEY_MSGS_PREFIX,
+    activateConversation,
+    setConversations,
+    setMessages,
+  ]);
 
   // ── Multi-device busy state: poll + WS events ──
   useEffect(() => {

--- a/apps/setup-center/src/views/chat/utils/__tests__/sessionRestore.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/sessionRestore.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  restoreSessionsUntilReady,
+  sessionRestoreRetryDelay,
+  type SessionRestoreEvent,
+} from "../sessionRestore";
+
+describe("restoreSessionsUntilReady", () => {
+  it("continues past six attempts until the session manager is ready", async () => {
+    const controller = new AbortController();
+    const events: SessionRestoreEvent[] = [];
+    const request = vi.fn(async () => ({ ready: request.mock.calls.length >= 7 }));
+    const reconcile = vi.fn();
+
+    const result = await restoreSessionsUntilReady({
+      signal: controller.signal,
+      request,
+      isReady: (payload) => payload.ready,
+      reconcile,
+      onEvent: (event) => events.push(event),
+      retryDelay: () => 0,
+      wait: async () => true,
+    });
+
+    expect(result).toEqual({ status: "restored", attempts: 7 });
+    expect(request).toHaveBeenCalledTimes(7);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toEqual({ type: "restored", attempt: 7 });
+  });
+
+  it("retries request failures and only reconciles a ready response", async () => {
+    const controller = new AbortController();
+    const request = vi
+      .fn<() => Promise<{ ready: boolean }>>()
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValueOnce({ ready: false })
+      .mockResolvedValueOnce({ ready: true });
+    const reconcile = vi.fn();
+
+    const result = await restoreSessionsUntilReady({
+      signal: controller.signal,
+      request,
+      isReady: (payload) => payload.ready,
+      reconcile,
+      retryDelay: () => 0,
+      wait: async () => true,
+    });
+
+    expect(result).toEqual({ status: "restored", attempts: 3 });
+    expect(reconcile).toHaveBeenCalledWith({ ready: true });
+  });
+
+  it("does not complete until reconciliation succeeds", async () => {
+    const controller = new AbortController();
+    const reconcile = vi
+      .fn<(payload: { ready: boolean }) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("local storage unavailable"))
+      .mockResolvedValueOnce();
+
+    const result = await restoreSessionsUntilReady({
+      signal: controller.signal,
+      request: async () => ({ ready: true }),
+      isReady: (payload) => payload.ready,
+      reconcile,
+      retryDelay: () => 0,
+      wait: async () => true,
+    });
+
+    expect(result).toEqual({ status: "restored", attempts: 2 });
+    expect(reconcile).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops retrying when cancelled", async () => {
+    const controller = new AbortController();
+    const events: SessionRestoreEvent[] = [];
+
+    const result = await restoreSessionsUntilReady({
+      signal: controller.signal,
+      request: async () => ({ ready: false }),
+      isReady: (payload) => payload.ready,
+      reconcile: vi.fn(),
+      onEvent: (event) => events.push(event),
+      wait: async () => {
+        controller.abort();
+        return false;
+      },
+    });
+
+    expect(result).toEqual({ status: "cancelled", attempts: 1 });
+    expect(events.at(-1)).toEqual({ type: "cancelled", attempt: 1 });
+  });
+});
+
+describe("sessionRestoreRetryDelay", () => {
+  it("caps retries at five seconds", () => {
+    expect(sessionRestoreRetryDelay(1)).toBe(1000);
+    expect(sessionRestoreRetryDelay(2)).toBe(1500);
+    expect(sessionRestoreRetryDelay(10)).toBe(5000);
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/sessionRestore.ts
+++ b/apps/setup-center/src/views/chat/utils/sessionRestore.ts
@@ -1,0 +1,75 @@
+export type SessionRestoreEvent =
+  | { type: "attempt"; attempt: number }
+  | { type: "not_ready"; attempt: number; delayMs: number }
+  | { type: "error"; attempt: number; delayMs: number; error: unknown }
+  | { type: "restored"; attempt: number }
+  | { type: "cancelled"; attempt: number };
+
+export type SessionRestoreResult = {
+  status: "restored" | "cancelled";
+  attempts: number;
+};
+
+export function sessionRestoreRetryDelay(attempt: number): number {
+  return Math.min(1000 * Math.pow(1.5, Math.max(0, attempt - 1)), 5000);
+}
+
+function waitForRetry(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return Promise.resolve(false);
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve(false);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function restoreSessionsUntilReady<T>(options: {
+  signal: AbortSignal;
+  request: (attempt: number) => Promise<T>;
+  isReady: (payload: T) => boolean;
+  reconcile: (payload: T) => void | Promise<void>;
+  onEvent?: (event: SessionRestoreEvent) => void;
+  retryDelay?: (attempt: number) => number;
+  wait?: (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+}): Promise<SessionRestoreResult> {
+  const retryDelay = options.retryDelay ?? sessionRestoreRetryDelay;
+  const wait = options.wait ?? waitForRetry;
+  let attempt = 0;
+
+  while (!options.signal.aborted) {
+    attempt += 1;
+    options.onEvent?.({ type: "attempt", attempt });
+
+    try {
+      const payload = await options.request(attempt);
+      if (options.signal.aborted) break;
+
+      if (options.isReady(payload)) {
+        await options.reconcile(payload);
+        if (options.signal.aborted) break;
+        options.onEvent?.({ type: "restored", attempt });
+        return { status: "restored", attempts: attempt };
+      }
+
+      const delayMs = retryDelay(attempt);
+      options.onEvent?.({ type: "not_ready", attempt, delayMs });
+      if (!(await wait(delayMs, options.signal))) break;
+    } catch (error) {
+      if (options.signal.aborted) break;
+      const delayMs = retryDelay(attempt);
+      options.onEvent?.({ type: "error", attempt, delayMs, error });
+      if (!(await wait(delayMs, options.signal))) break;
+    }
+  }
+
+  options.onEvent?.({ type: "cancelled", attempt });
+  return { status: "cancelled", attempts: attempt };
+}


### PR DESCRIPTION
## Summary

- Wait for the desktop session manager to report `ready: true` before reconciling restored conversations.
- Retry restoration until reconciliation succeeds and emit structured lifecycle diagnostics for startup failures.

## Tests

- `npm run test:run`
- `npx tsc -b --pretty false`

Fixes #802
