### PR TITLE
make Subtitle Craft browser readiness actionable with system detection and managed Chromium installation

### DIFF
--- a/plugins/subtitle-craft/README.md
+++ b/plugins/subtitle-craft/README.md
@@ -39,6 +39,8 @@ OpenAkita 的 AI 字幕全生命周期插件 — 一个插件涵盖 **自动字�
   pip install playwright
   python -m playwright install chromium
   ```
+  也可在「设置 → 其他依赖」中点击安装;页面会分别显示系统 Chromium 与
+  Playwright 专用 Chromium 的检测结果。
 - 中文/日韩字体：HTML 烧制依赖系统已安装目标语言字体。Linux 服务器请预装 Noto CJK 系列。
 
 ### 2.3 安装 / 启用
@@ -82,15 +84,16 @@ GET    /settings                         - 当前配置（API key 仅返回掩�
 PUT    /settings                         - 更新配置
 GET    /storage/stats                    - 存储统计
 GET    /modes                            - 模式 / 翻译模型 / 错误码字典
-GET    /healthz                          - 健康检查（4 字段)
+GET    /healthz                          - 健康检查（5 字段)
 ```
 
-`/healthz` 返回固定 4 字段,**永不回显 API key 本体**:
+`/healthz` 返回固定 5 字段,**永不回显 API key 本体**:
 ```json
 {
   "ffmpeg_ok": true,
   "playwright_ok": true,
   "playwright_browser_ready": false,
+  "system_chromium_ok": true,
   "dashscope_api_key_present": true
 }
 ```

--- a/plugins/subtitle-craft/plugin.py
+++ b/plugins/subtitle-craft/plugin.py
@@ -28,10 +28,9 @@ Architectural rules baked in (red-line guardrails):
   the host.
 - **All Pydantic request bodies** declare ``model_config =
   ConfigDict(extra="forbid")`` (red-line C6 reverse-example).
