### PR TITLE
Recover desktop session history when local storage is full

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -93,6 +93,11 @@ import {
   restoreSessionsUntilReady,
   type SessionRestoreEvent,
 } from "./chat/utils/sessionRestore";
+import {
+  isStorageQuotaExceededError,
+  persistStorageValueWithMessageEviction,
+  retryStorageWriteAfterMessageEviction,
+} from "./chat/utils/storageRecovery";
 import { useMdModules } from "./chat/hooks/useMdModules";
 import { useMessageReducer, useConversationReducer } from "./chat/hooks/useMessages";
 import { useQueryGuard } from "./chat/hooks/useQueryGuard";
@@ -1544,14 +1549,59 @@ export function ChatView({
   }, []);
 
   // ── 持久化会话列表 & 当前对话 ID ──
+  const recoverChatStorageWrite = useCallback((
+    operation: string,
+    tryWrite: () => boolean,
+  ): boolean => {
+    const result = retryStorageWriteAfterMessageEviction({
+      storage: localStorage,
+      messageKeyPrefix: STORAGE_KEY_MSGS_PREFIX,
+      conversations: latestConversationsRef.current,
+      activeConversationId: activeConvIdRef.current,
+      tryWrite,
+    });
+    if (result.evictedKeys.length > 0) {
+      logger.warn("Chat.Storage", "evicted cached messages after storage quota exhaustion", {
+        workspace: wsTag,
+        operation,
+        evictedCount: result.evictedKeys.length,
+        recovered: result.succeeded,
+      });
+    }
+    return result.succeeded;
+  }, [STORAGE_KEY_MSGS_PREFIX, latestConversationsRef, wsTag]);
+
+  const persistChatStorageValue = useCallback((
+    operation: string,
+    key: string,
+    value: string,
+  ) => {
+    const result = persistStorageValueWithMessageEviction({
+      storage: localStorage,
+      key,
+      value,
+      messageKeyPrefix: STORAGE_KEY_MSGS_PREFIX,
+      conversations: latestConversationsRef.current,
+      activeConversationId: activeConvIdRef.current,
+    });
+    if (result.evictedKeys.length > 0) {
+      logger.warn("Chat.Storage", "evicted cached messages after storage quota exhaustion", {
+        workspace: wsTag,
+        operation,
+        evictedCount: result.evictedKeys.length,
+        recovered: result.succeeded,
+      });
+    }
+    return result;
+  }, [STORAGE_KEY_MSGS_PREFIX, latestConversationsRef, wsTag]);
+
   // STORAGE_KEY_* intentionally excluded from deps: when only the key changes
   // (workspace switch), the workspace-change effect handles loading new data; if
   // we included the key here, old workspace data would be written to the new key
   // before the workspace-change effect has a chance to run.
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY_CONVS, JSON.stringify(conversations));
-    } catch { /* quota exceeded or private mode */ }
+    const serialized = JSON.stringify(conversations);
+    persistChatStorageValue("conversation_list", STORAGE_KEY_CONVS, serialized);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations]);
 
