### PR TITLE
Fix WebKitGTK rendering on FriendlyElec ARM64 Mali devices

### DIFF
--- a/apps/setup-center/src-tauri/src/app.rs
+++ b/apps/setup-center/src-tauri/src/app.rs
@@ -22,6 +22,7 @@ pub fn run() {
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
+    crate::graphics::configure_webview_environment();
     spawn_machine_info_collector();
 
     // Native crash handler: capture SEH exceptions (access violation /
@@ -90,15 +91,6 @@ pub fn run() {
                 };
                 std::env::set_var(key, &val);
             }
-        }
-    }
-
-    // Workaround: NVIDIA drivers on Linux can cause a blank WebKitGTK window
-    // due to DMA-BUF renderer incompatibility. Disable it preemptively.
-    #[cfg(target_os = "linux")]
-    {
-        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
     }
 

--- a/apps/setup-center/src-tauri/src/graphics.rs
+++ b/apps/setup-center/src-tauri/src/graphics.rs
@@ -1,0 +1,145 @@
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinuxGraphicsProfile {
+    Default,
+    FriendlyElecVendorMaliArm64,
+}
+
+#[cfg(any(target_os = "linux", test))]
+const DEFAULT_LINUX_WEBKIT_ENV: &[(&str, &str)] = &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")];
+
+#[cfg(any(target_os = "linux", test))]
+const FRIENDLYELEC_VENDOR_MALI_ARM64_WEBKIT_ENV: &[(&str, &str)] = &[
+    ("GDK_GL", "gles"),
+    ("WEBKIT_DISABLE_DMABUF_RENDERER", "0"),
+    ("WEBKIT_SKIA_ENABLE_CPU_RENDERING", "1"),
+];
+
+#[cfg(any(target_os = "linux", test))]
+fn select_linux_graphics_profile(
+    is_arm64: bool,
+    is_friendlyelec_image: bool,
+    has_vendor_mali_device: bool,
+) -> LinuxGraphicsProfile {
+    if is_arm64 && is_friendlyelec_image && has_vendor_mali_device {
+        LinuxGraphicsProfile::FriendlyElecVendorMaliArm64
+    } else {
+        LinuxGraphicsProfile::Default
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn defaults_for_profile(profile: LinuxGraphicsProfile) -> &'static [(&'static str, &'static str)] {
+    match profile {
+        LinuxGraphicsProfile::Default => DEFAULT_LINUX_WEBKIT_ENV,
+        LinuxGraphicsProfile::FriendlyElecVendorMaliArm64 => {
+            FRIENDLYELEC_VENDOR_MALI_ARM64_WEBKIT_ENV
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn apply_missing_defaults(
+    defaults: &[(&'static str, &'static str)],
+    mut is_set: impl FnMut(&str) -> bool,
+    mut set: impl FnMut(&'static str, &'static str),
+) -> Vec<&'static str> {
+    let mut applied = Vec::new();
+    for &(key, value) in defaults {
+        if !is_set(key) {
+            set(key, value);
+            applied.push(key);
+        }
+    }
+    applied
+}
+
+pub(crate) fn configure_webview_environment() {
+    #[cfg(target_os = "linux")]
+    {
+        // FriendlyElec's proprietary Mali stack exposes /dev/mali0 and needs CPU Skia
+        // rasterization to avoid stale WebKitGTK layers while retaining GPU compositing.
+        let profile = select_linux_graphics_profile(
+            cfg!(target_arch = "aarch64"),
+            std::path::Path::new("/etc/friendlyelec-release").is_file(),
+            std::path::Path::new("/dev/mali0").exists(),
+        );
+        let applied = apply_missing_defaults(
+            defaults_for_profile(profile),
+            |key| std::env::var_os(key).is_some(),
+            |key, value| std::env::set_var(key, value),
+        );
+
+        if profile == LinuxGraphicsProfile::FriendlyElecVendorMaliArm64 {
+            eprintln!(
+                "[graphics] detected FriendlyElec ARM64 vendor Mali; applied WebKitGTK defaults: {}",
+                if applied.is_empty() {
+                    "none (environment already configured)".to_string()
+                } else {
+                    applied.join(", ")
+                }
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn selects_profile_only_for_friendlyelec_arm64_with_mali_device() {
+        assert_eq!(
+            select_linux_graphics_profile(true, true, true),
+            LinuxGraphicsProfile::FriendlyElecVendorMaliArm64
+        );
+        assert_eq!(
+            select_linux_graphics_profile(false, true, true),
+            LinuxGraphicsProfile::Default
+        );
+        assert_eq!(
+            select_linux_graphics_profile(true, false, true),
+            LinuxGraphicsProfile::Default
+        );
+        assert_eq!(
+            select_linux_graphics_profile(true, true, false),
+            LinuxGraphicsProfile::Default
+        );
+    }
+
+    #[test]
+    fn vendor_mali_profile_uses_tested_hybrid_rendering_defaults() {
+        assert_eq!(
+            defaults_for_profile(LinuxGraphicsProfile::FriendlyElecVendorMaliArm64),
+            [
+                ("GDK_GL", "gles"),
+                ("WEBKIT_DISABLE_DMABUF_RENDERER", "0"),
+                ("WEBKIT_SKIA_ENABLE_CPU_RENDERING", "1"),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_profile_preserves_existing_linux_dmabuf_workaround() {
+        assert_eq!(
+            defaults_for_profile(LinuxGraphicsProfile::Default),
+            [("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
+        );
+    }
+
+    #[test]
+    fn explicit_environment_values_take_precedence() {
+        let existing = HashSet::from(["GDK_GL", "WEBKIT_SKIA_ENABLE_CPU_RENDERING"]);
+        let mut writes = Vec::new();
+
+        let applied = apply_missing_defaults(
+            FRIENDLYELEC_VENDOR_MALI_ARM64_WEBKIT_ENV,
+            |key| existing.contains(key),
+            |key, value| writes.push((key, value)),
+        );
+
+        assert_eq!(applied, ["WEBKIT_DISABLE_DMABUF_RENDERER"]);
+        assert_eq!(writes, [("WEBKIT_DISABLE_DMABUF_RENDERER", "0")]);
+    }
+}

--- a/apps/setup-center/src-tauri/src/lib.rs
+++ b/apps/setup-center/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod crash_handler;
 mod environment;
 mod feedback;
 pub(crate) mod finance;
+mod graphics;
 mod lifecycle;
 pub(crate) mod migrations;
 mod network;


### PR DESCRIPTION
## Summary

- Detect FriendlyElec ARM64 systems through the official image marker and proprietary Mali device.
- Apply the tested hybrid WebKitGTK rendering defaults while preserving explicit user overrides and existing behavior on other Linux systems.

## Tests

- `rustc --edition 2021 --test apps/setup-center/src-tauri/src/graphics.rs` (4 tests passed)
- `cargo check --lib`
- `rustfmt --edition 2021 --check` on the changed Rust files
- Linux-gated graphics module compilation with `rustc`