-- **``/healthz``** returns the **4-field** contract per §8.4 + Phase 4
-  DoD: ``{ffmpeg_ok, playwright_ok, playwright_browser_ready,
-  dashscope_api_key_present}``. The API key is **never** echoed back —
-  only its presence as a boolean.
+- **``/healthz``** reports FFmpeg, Playwright, Playwright-managed Chromium,
+  system Chromium, and DashScope API-key readiness. The API key is **never**
+  echoed back — only its presence as a boolean.
 - **``provides.tools``** is **4 tools** (not 7); v1 had 7 including
   ``subtitle_craft_handoff_*`` which v2 deferred to v1.1+.
 - **SSE event name** is hard-coded ``task_update`` (red line #21); the
@@ -799,19 +798,25 @@ class Plugin(PluginBase):
                 raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     # ------------------------------------------------------------------
-    # /healthz — 4-field contract (Phase 4 DoD + §8.4)
+    # /healthz — runtime readiness without secret values
     # ------------------------------------------------------------------
 
     async def _compute_health(self) -> dict[str, Any]:
         ffmpeg_ok = self._detect_ffmpeg()
         playwright_ok = await asyncio.to_thread(self._detect_playwright_pkg)
-        playwright_browser_ready = await asyncio.to_thread(self._detect_playwright_browser)
+        playwright_browser = await asyncio.to_thread(
+            self._sysdeps.detect, "playwright-chromium", force=True
+        )
+        system_chromium = await asyncio.to_thread(
+            self._sysdeps.detect, "system-chromium", force=True
+        )
         api_key = await self._tm.get_config("dashscope_api_key") or ""
         dashscope_api_key_present = bool(api_key.strip())
         return {
             "ffmpeg_ok": ffmpeg_ok,
             "playwright_ok": playwright_ok,
-            "playwright_browser_ready": playwright_browser_ready,
+            "playwright_browser_ready": bool(playwright_browser.get("found")),
+            "system_chromium_ok": bool(system_chromium.get("found")),
             "dashscope_api_key_present": dashscope_api_key_present,
         }
 
@@ -841,21 +846,6 @@ class Plugin(PluginBase):
         import importlib.util
 
         return importlib.util.find_spec("playwright") is not None
-
-    @staticmethod
-    def _detect_playwright_browser() -> bool:
-        # The browser is "ready" iff the Chromium binary is present in the
-        # default ms-playwright cache. We do not launch it here (P0-13 lazy
-        # import contract). Cheap filesystem probe only.
-        candidates = [
-            Path.home() / "AppData" / "Local" / "ms-playwright",  # Windows
-            Path.home() / ".cache" / "ms-playwright",  # Linux
-            Path.home() / "Library" / "Caches" / "ms-playwright",  # macOS
-        ]
-        for cache_dir in candidates:
-            if cache_dir.exists() and any(cache_dir.glob("chromium-*")):
-                return True
-        return False
 
     # ------------------------------------------------------------------
     # Custom style storage (single JSON blob in config)

--- a/plugins/subtitle-craft/subtitle_craft_inline/system_deps.py
+++ b/plugins/subtitle-craft/subtitle_craft_inline/system_deps.py
@@ -2,7 +2,7 @@
 
 After SDK 0.7.0 retired ``openakita_plugin_sdk.contrib.DependencyGate`` and
 the host-mounted ``/api/plugins/_sdk/deps/*`` SSE endpoint, plugins that
-need a system binary (here: FFmpeg) must own their installer end-to-end.
+need a system/runtime component must own their installer end-to-end.
 
 Design rules
 ------------
@@ -31,9 +31,11 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,99 @@ def _is_root() -> bool:
         return os.geteuid() == 0  # type: ignore[attr-defined]
     except AttributeError:
         return False
+
+
+def _resolve_python_executable() -> str:
+    """Return a Python executable that can run the installed Playwright module."""
+    if not getattr(sys, "frozen", False):
+        return sys.executable
+    exe_dir = Path(sys.executable).parent
+    internal = exe_dir if exe_dir.name == "_internal" else exe_dir / "_internal"
+    candidates = (
+        [internal / "python.exe", internal / "python3.exe"]
+        if sys.platform == "win32"
+        else [internal / "python3", internal / "python"]
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return sys.executable
+
+
+def _system_chromium_probes() -> tuple[str, ...]:
+    command_names = (
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium.exe",
+        "chrome.exe",
+    )
+    if os.name == "nt":
+        return command_names + (
+            r"%PROGRAMFILES%\Chromium\Application\chrome.exe",
+            r"%PROGRAMFILES%\Google\Chrome\Application\chrome.exe",
+            r"%LOCALAPPDATA%\Chromium\Application\chrome.exe",
+            r"%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe",
+        )
+    if sys.platform == "darwin":
+        return command_names + (
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        )
+    return command_names
+
+
+def _playwright_browser_roots() -> list[Path]:
+    roots: list[Path] = []
+    configured = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    if configured and configured != "0":
+        roots.append(Path(configured).expanduser())
+    elif configured == "0":
+        try:
+            import importlib.util
+
+            spec = importlib.util.find_spec("playwright")
+            if spec and spec.origin:
+                roots.append(Path(spec.origin).parent / "driver" / "package" / ".local-browsers")
+        except Exception:
+            pass
+
+    roots.extend(
+        [
+            Path.home() / "AppData" / "Local" / "ms-playwright",
+            Path.home() / ".cache" / "ms-playwright",
+            Path.home() / "Library" / "Caches" / "ms-playwright",
+        ]
+    )
+    unique: list[Path] = []
+    for root in roots:
+        if root not in unique:
+            unique.append(root)
+    return unique
+
+
+def _find_playwright_chromium() -> str:
+    executable_names = {
+        "headless_shell",
+        "headless_shell.exe",
+        "chrome-headless-shell",
+        "chrome-headless-shell.exe",
+        "chrome",
+        "chrome.exe",
+        "Chromium",
+    }
+    for root in _playwright_browser_roots():
+        if not root.is_dir():
+            continue
+        for bundle_pattern in ("chromium_headless_shell-*", "chromium-*"):
+            for bundle in sorted(root.glob(bundle_pattern), reverse=True):
+                if not bundle.is_dir():
+                    continue
+                for executable in bundle.rglob("*"):
+                    if executable.name in executable_names and executable.is_file():
+                        return str(executable)
+    return ""
 
 
 # ── Windows PATH refresh ──────────────────────────────────────────────────
@@ -214,7 +309,7 @@ class DepSpec:
     uninstall_methods: tuple[InstallMethod, ...] = ()
 
 
-# ── Catalog (keep tiny; only what seedance-video itself needs) ────────────
+# ── Catalog (keep tiny; only what subtitle-craft itself needs) ────────────
 
 _FFMPEG = DepSpec(
     id="ffmpeg",
@@ -313,7 +408,55 @@ _FFMPEG = DepSpec(
 )
 
 
-_SPECS: dict[str, DepSpec] = {_FFMPEG.id: _FFMPEG}
+_SYSTEM_CHROMIUM = DepSpec(
+    id="system-chromium",
+    display_name="System Chromium / Chrome",
+    description="System browser detected for environment diagnostics.",
+    homepage="https://www.chromium.org/",
+    probes=_system_chromium_probes(),
+    version_argv=("chromium", "--version"),
+    version_regex=r"(?:Chromium|Google Chrome|Chrome)\s+([^\s]+)",
+    install_methods=(),
+)
+
+
+def _playwright_install_methods() -> tuple[InstallMethod, ...]:
+    command = (
+        _resolve_python_executable(),
+        "-m",
+        "playwright",
+        "install",
+        "chromium",
+    )
+    return tuple(
+        InstallMethod(
+            platform=target,
+            strategy="playwright",
+            command=command,
+            description="Install the Chromium browser managed by Playwright.",
+            estimated_seconds=180,
+        )
+        for target in ("windows", "macos", "linux")
+    )
+
+
+_PLAYWRIGHT_CHROMIUM = DepSpec(
+    id="playwright-chromium",
+    display_name="Playwright Chromium",
+    description="Playwright-managed browser used by the HTML subtitle renderer.",
+    homepage="https://playwright.dev/python/docs/browsers",
+    probes=(),
+    version_argv=(),
+    version_regex="",
+    install_methods=_playwright_install_methods(),
+)
+
+
+_SPECS: dict[str, DepSpec] = {
+    _FFMPEG.id: _FFMPEG,
+    _SYSTEM_CHROMIUM.id: _SYSTEM_CHROMIUM,
+    _PLAYWRIGHT_CHROMIUM.id: _PLAYWRIGHT_CHROMIUM,
+}
 
 
 @dataclass
@@ -372,7 +515,11 @@ class SystemDepsManager:
             return self._detect_dict(spec, st)
 
         st.detect_error = ""
-        location = self._probe_locations(spec)
+        location = (
+            _find_playwright_chromium()
+            if dep_id == "playwright-chromium"
+            else self._probe_locations(spec)
+        )
 
         if not location and self._platform == "windows":
             # Likely just installed via winget — registry got the new PATH
@@ -415,6 +562,9 @@ class SystemDepsManager:
 
     def _probe_locations(self, spec: DepSpec) -> str:
         for probe in spec.probes:
+            expanded = os.path.expandvars(probe)
+            if os.path.isabs(expanded) and os.path.isfile(expanded):
+                return expanded
             found_path = shutil.which(probe)
             if found_path:
                 return found_path

--- a/plugins/subtitle-craft/tests/test_plugin.py
+++ b/plugins/subtitle-craft/tests/test_plugin.py
@@ -1,11 +1,11 @@
-"""Phase 4 plugin entry tests — 25 routes, 4 tools, healthz, no-handoff guards.
+"""Plugin entry tests — routes, tools, healthz, and no-handoff guards.
 
 These tests cover the Phase 4 DoD checklist from
 ``docs/subtitle-craft-plan.md`` §11 + Gate 4:
 
 - ``provides.tools`` is exactly 4 (no ``*_handoff_*``).
 - 25 routes are wired and answer per their contract (21 business + 4 system/*).
-- ``/healthz`` returns the 4-field shape and never echoes the API key.
+- ``/healthz`` returns boolean runtime readiness and never echoes the API key.
 - ``on_unload`` invokes ``_PlaywrightSingleton.close()`` (mocked).
 - All Pydantic request bodies declare ``ConfigDict(extra="forbid")``
   so typos surface as 422.
@@ -284,12 +284,12 @@ async def test_no_handoff_routes_registered(loaded_plugin):
 
 
 # ---------------------------------------------------------------------------
-# /healthz contract — 4 fields, no leak of api key
+# /healthz contract — boolean fields, no leak of api key
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_healthz_returns_four_canonical_fields(loaded_plugin):
+async def test_healthz_returns_canonical_boolean_fields(loaded_plugin):
     _, _, client = loaded_plugin
     resp = client.get("/healthz")
     assert resp.status_code == 200
@@ -298,10 +298,46 @@ async def test_healthz_returns_four_canonical_fields(loaded_plugin):
         "ffmpeg_ok",
         "playwright_ok",
         "playwright_browser_ready",
+        "system_chromium_ok",
         "dashscope_api_key_present",
     }
     for v in body.values():
         assert isinstance(v, bool)
+
+
+@pytest.mark.asyncio
+async def test_system_components_include_browser_detection_and_installer(loaded_plugin):
+    _, _, client = loaded_plugin
+    resp = client.get("/system/components")
+    assert resp.status_code == 200
+    by_id = {item["id"]: item for item in resp.json()["items"]}
+    assert "system-chromium" in by_id
+    assert by_id["system-chromium"]["methods"] == []
+    assert "playwright-chromium" in by_id
+    methods = by_id["playwright-chromium"]["methods"]
+    assert len(methods) == 1
+    assert methods[0]["strategy"] == "playwright"
+    assert methods[0]["command_hint"].endswith("-m playwright install chromium")
+
+
+@pytest.mark.asyncio
+async def test_playwright_browser_install_route_dispatches_whitelisted_component(loaded_plugin):
+    plugin, _, client = loaded_plugin
+    plugin._sysdeps.start_install = AsyncMock(
+        return_value={"ok": True, "busy": True, "method_strategy": "playwright"}
+    )
+
+    resp = client.post(
+        "/system/playwright-chromium/install",
+        json={"method_index": 0},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["method_strategy"] == "playwright"
+    plugin._sysdeps.start_install.assert_awaited_once_with(
+        "playwright-chromium",
+        method_index=0,
+    )
 
 
 @pytest.mark.asyncio

--- a/plugins/subtitle-craft/tests/test_system_deps.py
+++ b/plugins/subtitle-craft/tests/test_system_deps.py
@@ -1,0 +1,59 @@
+"""Browser detection and whitelisted installer coverage for subtitle-craft."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from subtitle_craft_inline import system_deps
+
+
+def test_detects_system_chromium_from_path(monkeypatch):
+    manager = system_deps.SystemDepsManager()
+    browser = "/usr/bin/chromium-browser"
+
+    monkeypatch.setattr(
+        system_deps.shutil,
+        "which",
+        lambda probe: browser if probe == "chromium-browser" else None,
+    )
+    monkeypatch.setattr(
+        system_deps.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="Chromium 143.0.7499.40 Built on NanoPC-T6\n",
+            stderr="",
+        ),
+    )
+
+    snapshot = manager.detect("system-chromium")
+
+    assert snapshot["found"] is True
+    assert snapshot["location"] == browser
+    assert snapshot["version"] == "143.0.7499.40"
+
+
+def test_detects_playwright_browser_from_configured_cache(tmp_path: Path, monkeypatch):
+    executable = (
+        tmp_path
+        / "chromium_headless_shell-1228"
+        / "chrome-linux"
+        / "headless_shell"
+    )
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
+
+    snapshot = system_deps.SystemDepsManager().detect("playwright-chromium")
+
+    assert snapshot["found"] is True
+    assert snapshot["location"] == str(executable)
+
+
+def test_playwright_installer_command_is_fixed_to_current_runtime():
+    methods = system_deps.SystemDepsManager().methods("playwright-chromium")
+
+    assert len(methods) == 1
+    command = methods[0]["command_hint"]
+    assert command.endswith("-m playwright install chromium")
+    assert methods[0]["requires_sudo"] is False

--- a/plugins/subtitle-craft/tests/test_ui_smoke.py
+++ b/plugins/subtitle-craft/tests/test_ui_smoke.py
@@ -19,7 +19,7 @@ invariants on ``ui/dist/index.html`` that we promised in Gate 5:
     8. Toast + modal (``modal-mask`` + ``showToast``)
 - ``character_identify_enabled`` is gated on diarization (red line:
   toggle disabled when diarization is off).
-- ``/healthz`` is rendered with all 4 fields.
+- ``/healthz`` readiness and browser install controls are rendered.
 - SSE event ``task_update`` is wired (red line #21).
 """
 
@@ -152,7 +152,7 @@ def test_char_identify_gated_by_diarization():
     assert "create.charIdentify.requireDiarization" in text
 
 
-def test_healthz_renders_all_four_fields():
+def test_healthz_renders_runtime_fields_and_browser_installer():
     text = _read()
     # FFmpeg health used to be a plain `ffmpeg_ok` HealthRow tag;
     # since the 系统组件 redesign it is surfaced by the FfmpegInstaller
@@ -166,9 +166,13 @@ def test_healthz_renders_all_four_fields():
     for f in (
         "playwright_ok",
         "playwright_browser_ready",
+        "system_chromium_ok",
         "dashscope_api_key_present",
     ):
         assert f in text, f"healthz field missing in UI: {f}"
+    assert '"/system/playwright-chromium/install"' in text
+    assert '"/system/playwright-chromium/status"' in text
+    assert "settings.system.health.installBrowser" in text
 
 
 def test_sse_event_wired():

--- a/plugins/subtitle-craft/ui/dist/index.html
+++ b/plugins/subtitle-craft/ui/dist/index.html
@@ -1081,12 +1081,18 @@ const I18N_DICT = {
     "settings.system.logEmpty": "暂无输出",
     "settings.system.healthTitle": "其他依赖",
     "settings.system.health.playwright": "Playwright 包",
-    "settings.system.health.playwrightBrowser": "Chromium 浏览器",
+    "settings.system.health.playwrightBrowser": "Playwright 专用 Chromium",
+    "settings.system.health.systemChromium": "系统 Chromium / Chrome",
     "settings.system.health.apiKey": "DashScope API Key",
     "settings.system.health.refresh": "重新检测",
     "settings.system.health.ok": "可用",
     "settings.system.health.missing": "缺失",
-    "settings.system.health.intro": "Playwright + Chromium 用于 HTML 字幕渲染(高级模式);DashScope API Key 用于 ASR 与翻译。下面 3 项任意缺失,对应功能会自动降级或拒绝执行。",
+    "settings.system.health.installBrowser": "安装",
+    "settings.system.health.browserInstalling": "安装中",
+    "settings.system.health.browserInstalled": "Playwright Chromium 安装成功",
+    "settings.system.health.browserInstallFailed": "Playwright Chromium 安装失败:{msg}",
+    "settings.system.health.playwrightRequired": "需要先安装 Playwright 包",
+    "settings.system.health.intro": "HTML 字幕渲染使用 Playwright 专用 Chromium;系统 Chromium 单独显示用于环境诊断。DashScope API Key 用于 ASR 与翻译。",
     "settings.storage.title": "存储统计",
     "settings.storage.totalFiles": "文件总数",
     "settings.storage.totalSize": "总大小",
@@ -1414,12 +1420,18 @@ const I18N_DICT = {
     "settings.system.logEmpty": "No output yet",
     "settings.system.healthTitle": "Other dependencies",
     "settings.system.health.playwright": "Playwright package",
-    "settings.system.health.playwrightBrowser": "Chromium browser",
+    "settings.system.health.playwrightBrowser": "Playwright Chromium",
+    "settings.system.health.systemChromium": "System Chromium / Chrome",
     "settings.system.health.apiKey": "DashScope API Key",
     "settings.system.health.refresh": "Re-check",
     "settings.system.health.ok": "OK",
     "settings.system.health.missing": "Missing",
-    "settings.system.health.intro": "Playwright + Chromium are used by the HTML subtitle renderer (advanced mode); the DashScope API key drives ASR and translation. Any of these missing will gracefully degrade or refuse the matching feature.",
+    "settings.system.health.installBrowser": "Install",
+    "settings.system.health.browserInstalling": "Installing",
+    "settings.system.health.browserInstalled": "Playwright Chromium installed",
+    "settings.system.health.browserInstallFailed": "Playwright Chromium install failed: {msg}",
+    "settings.system.health.playwrightRequired": "Install the Playwright package first",
+    "settings.system.health.intro": "The HTML subtitle renderer uses Playwright Chromium. System Chromium is reported separately for environment diagnostics. The DashScope API key drives ASR and translation.",
     "settings.storage.title": "Storage",
     "settings.storage.totalFiles": "Files",
     "settings.storage.totalSize": "Total size",
@@ -3647,6 +3659,125 @@ function FfmpegInstaller({ onChanged }) {
   );
 }
 
+function BrowserRuntimeInstaller({ playwrightReady, managedFallback, systemFallback, onChanged }) {
+  const t = useT();
+  const [managed, setManaged] = useState(null);
+  const [systemBrowser, setSystemBrowser] = useState(null);
+  const [status, setStatus] = useState(null);
+  const notifiedRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await pluginApi("GET", "/system/components");
+      const items = (r.body && r.body.items) || [];
+      const managedItem = items.find(x => x.id === "playwright-chromium") || null;
+      setManaged(managedItem);
+      setSystemBrowser(items.find(x => x.id === "system-chromium") || null);
+      if (managedItem && managedItem.busy) {
+        setStatus((managedItem.last_install) || { busy: true, log_tail: [] });
+      }
+    } catch (e) { /* The healthz fallback remains visible after a transient request failure. */ }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const busy = !!((status && status.busy) || (managed && managed.busy));
+
+  useEffect(() => {
+    if (!busy) return;
+    let disposed = false;
+    const tick = async () => {
+      try {
+        const r = await pluginApi("GET", "/system/playwright-chromium/status");
+        const next = r.body || {};
+        if (disposed) return;
+        setStatus(next);
+        if (!next.busy) {
+          await refresh();
+          if (onChanged) onChanged();
+          if (!notifiedRef.current) {
+            notifiedRef.current = true;
+            if (next.found) showToast(_tr("settings.system.health.browserInstalled"));
+            else showToast(_tr("settings.system.health.browserInstallFailed", { msg: next.error || "?" }), "error");
+          }
+        }
+      } catch (e) { /* Retry on the next poll. */ }
+    };
+    tick();
+    const timer = setInterval(tick, 3000);
+    return () => { disposed = true; clearInterval(timer); };
+  }, [busy, refresh, onChanged]);
+
+  const install = async () => {
+    if (!playwrightReady || busy) return;
+    notifiedRef.current = false;
+    setStatus({ busy: true, log_tail: [], elapsed_sec: 0 });
+    try {
+      const r = await pluginApi(
+        "POST",
+        "/system/playwright-chromium/install",
+        { method_index: 0 },
+      );
+      const body = r.body || {};
+      if (body.ok === false) {
+        setStatus({ busy: false, error: body.error || "unknown", log_tail: [] });
+        showToast(_tr("settings.system.health.browserInstallFailed", { msg: body.error || "unknown" }), "error");
+      }
+    } catch (e) {
+      setStatus({ busy: false, error: e.message || "network error", log_tail: [] });
+      showToast(_tr("settings.system.health.browserInstallFailed", { msg: e.message || "network error" }), "error");
+    }
+  };
+
+  const managedOk = managed ? !!managed.found : !!managedFallback;
+  const systemOk = systemBrowser ? !!systemBrowser.found : !!systemFallback;
+  const detail = snap => snap
+    ? [snap.version, snap.location].filter(Boolean).join(" · ")
+    : "";
+  const live = status || (managed && managed.last_install) || null;
+  const logLines = (live && live.log_tail) || [];
+  const installAction = !managedOk ? (
+    <button className="btn btn-sm btn-primary"
+            onClick={install}
+            disabled={busy || !playwrightReady}
+            title={!playwrightReady ? t("settings.system.health.playwrightRequired") : undefined}>
+      {busy
+        ? <><span className="sysdep-spinner" /> {t("settings.system.health.browserInstalling")}</>
+        : <><OAIcon name="package" /> {t("settings.system.health.installBrowser")}</>}
+    </button>
+  ) : null;
+
+  return (
+    <>
+      <HealthRow
+        label={t("settings.system.health.playwrightBrowser")}
+        ok={managedOk}
+        pending={busy}
+        detail={detail(managed)}
+        action={installAction}
+        t={t}
+      />
+      <HealthRow
+        label={t("settings.system.health.systemChromium")}
+        ok={systemOk}
+        detail={detail(systemBrowser)}
+        t={t}
+      />
+      {(busy || logLines.length > 0) && (
+        <div className="sysdep-log" style={{gridColumn: "1 / -1", marginTop: 0}}>
+          <div className="sysdep-log__head">
+            <span>{t("settings.system.logTitle")}</span>
+            {busy && live && live.elapsed_sec != null && <span>{Math.round(live.elapsed_sec)}s</span>}
+          </div>
+          {logLines.length
+            ? <pre className="sysdep-log__body">{logLines.join("\n")}</pre>
+            : <pre className="sysdep-log__body sysdep-log__body--empty">{t("settings.system.logEmpty")}</pre>}
+        </div>
+      )}
+    </>
+  );
+}
+
 /* =================================================================
  * SettingsTab — DashScope key, system components (FFmpeg + health),
  * default runtime parameters, storage stats. The old standalone
@@ -3791,10 +3922,15 @@ function SettingsTab({ health, onApiKeyChange }) {
           <div className="text-xs text-dim" style={{marginBottom: 8, lineHeight: 1.6}}>
             {t("settings.system.health.intro")}
           </div>
-          <div className="grid-2" style={{gap: 8}}>
+          <div className="grid-2" style={{gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))"}}>
             <HealthRow label={t("settings.system.health.playwright")} ok={healthLocal && healthLocal.playwright_ok} t={t} />
-            <HealthRow label={t("settings.system.health.playwrightBrowser")} ok={healthLocal && healthLocal.playwright_browser_ready} t={t} />
             <HealthRow label={t("settings.system.health.apiKey")} ok={healthLocal && healthLocal.dashscope_api_key_present} t={t} />
+            <BrowserRuntimeInstaller
+              playwrightReady={!!(healthLocal && healthLocal.playwright_ok)}
+              managedFallback={!!(healthLocal && healthLocal.playwright_browser_ready)}
+              systemFallback={!!(healthLocal && healthLocal.system_chromium_ok)}
+              onChanged={refresh}
+            />
           </div>
         </div>
       </div>
@@ -3848,13 +3984,21 @@ function SettingsTab({ health, onApiKeyChange }) {
   );
 }
 
-function HealthRow({ label, ok, t }) {
+function HealthRow({ label, ok, pending=false, detail="", action=null, t }) {
   return (
-    <div className="flex items-center justify-between" style={{padding: "6px 10px", border: "1px solid var(--border)", borderRadius: 6}}>
-      <span className="text-sm">{label}</span>
-      <span className={"tag " + (ok ? "tag-green" : "tag-red")}>
-        {ok ? t("settings.system.health.ok") : t("settings.system.health.missing")}
-      </span>
+    <div className="flex items-center justify-between" style={{padding: "6px 10px", minHeight: 42, gap: 8, border: "1px solid var(--border)", borderRadius: 6}}>
+      <div style={{minWidth: 0}}>
+        <div className="text-sm">{label}</div>
+        {detail && <div className="text-xs text-dim" style={{marginTop: 2, wordBreak: "break-all"}} title={detail}>{detail}</div>}
+      </div>
+      <div className="flex items-center" style={{gap: 6, flexShrink: 0}}>
+        <span className={"tag " + (pending ? "" : (ok ? "tag-green" : "tag-red"))}>
+          {pending
+            ? t("settings.system.health.browserInstalling")
+            : (ok ? t("settings.system.health.ok") : t("settings.system.health.missing"))}
+        </span>
+        {action}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Report system Chromium/Chrome separately from the Playwright-managed Chromium runtime, including detected version and executable path.
- Add a whitelisted, asynchronous Playwright Chromium installer with progress polling and install logs in Subtitle Craft settings.
- Keep system Chromium informational while preserving Playwright's revision-matched browser behavior, and make the dependency layout responsive on narrow screens.

## Tests

- `uv run --no-sync pytest plugins/subtitle-craft/tests -q` (`193 passed, 4 skipped`)
- `uv run --no-sync ruff check plugins/subtitle-craft/plugin.py plugins/subtitle-craft/subtitle_craft_inline/system_deps.py plugins/subtitle-craft/tests/test_plugin.py plugins/subtitle-craft/tests/test_system_deps.py plugins/subtitle-craft/tests/test_ui_smoke.py`
- `git diff --check`
- Browser verification at 1280px and 390px widths with no console errors or dependency-row overflow.