@@ -1595,14 +1645,10 @@ export function ChatView({
 
     const doSave = () => {
       if (!saveMessagesToStorage(STORAGE_KEY_MSGS_PREFIX + activeConvId, messages)) {
-        try {
-          const convs: ChatConversation[] = JSON.parse(localStorage.getItem(STORAGE_KEY_CONVS) || "[]");
-          const toEvict = [...convs].reverse().find(c => c.id !== activeConvId);
-          if (toEvict) {
-            localStorage.removeItem(STORAGE_KEY_MSGS_PREFIX + toEvict.id);
-            saveMessagesToStorage(STORAGE_KEY_MSGS_PREFIX + activeConvId, messages);
-          }
-        } catch { /* give up */ }
+        recoverChatStorageWrite(
+          "active_conversation_messages",
+          () => saveMessagesToStorage(STORAGE_KEY_MSGS_PREFIX + activeConvId, messages),
+        );
       }
     };
 
@@ -1615,8 +1661,9 @@ export function ChatView({
       saveMessagesTimerRef.current = setTimeout(doSave, 300) as unknown as number;
     }
     return () => { if (saveMessagesTimerRef.current) clearTimeout(saveMessagesTimerRef.current); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- STORAGE_KEY_* excluded
-  // to avoid writing stale data to a new workspace key during workspace transition.
+  // STORAGE_KEY_* and the recovery callback are excluded to avoid writing stale
+  // data to a new workspace key during workspace transition.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages, activeConvId, streamingTick]);
 
   // (messagesSnapshotRef / liveMessagesCache removed — StreamContext manages live messages)
@@ -2395,12 +2442,23 @@ export function ChatView({
           ...base,
           delayMs: event.delayMs,
         });
-      } else if (event.type === "error") {
+      } else if (event.type === "request_error") {
         logger.warn("Chat.SessionRestore", "request failed; retrying", {
           ...base,
           delayMs: event.delayMs,
           error: String(event.error),
         });
+      } else if (event.type === "reconcile_error") {
+        logger.warn(
+          "Chat.SessionRestore",
+          event.retry ? "reconciliation failed; retrying" : "reconciliation failed; stopping",
+          {
+            ...base,
+            retry: event.retry,
+            ...(event.delayMs !== undefined ? { delayMs: event.delayMs } : {}),
+            error: String(event.error),
+          },
+        );
       } else if (event.type === "cancelled") {
         logger.info("Chat.SessionRestore", "cancelled", base);
       }
@@ -2452,17 +2510,43 @@ export function ChatView({
         try { localStorage.removeItem("openakita_data_epoch"); } catch { /* ignore */ }
 
         if (epoch) {
-          const cached = localStorage.getItem(STORAGE_KEY_DATA_EPOCH);
-          localStorage.setItem(STORAGE_KEY_DATA_EPOCH, epoch);
-          if (cached && cached !== epoch) {
-            setConversations((prev) => {
-              for (const c of prev) {
-                try { localStorage.removeItem(STORAGE_KEY_MSGS_PREFIX + c.id); } catch {}
-              }
-              return [];
+          let cached: string | null = null;
+          try {
+            cached = localStorage.getItem(STORAGE_KEY_DATA_EPOCH);
+          } catch (error) {
+            logger.warn("Chat.SessionRestore", "data epoch cache read failed; continuing", {
+              scope: sessionRestoreScope,
+              workspace: wsTag,
+              error: String(error),
             });
+          }
+          const epochChanged = Boolean(cached && cached !== epoch);
+          if (epochChanged) {
+            for (const conversation of latestConversationsRef.current) {
+              try {
+                localStorage.removeItem(STORAGE_KEY_MSGS_PREFIX + conversation.id);
+              } catch { /* best effort */ }
+            }
+            setConversations([]);
             activateConversation(null);
             setMessages([]);
+          }
+
+          const epochPersistence = persistChatStorageValue(
+            "data_epoch",
+            STORAGE_KEY_DATA_EPOCH,
+            epoch,
+          );
+          if (!epochPersistence.succeeded) {
+            logger.warn("Chat.SessionRestore", "data epoch cache write failed; continuing", {
+              scope: sessionRestoreScope,
+              workspace: wsTag,
+              quotaExceeded: epochPersistence.quotaExceeded,
+              error: String(epochPersistence.error),
+            });
+          }
+
+          if (epochChanged) {
             logger.warn("Chat.SessionRestore", "data epoch changed; cleared local conversations", {
               scope: sessionRestoreScope,
               workspace: wsTag,
@@ -2498,6 +2582,7 @@ export function ChatView({
           activateConversation(restoredConvs[0].id);
         }
       },
+      shouldRetryReconcileError: (error) => !isStorageQuotaExceededError(error),
       onEvent: logRestoreEvent,
     }).then((result) => {
       if (result.status !== "restored" || controller.signal.aborted) return;
@@ -2520,6 +2605,9 @@ export function ChatView({
     STORAGE_KEY_DATA_EPOCH,
     STORAGE_KEY_MSGS_PREFIX,
     activateConversation,
+    latestConversationsRef,
+    persistChatStorageValue,
+    recoverChatStorageWrite,
     setConversations,
     setMessages,
   ]);

--- a/apps/setup-center/src/views/chat/utils/__tests__/sessionRestore.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/sessionRestore.test.ts
@@ -31,6 +31,7 @@ describe("restoreSessionsUntilReady", () => {
 
   it("retries request failures and only reconciles a ready response", async () => {
     const controller = new AbortController();
+    const events: SessionRestoreEvent[] = [];
     const request = vi
       .fn<() => Promise<{ ready: boolean }>>()
       .mockRejectedValueOnce(new Error("connection refused"))
@@ -43,12 +44,14 @@ describe("restoreSessionsUntilReady", () => {
       request,
       isReady: (payload) => payload.ready,
       reconcile,
+      onEvent: (event) => events.push(event),
       retryDelay: () => 0,
       wait: async () => true,
     });
 
     expect(result).toEqual({ status: "restored", attempts: 3 });
     expect(reconcile).toHaveBeenCalledWith({ ready: true });
+    expect(events[1]).toMatchObject({ type: "request_error", attempt: 1 });
   });
 
   it("does not complete until reconciliation succeeds", async () => {
@@ -69,6 +72,33 @@ describe("restoreSessionsUntilReady", () => {
 
     expect(result).toEqual({ status: "restored", attempts: 2 });
     expect(reconcile).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops deterministic reconciliation failures without treating them as request errors", async () => {
+    const controller = new AbortController();
+    const quotaError = { name: "QuotaExceededError" };
+    const events: SessionRestoreEvent[] = [];
+    const request = vi.fn(async () => ({ ready: true }));
+
+    const result = await restoreSessionsUntilReady({
+      signal: controller.signal,
+      request,
+      isReady: (payload) => payload.ready,
+      reconcile: async () => { throw quotaError; },
+      shouldRetryReconcileError: () => false,
+      onEvent: (event) => events.push(event),
+      wait: async () => true,
+    });
+
+    expect(result).toEqual({ status: "failed", attempts: 1, error: quotaError });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toEqual({
+      type: "reconcile_error",
+      attempt: 1,
+      retry: false,
+      delayMs: undefined,
+      error: quotaError,
+    });
   });
 
   it("stops retrying when cancelled", async () => {

--- a/apps/setup-center/src/views/chat/utils/__tests__/storageRecovery.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/storageRecovery.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatConversation } from "../chatTypes";
+import {
+  isStorageQuotaExceededError,
+  persistStorageValueWithMessageEviction,
+  retryStorageWriteAfterMessageEviction,
+  type ChatStorage,
+} from "../storageRecovery";
+
+function conversation(id: string, timestamp: number): ChatConversation {
+  return { id, timestamp, title: id, lastMessage: "", messageCount: 0 };
+}
+
+function memoryStorage(initial: Record<string, string>): ChatStorage & { values: Map<string, string> } {
+  const values = new Map(Object.entries(initial));
+  return {
+    values,
+    get length() { return values.size; },
+    key: (index) => [...values.keys()][index] ?? null,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+  };
+}
+
+describe("isStorageQuotaExceededError", () => {
+  it("recognizes browser quota errors without requiring a DOMException instance", () => {
+    expect(isStorageQuotaExceededError({ name: "QuotaExceededError" })).toBe(true);
+    expect(isStorageQuotaExceededError({ code: 22 })).toBe(true);
+    expect(isStorageQuotaExceededError(new Error("storage exceeded the quota"))).toBe(true);
+    expect(isStorageQuotaExceededError(new Error("permission denied"))).toBe(false);
+  });
+});
+
+describe("retryStorageWriteAfterMessageEviction", () => {
+  it("evicts orphaned caches before known conversations", () => {
+    const storage = memoryStorage({
+      "chat_msgs_default_orphan": "old",
+      "chat_msgs_default_known": "known",
+    });
+    const tryWrite = vi.fn(() => !storage.values.has("chat_msgs_default_orphan"));
+
+    const result = retryStorageWriteAfterMessageEviction({
+      storage,
+      messageKeyPrefix: "chat_msgs_default_",
+      conversations: [conversation("known", 10)],
+      activeConversationId: null,
+      tryWrite,
+    });
+
+    expect(result).toEqual({
+      succeeded: true,
+      evictedKeys: ["chat_msgs_default_orphan"],
+    });
+    expect(storage.values.has("chat_msgs_default_known")).toBe(true);
+  });
+
+  it("evicts non-active conversations from oldest to newest until the write succeeds", () => {
+    const storage = memoryStorage({
+      "chat_msgs_default_oldest": "one",
+      "chat_msgs_default_newer": "two",
+      "chat_msgs_default_active": "three",
+    });
+    const tryWrite = vi.fn(() => (
+      !storage.values.has("chat_msgs_default_oldest")
+      && !storage.values.has("chat_msgs_default_newer")
+    ));
+
+    const result = retryStorageWriteAfterMessageEviction({
+      storage,
+      messageKeyPrefix: "chat_msgs_default_",
+      conversations: [
+        conversation("active", 30),
+        conversation("newer", 20),
+        conversation("oldest", 10),
+      ],
+      activeConversationId: "active",
+      tryWrite,
+    });
+
+    expect(result).toEqual({
+      succeeded: true,
+      evictedKeys: ["chat_msgs_default_oldest", "chat_msgs_default_newer"],
+    });
+    expect(storage.values.has("chat_msgs_default_active")).toBe(true);
+    expect(tryWrite).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports failure without evicting the active conversation", () => {
+    const storage = memoryStorage({ "chat_msgs_default_active": "keep" });
+
+    const result = retryStorageWriteAfterMessageEviction({
+      storage,
+      messageKeyPrefix: "chat_msgs_default_",
+      conversations: [conversation("active", 10)],
+      activeConversationId: "active",
+      tryWrite: () => false,
+    });
+
+    expect(result).toEqual({ succeeded: false, evictedKeys: [] });
+    expect(storage.values.has("chat_msgs_default_active")).toBe(true);
+  });
+});
+
+describe("persistStorageValueWithMessageEviction", () => {
+  it("recovers a quota-limited write by evicting old message caches", () => {
+    const storage = memoryStorage({ "chat_msgs_default_old": "large cache" });
+    storage.setItem = (key, value) => {
+      if (storage.values.has("chat_msgs_default_old")) {
+        throw { name: "QuotaExceededError" };
+      }
+      storage.values.set(key, value);
+    };
+
+    const result = persistStorageValueWithMessageEviction({
+      storage,
+      key: "openakita_data_epoch_default",
+      value: "epoch-2",
+      messageKeyPrefix: "chat_msgs_default_",
+      conversations: [conversation("old", 10)],
+      activeConversationId: null,
+    });
+
+    expect(result).toEqual({
+      succeeded: true,
+      evictedKeys: ["chat_msgs_default_old"],
+      quotaExceeded: true,
+    });
+    expect(storage.values.get("openakita_data_epoch_default")).toBe("epoch-2");
+  });
+
+  it("returns a failed result instead of throwing when quota recovery is impossible", () => {
+    const quotaError = { name: "QuotaExceededError" };
+    const storage = memoryStorage({ "chat_msgs_default_active": "keep" });
+    storage.setItem = () => { throw quotaError; };
+
+    const result = persistStorageValueWithMessageEviction({
+      storage,
+      key: "openakita_data_epoch_default",
+      value: "epoch-2",
+      messageKeyPrefix: "chat_msgs_default_",
+      conversations: [conversation("active", 10)],
+      activeConversationId: "active",
+    });
+
+    expect(result).toEqual({
+      succeeded: false,
+      evictedKeys: [],
+      quotaExceeded: true,
+      error: quotaError,
+    });
+    expect(storage.values.has("chat_msgs_default_active")).toBe(true);
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/sessionRestore.ts
+++ b/apps/setup-center/src/views/chat/utils/sessionRestore.ts
@@ -1,14 +1,20 @@
 export type SessionRestoreEvent =
   | { type: "attempt"; attempt: number }
   | { type: "not_ready"; attempt: number; delayMs: number }
-  | { type: "error"; attempt: number; delayMs: number; error: unknown }
+  | { type: "request_error"; attempt: number; delayMs: number; error: unknown }
+  | {
+    type: "reconcile_error";
+    attempt: number;
+    retry: boolean;
+    delayMs?: number;
+    error: unknown;
+  }
   | { type: "restored"; attempt: number }
   | { type: "cancelled"; attempt: number };
 
-export type SessionRestoreResult = {
-  status: "restored" | "cancelled";
-  attempts: number;
-};
+export type SessionRestoreResult =
+  | { status: "restored" | "cancelled"; attempts: number }
+  | { status: "failed"; attempts: number; error: unknown };
 
 export function sessionRestoreRetryDelay(attempt: number): number {
   return Math.min(1000 * Math.pow(1.5, Math.max(0, attempt - 1)), 5000);
@@ -39,6 +45,7 @@ export async function restoreSessionsUntilReady<T>(options: {
   onEvent?: (event: SessionRestoreEvent) => void;
   retryDelay?: (attempt: number) => number;
   wait?: (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+  shouldRetryReconcileError?: (error: unknown) => boolean;
 }): Promise<SessionRestoreResult> {
   const retryDelay = options.retryDelay ?? sessionRestoreRetryDelay;
   const wait = options.wait ?? waitForRetry;
@@ -48,26 +55,38 @@ export async function restoreSessionsUntilReady<T>(options: {
     attempt += 1;
     options.onEvent?.({ type: "attempt", attempt });
 
+    let payload: T;
     try {
-      const payload = await options.request(attempt);
-      if (options.signal.aborted) break;
-
-      if (options.isReady(payload)) {
-        await options.reconcile(payload);
-        if (options.signal.aborted) break;
-        options.onEvent?.({ type: "restored", attempt });
-        return { status: "restored", attempts: attempt };
-      }
-
-      const delayMs = retryDelay(attempt);
-      options.onEvent?.({ type: "not_ready", attempt, delayMs });
-      if (!(await wait(delayMs, options.signal))) break;
+      payload = await options.request(attempt);
     } catch (error) {
       if (options.signal.aborted) break;
       const delayMs = retryDelay(attempt);
-      options.onEvent?.({ type: "error", attempt, delayMs, error });
+      options.onEvent?.({ type: "request_error", attempt, delayMs, error });
       if (!(await wait(delayMs, options.signal))) break;
+      continue;
     }
+    if (options.signal.aborted) break;
+
+    if (options.isReady(payload)) {
+      try {
+        await options.reconcile(payload);
+      } catch (error) {
+        if (options.signal.aborted) break;
+        const retry = options.shouldRetryReconcileError?.(error) ?? true;
+        const delayMs = retry ? retryDelay(attempt) : undefined;
+        options.onEvent?.({ type: "reconcile_error", attempt, retry, delayMs, error });
+        if (!retry) return { status: "failed", attempts: attempt, error };
+        if (!(await wait(delayMs!, options.signal))) break;
+        continue;
+      }
+      if (options.signal.aborted) break;
+      options.onEvent?.({ type: "restored", attempt });
+      return { status: "restored", attempts: attempt };
+    }
+
+    const delayMs = retryDelay(attempt);
+    options.onEvent?.({ type: "not_ready", attempt, delayMs });
+    if (!(await wait(delayMs, options.signal))) break;
   }
 
   options.onEvent?.({ type: "cancelled", attempt });

--- a/apps/setup-center/src/views/chat/utils/storageRecovery.ts
+++ b/apps/setup-center/src/views/chat/utils/storageRecovery.ts
@@ -1,0 +1,125 @@
+import type { ChatConversation } from "./chatTypes";
+
+export type ChatStorage = Pick<
+  Storage,
+  "getItem" | "setItem" | "removeItem" | "key" | "length"
+>;
+
+export type StorageEvictionResult = {
+  succeeded: boolean;
+  evictedKeys: string[];
+};
+
+export type StorageWriteRecoveryResult = StorageEvictionResult & {
+  quotaExceeded: boolean;
+  error?: unknown;
+};
+
+export function isStorageQuotaExceededError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
+  if (candidate.name === "QuotaExceededError" || candidate.name === "NS_ERROR_DOM_QUOTA_REACHED") {
+    return true;
+  }
+  if (candidate.code === 22 || candidate.code === 1014) return true;
+  return typeof candidate.message === "string" && /quota.*exceed|exceed.*quota/i.test(candidate.message);
+}
+
+function storageKeys(storage: ChatStorage): string[] {
+  const keys: string[] = [];
+  try {
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key) keys.push(key);
+    }
+  } catch {
+    return [];
+  }
+  return keys;
+}
+
+/**
+ * Free chat message caches after a write has already failed, retrying after
+ * every eviction. Orphaned caches are discarded first, followed by known
+ * non-active conversations from oldest to newest.
+ */
+export function retryStorageWriteAfterMessageEviction(options: {
+  storage: ChatStorage;
+  messageKeyPrefix: string;
+  conversations: readonly ChatConversation[];
+  activeConversationId: string | null;
+  tryWrite: () => boolean;
+}): StorageEvictionResult {
+  const {
+    storage,
+    messageKeyPrefix,
+    conversations,
+    activeConversationId,
+    tryWrite,
+  } = options;
+  const activeKey = activeConversationId
+    ? `${messageKeyPrefix}${activeConversationId}`
+    : null;
+  const knownKeys = new Set(conversations.map((conversation) => (
+    `${messageKeyPrefix}${conversation.id}`
+  )));
+  const orphanedKeys = storageKeys(storage).filter((key) => (
+    key.startsWith(messageKeyPrefix) && key !== activeKey && !knownKeys.has(key)
+  ));
+  const oldestConversationKeys = [...conversations]
+    .filter((conversation) => conversation.id !== activeConversationId)
+    .sort((left, right) => left.timestamp - right.timestamp)
+    .map((conversation) => `${messageKeyPrefix}${conversation.id}`);
+  const candidates = [...new Set([...orphanedKeys, ...oldestConversationKeys])];
+  const evictedKeys: string[] = [];
+
+  for (const key of candidates) {
+    try {
+      if (storage.getItem(key) === null) continue;
+      storage.removeItem(key);
+      evictedKeys.push(key);
+    } catch {
+      continue;
+    }
+    if (tryWrite()) return { succeeded: true, evictedKeys };
+  }
+
+  return { succeeded: false, evictedKeys };
+}
+
+/** Persist a value without allowing storage failures to escape into UI workflows. */
+export function persistStorageValueWithMessageEviction(options: {
+  storage: ChatStorage;
+  key: string;
+  value: string;
+  messageKeyPrefix: string;
+  conversations: readonly ChatConversation[];
+  activeConversationId: string | null;
+}): StorageWriteRecoveryResult {
+  const { storage, key, value } = options;
+  let lastError: unknown;
+  const tryWrite = () => {
+    try {
+      storage.setItem(key, value);
+      lastError = undefined;
+      return true;
+    } catch (error) {
+      lastError = error;
+      return false;
+    }
+  };
+
+  if (tryWrite()) {
+    return { succeeded: true, evictedKeys: [], quotaExceeded: false };
+  }
+  if (!isStorageQuotaExceededError(lastError)) {
+    return { succeeded: false, evictedKeys: [], quotaExceeded: false, error: lastError };
+  }
+
+  const recovery = retryStorageWriteAfterMessageEviction({ ...options, tryWrite });
+  return {
+    ...recovery,
+    quotaExceeded: true,
+    ...(recovery.succeeded ? {} : { error: lastError }),
+  };
+}


### PR DESCRIPTION
## Summary

- Continue restoring backend sessions when the local epoch cache cannot be persisted.
- Separate request and reconciliation failures and stop deterministic quota retry loops.
- Reclaim storage by evicting orphaned and oldest non-active message caches while preserving the active conversation.

## Tests

- `npm run test:run`
- `npx tsc -b --pretty false`
- `npx eslint src/views/ChatView.tsx src/views/chat/utils/sessionRestore.ts src/views/chat/utils/storageRecovery.ts src/views/chat/utils/__tests__/sessionRestore.test.ts src/views/chat/utils/__tests__/storageRecovery.test.ts`

Fixes #812
