### PR TITLE
improve session history scalability with SQLite-backed lazy loading

### DIFF
--- a/apps/setup-center/src/styles.css
+++ b/apps/setup-center/src/styles.css
@@ -5270,9 +5270,23 @@ button.btnPrimary:hover {
 
 .convSidebarList {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 4px 6px;
+}
+
+.convListLoading {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  opacity: 0.4;
+}
+
+.convListLoading svg {
+  animation: convSpin 1s linear infinite;
 }
 
 .fileTreeToolbar {

--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { Virtuoso } from "react-virtuoso";
 import { setLanguage } from "../i18n";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { ProviderIcon } from "../components/ProviderIcon";
@@ -93,6 +94,12 @@ import {
   restoreSessionsUntilReady,
   type SessionRestoreEvent,
 } from "./chat/utils/sessionRestore";
+import {
+  buildConversationListRows,
+  sessionListPageStateFromPayload,
+  sessionListPageUrl,
+  type SessionListPageState,
+} from "./chat/utils/sessionListPaging";
 import {
   isStorageQuotaExceededError,
   persistStorageValueWithMessageEviction,
@@ -865,6 +872,13 @@ function _isActiveSecurityConfirm(confirm: SecurityConfirmData | null): confirm 
 }
 
 const HISTORY_PAGE_LIMIT = 80;
+const EMPTY_SESSION_LIST_PAGE: SessionListPageState = {
+  query: "",
+  nextOffset: 0,
+  total: 0,
+  hasMore: false,
+  loading: false,
+};
 type EndpointPolicy = "prefer" | "require";
 type AskUserReplyBody = {
   kind: "normal";
@@ -1056,6 +1070,12 @@ export function ChatView({
     hasMoreBefore: false,
     loadingOlder: false,
   });
+  const [sessionListPage, setSessionListPageState] = useState<SessionListPageState>(EMPTY_SESSION_LIST_PAGE);
+  const sessionListPageRef = useRef<SessionListPageState>(EMPTY_SESSION_LIST_PAGE);
+  const updateSessionListPage = useCallback((next: SessionListPageState) => {
+    sessionListPageRef.current = next;
+    setSessionListPageState(next);
+  }, []);
 
   // ── Workspace switch: reload chat state from new scoped keys ──
   // Also performs one-time migration of legacy global keys into the first real
@@ -1083,6 +1103,7 @@ export function ChatView({
     } catch { convs = []; }
     latestConversationsRef.current = convs;
     convDispatch({ type: "SET_ALL", conversations: convs });
+    updateSessionListPage(EMPTY_SESSION_LIST_PAGE);
 
     // ── activeConvId ──
     let convId: string | null = null;
@@ -1147,9 +1168,8 @@ export function ChatView({
     setFileTrees({});
     setSidebarView("conversations");
   // eslint-disable-next-line react-hooks/exhaustive-deps -- STORAGE_KEY_*/OLD_KEY_* are
-  // derived from wsTag (or are constants); listing wsTag alone is sufficient and
-  // avoids re-running the migration on every render.
-  }, [wsTag]);
+  // derived from wsTag (or are constants); updateSessionListPage is stable.
+  }, [wsTag, updateSessionListPage]);
   const inputTextRef = useRef("");
   const [hasInputText, setHasInputText] = useState(false);
   const [selectedEndpoint, setSelectedEndpoint] = useState("auto");
@@ -2418,7 +2438,30 @@ export function ChatView({
   // 启动后后台对账会话列表：本地先展示，后端异步增量合并，避免"今天新会话缺失"。
   // 只有 SessionManager 明确 ready 后才标记完成；进程存活或 HTTP 可达都不够。
   const sessionRestoreCompletedScope = useRef<string | null>(null);
+  const sessionListRequestIdRef = useRef(0);
   const sessionRestoreScope = `${apiBaseUrl}|${wsTag}`;
+
+  const mergeRestoredSessionPayload = useCallback((rawSessions: unknown[]): ChatConversation[] => {
+    const restoredConvs = rawSessions
+      .map((session) => _sessionConversationFromPayload(session as Record<string, unknown>))
+      .filter((conversation): conversation is ChatConversation => Boolean(conversation));
+
+    if (restoredConvs.length === 0) return restoredConvs;
+    setConversations((prev) => {
+      const prevMap = new Map(prev.map((conversation) => [conversation.id, conversation]));
+      const mergedFromBackend = restoredConvs.map((backendConversation) => {
+        const local = prevMap.get(backendConversation.id);
+        if (!local) return backendConversation;
+        return _mergeSessionConversation(local, backendConversation, {
+          timestampMode: streamContexts.current.has(backendConversation.id) ? "max" : "backend",
+        });
+      });
+      const backendIds = new Set(restoredConvs.map((conversation) => conversation.id));
+      const localOnly = prev.filter((conversation) => !backendIds.has(conversation.id));
+      return [...mergedFromBackend, ...localOnly];
+    });
+    return restoredConvs;
+  }, [setConversations]);
 
   useEffect(() => {
     if (!serviceRunning) {
@@ -2464,10 +2507,11 @@ export function ChatView({
       }
     };
 
+    const restoreRequestId = ++sessionListRequestIdRef.current;
     void restoreSessionsUntilReady<Record<string, unknown>>({
       signal: controller.signal,
       request: async (attempt) => {
-        const res = await safeFetchResponse(`${apiBaseUrl}/api/sessions?channel=desktop`, {
+        const res = await safeFetchResponse(sessionListPageUrl(apiBaseUrl, 0), {
           signal: controller.signal,
         });
         const data = await res.json() as Record<string, unknown>;
@@ -2551,35 +2595,27 @@ export function ChatView({
               scope: sessionRestoreScope,
               workspace: wsTag,
             });
+            updateSessionListPage(EMPTY_SESSION_LIST_PAGE);
             return;
           }
         }
+        if (restoreRequestId !== sessionListRequestIdRef.current) return;
+        updateSessionListPage(sessionListPageStateFromPayload(
+          data,
+          0,
+          backendSessions.length,
+          "",
+        ));
         if (backendSessions.length === 0) return;
 
-        const restoredConvs: ChatConversation[] = backendSessions
-          .map((s) => _sessionConversationFromPayload(s as Record<string, unknown>))
-          .filter((c): c is ChatConversation => Boolean(c));
-
-        setConversations((prev) => {
-          const prevMap = new Map(prev.map((c) => [c.id, c]));
-          const mergedFromBackend: ChatConversation[] = restoredConvs.map((b) => {
-            const local = prevMap.get(b.id);
-            if (!local) return b;
-            // 后端时间戳现以"最后一条真实消息"为准（见后端 #628 修复），是列表
-            // 排序/显示的权威值。只有正在流式输出的会话保留本地乐观值，避免
-            // 对账瞬间把活跃会话往下挪。
-            return _mergeSessionConversation(local, b, {
-              timestampMode: streamContexts.current.has(b.id) ? "max" : "backend",
-            });
-          });
-          const backendIds = new Set(restoredConvs.map((c) => c.id));
-          const localOnly = prev.filter((c) => !backendIds.has(c.id));
-          return [...mergedFromBackend, ...localOnly];
-        });
+        const restoredConvs = mergeRestoredSessionPayload(backendSessions);
 
         // 没有活跃会话时，默认打开后端最新会话
         if (!activeConvIdRef.current) {
-          activateConversation(restoredConvs[0].id);
+          const latestConversation = restoredConvs.reduce((latest, conversation) => (
+            conversation.timestamp > latest.timestamp ? conversation : latest
+          ));
+          activateConversation(latestConversation.id);
         }
       },
       shouldRetryReconcileError: (error) => !isStorageQuotaExceededError(error),
@@ -2610,7 +2646,58 @@ export function ChatView({
     recoverChatStorageWrite,
     setConversations,
     setMessages,
+    updateSessionListPage,
+    mergeRestoredSessionPayload,
   ]);
+
+  const loadSessionListPage = useCallback(async (options?: { reset?: boolean; query?: string }) => {
+    if (!serviceRunning) return;
+    const current = sessionListPageRef.current;
+    const reset = options?.reset === true;
+    const query = (options?.query ?? current.query).trim();
+    if ((!reset && current.loading) || (!reset && !current.hasMore)) return;
+
+    const offset = reset ? 0 : current.nextOffset;
+    const requestId = ++sessionListRequestIdRef.current;
+    updateSessionListPage({
+      ...current,
+      query,
+      loading: true,
+      ...(reset ? { nextOffset: 0, total: 0, hasMore: false } : {}),
+    });
+    try {
+      const response = await safeFetchResponse(sessionListPageUrl(apiBaseUrl, offset, query));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json() as Record<string, unknown>;
+      if (data.ready !== true) throw new Error("session manager not ready");
+      if (requestId !== sessionListRequestIdRef.current) return;
+      const rawSessions = Array.isArray(data.sessions) ? data.sessions : [];
+      mergeRestoredSessionPayload(rawSessions);
+      updateSessionListPage(sessionListPageStateFromPayload(
+        data,
+        offset,
+        rawSessions.length,
+        query,
+      ));
+    } catch (error) {
+      if (requestId !== sessionListRequestIdRef.current) return;
+      logger.warn("Chat.SessionList", "page request failed", {
+        offset,
+        query,
+        error: String(error),
+      });
+      updateSessionListPage({ ...sessionListPageRef.current, loading: false });
+    }
+  }, [apiBaseUrl, mergeRestoredSessionPayload, serviceRunning, updateSessionListPage]);
+
+  useEffect(() => {
+    const query = convSearchQuery.trim();
+    if (query === sessionListPageRef.current.query) return;
+    const timer = window.setTimeout(() => {
+      void loadSessionListPage({ reset: true, query });
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [convSearchQuery, loadSessionListPage]);
 
   // ── Multi-device busy state: poll + WS events ──
   useEffect(() => {
@@ -7112,6 +7199,14 @@ export function ChatView({
     filteredConversations.filter((c) => !c.pinned).sort((a, b) => b.timestamp - a.timestamp),
     [filteredConversations]
   );
+  const conversationListRows = useMemo(() => buildConversationListRows(
+    pinnedConvs,
+    agentConvs,
+    {
+      pinned: t("chat.pinnedSection"),
+      conversations: t("chat.conversationsLabel") || "会话",
+    },
+  ), [agentConvs, pinnedConvs, t]);
 
   const quickStartItems = useMemo<Array<{
     id: string;
@@ -8559,27 +8654,40 @@ export function ChatView({
           </div>
 
           {sidebarView === "conversations" ? (
-            <div className="convSidebarList" role="tabpanel">
-              {pinnedConvs.length > 0 && (
-                <>
-                  <div className="convSectionLabel">{t("chat.pinnedSection")}</div>
-                  {pinnedConvs.map(renderConvItem)}
-                </>
-              )}
-
-              {agentConvs.length > 0 && (
-                <>
-                  <div className="convSectionLabel">{t("chat.conversationsLabel") || "会话"}</div>
-                  {agentConvs.map(renderConvItem)}
-                </>
-              )}
-
-              {filteredConversations.length === 0 && (
+            conversationListRows.length > 0 ? (
+              <Virtuoso
+                className="convSidebarList"
+                role="tabpanel"
+                data={conversationListRows}
+                increaseViewportBy={240}
+                computeItemKey={(_index, row) => row.kind === "section"
+                  ? `section:${row.id}`
+                  : `conversation:${row.conversation.id}`}
+                endReached={() => { void loadSessionListPage(); }}
+                itemContent={(_index, row) => row.kind === "section"
+                  ? <div className="convSectionLabel">{row.label}</div>
+                  : renderConvItem(row.conversation)}
+                components={{
+                  Footer: () => sessionListPage.loading ? (
+                    <div className="convListLoading" aria-label={t("common.loading", "加载中...")}>
+                      <IconLoader size={13} />
+                    </div>
+                  ) : null,
+                }}
+              />
+            ) : (
+              <div className="convSidebarList" role="tabpanel">
+                {sessionListPage.loading ? (
+                  <div className="convListLoading" aria-label={t("common.loading", "加载中...")}>
+                    <IconLoader size={13} />
+                  </div>
+                ) : (
                 <div className="convEmpty">
                   {convSearchQuery ? t("common.noResults") || "无结果" : t("common.noData")}
                 </div>
-              )}
-            </div>
+                )}
+              </div>
+            )
           ) : (
             <div className="fileTreePanel" role="tabpanel">
               {!activeConvId ? (

--- a/apps/setup-center/src/views/chat/utils/__tests__/sessionListPaging.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/sessionListPaging.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatConversation } from "../chatTypes";
+import {
+  buildConversationListRows,
+  SESSION_LIST_PAGE_LIMIT,
+  sessionListPageStateFromPayload,
+  sessionListPageUrl,
+} from "../sessionListPaging";
+
+function conversation(id: string): ChatConversation {
+  return {
+    id,
+    title: id,
+    lastMessage: "",
+    timestamp: 0,
+    messageCount: 0,
+  };
+}
+
+describe("sessionListPageUrl", () => {
+  it("requests bounded desktop pages and includes trimmed search text", () => {
+    const url = new URL(sessionListPageUrl("http://127.0.0.1:18900", 60, "  archived  "));
+
+    expect(url.pathname).toBe("/api/sessions");
+    expect(url.searchParams.get("channel")).toBe("desktop");
+    expect(url.searchParams.get("limit")).toBe(String(SESSION_LIST_PAGE_LIMIT));
+    expect(url.searchParams.get("offset")).toBe("60");
+    expect(url.searchParams.get("q")).toBe("archived");
+  });
+});
+
+describe("sessionListPageStateFromPayload", () => {
+  it("keeps the server cursor and total for the next lazy page", () => {
+    expect(sessionListPageStateFromPayload(
+      { total: 145, has_more: true, next_offset: 120 },
+      60,
+      60,
+      "",
+    )).toEqual({
+      query: "",
+      nextOffset: 120,
+      total: 145,
+      hasMore: true,
+      loading: false,
+    });
+  });
+});
+
+describe("buildConversationListRows", () => {
+  it("creates virtual rows with section labels and stable conversation order", () => {
+    const rows = buildConversationListRows(
+      [conversation("pinned")],
+      [conversation("recent"), conversation("older")],
+      { pinned: "Pinned", conversations: "Conversations" },
+    );
+
+    expect(rows.map((row) => row.kind === "section" ? row.id : row.conversation.id)).toEqual([
+      "pinned",
+      "pinned",
+      "conversations",
+      "recent",
+      "older",
+    ]);
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/sessionListPaging.ts
+++ b/apps/setup-center/src/views/chat/utils/sessionListPaging.ts
@@ -1,0 +1,77 @@
+import type { ChatConversation } from "./chatTypes";
+
+export const SESSION_LIST_PAGE_LIMIT = 60;
+
+export type SessionListPageState = {
+  query: string;
+  nextOffset: number;
+  total: number;
+  hasMore: boolean;
+  loading: boolean;
+};
+
+export type ConversationListRow =
+  | { kind: "section"; id: "pinned" | "conversations"; label: string }
+  | { kind: "conversation"; conversation: ChatConversation };
+
+export function sessionListPageUrl(
+  apiBaseUrl: string,
+  offset: number,
+  query = "",
+): string {
+  const params = new URLSearchParams({
+    channel: "desktop",
+    limit: String(SESSION_LIST_PAGE_LIMIT),
+    offset: String(Math.max(0, offset)),
+  });
+  const normalizedQuery = query.trim();
+  if (normalizedQuery) params.set("q", normalizedQuery);
+  return `${apiBaseUrl}/api/sessions?${params.toString()}`;
+}
+
+export function sessionListPageStateFromPayload(
+  payload: Record<string, unknown>,
+  offset: number,
+  received: number,
+  query: string,
+): SessionListPageState {
+  const total = typeof payload.total === "number" && Number.isFinite(payload.total)
+    ? Math.max(0, payload.total)
+    : offset + received;
+  const hasMore = payload.has_more === true;
+  const payloadNextOffset = payload.next_offset;
+  const nextOffset = hasMore && typeof payloadNextOffset === "number" && Number.isFinite(payloadNextOffset)
+    ? Math.max(offset + received, payloadNextOffset)
+    : offset + received;
+  return {
+    query,
+    nextOffset,
+    total,
+    hasMore,
+    loading: false,
+  };
+}
+
+export function buildConversationListRows(
+  pinned: ChatConversation[],
+  conversations: ChatConversation[],
+  labels: { pinned: string; conversations: string },
+): ConversationListRow[] {
+  const rows: ConversationListRow[] = [];
+  if (pinned.length > 0) {
+    rows.push({ kind: "section", id: "pinned", label: labels.pinned });
+    rows.push(...pinned.map((conversation) => ({ kind: "conversation" as const, conversation })));
+  }
+  if (conversations.length > 0) {
+    rows.push({
+      kind: "section",
+      id: "conversations",
+      label: labels.conversations,
+    });
+    rows.push(...conversations.map((conversation) => ({
+      kind: "conversation" as const,
+      conversation,
+    })));
+  }
+  return rows;
+}

--- a/src/openakita/api/routes/chat.py
+++ b/src/openakita/api/routes/chat.py
@@ -394,7 +394,7 @@ async def _handle_pending_risk_answer(
                         session,
                         operation=classification.get("operation_kind"),
                     )
-                    session_manager.persist()
+                    await asyncio.to_thread(session_manager.persist)
                     logger.info(
                         "[RiskGate] Session trust granted (operation=%s, session=%s, "
                         "confirmation=%s)",
@@ -471,7 +471,7 @@ async def _handle_pending_risk_answer(
                                 )
                         except Exception as exc:
                             logger.warning("[Chat API] Failed to derive AuthorizedIntent: %s", exc)
-                        session_manager.persist()
+                        await asyncio.to_thread(session_manager.persist)
                 except Exception as exc:
                     logger.warning("[Chat API] Failed to persist risk_authorized_replay: %s", exc)
             logger.info(
@@ -528,7 +528,7 @@ async def _handle_pending_risk_answer(
                         "result": result,
                     },
                 )
-                session_manager.persist()
+                await asyncio.to_thread(session_manager.persist)
         except Exception as exc:
             logger.warning("[Chat API] Failed to persist controlled confirmation: %s", exc)
 
@@ -1245,7 +1245,7 @@ def _schedule_background_save(
                 )
                 session.add_message("assistant", bg_reply, **meta)
                 if session_manager:
-                    session_manager.persist()
+                    await asyncio.to_thread(session_manager.persist)
                 logger.info(
                     "[Chat API] Background save: %d chars (conv=%s)",
                     len(bg_reply),
@@ -1825,7 +1825,7 @@ async def _stream_chat(
                             },
                         )
                         if session_manager is not None:
-                            session_manager.persist()
+                            await asyncio.to_thread(session_manager.persist)
             elif event_type == "pending_approval":
                 _pending_approval = True
             elif event_type == "plan_ready_for_approval":
@@ -2049,7 +2049,7 @@ async def _stream_chat(
                     _msg_meta["stream_error"] = _agent_error_msg
                 session.add_message("assistant", assistant_text_to_save, **_msg_meta)
                 if session_manager:
-                    session_manager.persist()
+                    await asyncio.to_thread(session_manager.persist)
             except Exception as e:
                 logger.error(
                     f"[Chat API] Failed to save assistant message to session: {e}", exc_info=True
@@ -2188,7 +2188,7 @@ async def _stream_chat(
                     )
                     session.add_message("assistant", _deferred_text, **_deferred_meta)
                     if session_manager:
-                        session_manager.persist()
+                        await asyncio.to_thread(session_manager.persist)
                     logger.info(
                         f"[Chat API] Deferred save: {len(_deferred_text)} chars "
                         f"(client_disconnected={_client_disconnected})"
@@ -2373,7 +2373,7 @@ async def _stream_org_command_chat(
     _BUSY_REFRESH_INTERVAL = 60.0
     _last_busy_refresh_ts = 0.0
 
-    def _persist_org_error(message: str, *, error_code: str, org_status: str | None) -> None:
+    async def _persist_org_error(message: str, *, error_code: str, org_status: str | None) -> None:
         if session_manager is None:
             return
         try:
@@ -2395,7 +2395,7 @@ async def _stream_org_command_chat(
                     "org_status": org_status,
                 },
             )
-            session_manager.persist()
+            await asyncio.to_thread(session_manager.persist)
         except Exception:
             logger.warning("[Chat API] failed to persist org command error", exc_info=True)
 
@@ -2447,7 +2447,7 @@ async def _stream_org_command_chat(
 
         if svc is None:
             message = "OrgCommandService not initialized"
-            _persist_org_error(
+            await _persist_org_error(
                 message,
                 error_code="org_command_service_unavailable",
                 org_status=None,
@@ -2491,7 +2491,7 @@ async def _stream_org_command_chat(
         except OrgCommandError as exc:
             error_code = getattr(exc, "error_code", "org_command_error")
             org_status = getattr(exc, "org_status", None)
-            _persist_org_error(
+            await _persist_org_error(
                 str(exc),
                 error_code=error_code,
                 org_status=org_status,
@@ -2510,7 +2510,7 @@ async def _stream_org_command_chat(
         except Exception:
             logger.exception("[Chat API] failed to submit org command (org=%s)", org_id)
             message = "组织命令提交失败，请重试。"
-            _persist_org_error(
+            await _persist_org_error(
                 message,
                 error_code="org_command_submit_failed",
                 org_status=None,

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -8,6 +8,7 @@ PATCH /api/sessions/{conversation_id}/title, POST /api/sessions/generate-title
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import logging
 import mimetypes
@@ -755,7 +756,17 @@ async def list_sessions(
             "has_more": False,
         }
 
-    if hasattr(session_manager, "list_session_summaries"):
+    if hasattr(session_manager, "list_session_summaries_page"):
+        catalog_page = session_manager.list_session_summaries_page(
+            channel=channel,
+            query=q,
+            exclude_org_chats=True,
+            limit=limit,
+            offset=offset,
+        )
+        total = catalog_page.total
+        result = [_session_list_item_from_summary(summary) for summary in catalog_page.summaries]
+    elif hasattr(session_manager, "list_session_summaries"):
         summaries = session_manager.list_session_summaries(channel=channel)
         summaries = [s for s in summaries if not str(s.get("chat_id") or "").startswith("org_")]
         normalized_query = q.strip().casefold()
@@ -775,8 +786,10 @@ async def list_sessions(
             reverse=True,
         )
         total = len(summaries)
-        page = summaries[offset : offset + limit]
-        result = [_session_list_item_from_summary(summary) for summary in page]
+        result = [
+            _session_list_item_from_summary(summary)
+            for summary in summaries[offset : offset + limit]
+        ]
     else:
         sessions = session_manager.list_sessions(channel=channel)
         sessions = [s for s in sessions if not s.chat_id.startswith("org_")]
@@ -899,7 +912,7 @@ async def create_session(
     )
     session_manager.mark_dirty()
     try:
-        session_manager.persist()
+        await asyncio.to_thread(session_manager.persist)
     except Exception as exc:
         logger.warning("[Sessions API] Failed to persist created session: %s", exc)
 
@@ -987,7 +1000,7 @@ async def update_session_ui_state(
     )
     session_manager.mark_dirty()
     try:
-        session_manager.persist()
+        await asyncio.to_thread(session_manager.persist_summary, session)
     except Exception as exc:
         logger.warning("[Sessions API] Failed to persist UI state: %s", exc)
     return {"ok": True}
@@ -1029,7 +1042,7 @@ async def update_session_title(
     session.set_metadata(_META_TITLE_GENERATED, generated)
     session_manager.mark_dirty()
     try:
-        session_manager.persist()
+        await asyncio.to_thread(session_manager.persist)
     except Exception as exc:
         logger.warning("[Sessions API] Failed to persist title: %s", exc)
 
@@ -1081,7 +1094,7 @@ async def update_session_pin(
     session.set_metadata(_META_PINNED, pinned)
     session_manager.mark_dirty()
     try:
-        session_manager.persist()
+        await asyncio.to_thread(session_manager.persist)
     except Exception as exc:
         logger.warning("[Sessions API] Failed to persist pin state: %s", exc)
 
@@ -1696,7 +1709,7 @@ async def generate_title(request: Request, body: GenerateTitleRequest):
                 if session_manager:
                     session_manager.mark_dirty()
                     try:
-                        session_manager.persist()
+                        await asyncio.to_thread(session_manager.persist)
                     except Exception as exc:
                         logger.warning("[Sessions API] Failed to persist generated title: %s", exc)
                 summary = _session_list_item(session)

--- a/src/openakita/api/routes/sessions.py
+++ b/src/openakita/api/routes/sessions.py
@@ -272,6 +272,31 @@ def _session_list_item(
     }
 
 
+def _session_list_item_from_summary(summary: dict) -> dict:
+    """Translate a persisted catalog projection to the desktop API shape."""
+    return {
+        "id": str(summary.get("chat_id") or ""),
+        "title": str(summary.get("title") or "对话"),
+        "titleGenerated": bool(summary.get("title_generated")),
+        "titleManuallySet": bool(summary.get("title_manually_set")),
+        "pinned": bool(summary.get("pinned")),
+        "lastMessage": str(summary.get("last_message") or ""),
+        "timestamp": int(summary.get("timestamp") or 0),
+        "messageCount": int(summary.get("message_count") or 0),
+        "agentProfileId": str(summary.get("agent_profile_id") or "default"),
+        "endpointId": summary.get("endpoint_id") or None,
+        "endpointPolicy": (
+            str(summary.get("endpoint_policy") or "prefer")
+            if summary.get("endpoint_id")
+            else "prefer"
+        ),
+        "orgMode": bool(summary.get("org_mode")),
+        "orgId": summary.get("org_id") or None,
+        "orgNodeId": summary.get("org_node_id") or None,
+        "workingDirectory": str(summary.get("working_directory") or ""),
+    }
+
+
 _BACKFILL_DONE_FLAG = "_history_backfilled"
 
 
@@ -705,39 +730,95 @@ def _reconcile_history_todo_lifecycle(
 
 
 @router.get("/api/sessions")
-async def list_sessions(request: Request, channel: str = "desktop"):
+async def list_sessions(
+    request: Request,
+    channel: str = "desktop",
+    limit: int = Query(60, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    q: str = Query("", max_length=200),
+):
     """List sessions for a given channel (default: desktop).
 
-    Returns a list of conversations with metadata, ordered by last_active desc.
+    Returns a page of conversations with metadata, pinned first and then by activity.
     """
     _validate_id(channel, "channel")
     session_manager = getattr(request.app.state, "session_manager", None)
     if not session_manager or not getattr(session_manager, "_sessions_loaded", False):
         wac = getattr(request.app.state, "web_access_config", None)
-        return {"sessions": [], "data_epoch": wac.data_epoch if wac else "", "ready": False}
+        return {
+            "sessions": [],
+            "data_epoch": wac.data_epoch if wac else "",
+            "ready": False,
+            "total": 0,
+            "offset": offset,
+            "next_offset": None,
+            "has_more": False,
+        }
 
-    sessions = session_manager.list_sessions(channel=channel)
-    # org_* sessions belong to OrgChatPanel (指挥台), not the main chat UI.
-    sessions = [s for s in sessions if not s.chat_id.startswith("org_")]
+    if hasattr(session_manager, "list_session_summaries"):
+        summaries = session_manager.list_session_summaries(channel=channel)
+        summaries = [s for s in summaries if not str(s.get("chat_id") or "").startswith("org_")]
+        normalized_query = q.strip().casefold()
+        if normalized_query:
+            summaries = [
+                summary
+                for summary in summaries
+                if normalized_query in str(summary.get("title") or "").casefold()
+                or normalized_query in str(summary.get("last_message") or "").casefold()
+            ]
+        summaries.sort(
+            key=lambda summary: (
+                bool(summary.get("pinned")),
+                int(summary.get("timestamp") or 0),
+                str(summary.get("chat_id") or ""),
+            ),
+            reverse=True,
+        )
+        total = len(summaries)
+        page = summaries[offset : offset + limit]
+        result = [_session_list_item_from_summary(summary) for summary in page]
+    else:
+        sessions = session_manager.list_sessions(channel=channel)
+        sessions = [s for s in sessions if not s.chat_id.startswith("org_")]
+        prepared = []
+        for session in sessions:
+            visible_msgs = [m for _, m in _visible_history_messages(session)]
+            prepared.append((session, visible_msgs, _last_activity_ms(session, visible_msgs)))
+        prepared.sort(
+            key=lambda item: (bool(item[0].get_metadata("pinned")), item[2]), reverse=True
+        )
+        legacy_result = [
+            _session_list_item(session, visible_msgs, last_ms)
+            for session, visible_msgs, last_ms in prepared
+        ]
+        normalized_query = q.strip().casefold()
+        if normalized_query:
+            legacy_result = [
+                item
+                for item in legacy_result
+                if normalized_query in str(item.get("title") or "").casefold()
+                or normalized_query in str(item.get("lastMessage") or "").casefold()
+            ]
+        total = len(legacy_result)
+        result = legacy_result[offset : offset + limit]
 
-    # 先算出每个会话的可见消息与"最后活动时间"，再按真实活动时间排序。
-    # 不能直接用 s.last_active 排序：它会被纯读取访问污染（issue #628）。
-    prepared = []
-    for s in sessions:
-        visible_msgs = [m for _, m in _visible_history_messages(s)]
-        prepared.append((s, visible_msgs, _last_activity_ms(s, visible_msgs)))
-    prepared.sort(key=lambda item: item[2], reverse=True)
-
-    result = []
-    for s, visible_msgs, last_ms in prepared:
-        result.append(_session_list_item(s, visible_msgs, last_ms))
+    next_offset = offset + len(result)
+    has_more = next_offset < total
 
     data_epoch = ""
     wac = getattr(request.app.state, "web_access_config", None)
     if wac:
         data_epoch = wac.data_epoch
 
-    return {"sessions": result, "data_epoch": data_epoch, "ready": True}
+    return {
+        "sessions": result,
+        "data_epoch": data_epoch,
+        "ready": True,
+        "total": total,
+        "offset": offset,
+        "next_offset": next_offset if has_more else None,
+        "has_more": has_more,
+    }
 
 
 @router.post("/api/sessions")

--- a/src/openakita/main.py
+++ b/src/openakita/main.py
@@ -343,10 +343,12 @@ async def ensure_session_manager():
 
 
 def _setup_session_backfill(agent_or_master):
-    """从 SQLite 回填 session 中可能缺失的消息（崩溃恢复）。
+    """Bind lazy SQLite history recovery and per-turn crash persistence.
 
     PR-D3：同时绑定 ``set_turn_writer``，让 ``Session.add_message`` 能在
     用户/助手每条消息落地时同步写一份到 SQLite，进程崩溃也不丢历史。
+    完整历史由 ``SessionManager.get_session`` 在会话实际使用时按需回填，
+    避免启动阶段为了修复少数会话而加载全部历史。
     """
     _actual_agent = agent_or_master
     if _actual_agent and hasattr(_actual_agent, "memory_manager"):
@@ -389,9 +391,6 @@ def _setup_session_backfill(agent_or_master):
                 _session_manager.set_turn_writer(_write_turn)
             except Exception as exc:
                 logger.warning(f"[main] set_turn_writer failed: {exc}")
-            backfilled = _session_manager.backfill_sessions_from_store()
-            if backfilled:
-                logger.info(f"Session backfill: recovered {backfilled} turns from SQLite")
 
 
 def _web_password_already_set() -> bool:

--- a/src/openakita/sessions/catalog.py
+++ b/src/openakita/sessions/catalog.py
@@ -1,16 +1,66 @@
-"""Lightweight random-access index for the canonical sessions.json store."""
+"""SQLite-backed random-access catalog for the canonical sessions.json store."""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable
+import logging
+import os
+import shutil
+import sqlite3
+import threading
+import time
+from collections.abc import Iterable, Iterator, Sequence
+from contextlib import closing, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from openakita.utils.atomic_io import atomic_json_write, safe_write
+from openakita.utils.atomic_io import path_transaction_lock
 
-CATALOG_VERSION = 1
+logger = logging.getLogger(__name__)
+
+CATALOG_VERSION = 3
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS catalog_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_key  TEXT PRIMARY KEY,
+    byte_offset  INTEGER NOT NULL,
+    byte_length  INTEGER NOT NULL,
+    session_id   TEXT NOT NULL,
+    channel      TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    state        TEXT NOT NULL,
+    chat_id      TEXT NOT NULL,
+    pinned       INTEGER NOT NULL,
+    timestamp_ms INTEGER NOT NULL,
+    title        TEXT NOT NULL,
+    last_message TEXT NOT NULL,
+    search_text  TEXT NOT NULL,
+    summary_json TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS session_search USING fts5(
+    session_key UNINDEXED,
+    search_text,
+    tokenize='trigram'
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_catalog_session_id
+    ON sessions (session_id);
+CREATE INDEX IF NOT EXISTS idx_session_catalog_listing
+    ON sessions (channel, pinned DESC, timestamp_ms DESC, chat_id DESC);
+CREATE INDEX IF NOT EXISTS idx_session_catalog_state_listing
+    ON sessions (channel, state, pinned DESC, timestamp_ms DESC, chat_id DESC);
+CREATE INDEX IF NOT EXISTS idx_session_catalog_user_listing
+    ON sessions (user_id, pinned DESC, timestamp_ms DESC, chat_id DESC);
+CREATE INDEX IF NOT EXISTS idx_session_catalog_user_state_listing
+    ON sessions (user_id, state, pinned DESC, timestamp_ms DESC, chat_id DESC);
+"""
 
 
 @dataclass(frozen=True)
@@ -20,85 +70,237 @@ class SessionCatalogEntry:
     length: int
     summary: dict[str, Any]
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "session_key": self.session_key,
-            "offset": self.offset,
-            "length": self.length,
-            "summary": self.summary,
-        }
 
-    @classmethod
-    def from_dict(cls, value: Any) -> SessionCatalogEntry | None:
-        if not isinstance(value, dict):
-            return None
-        session_key = value.get("session_key")
-        offset = value.get("offset")
-        length = value.get("length")
-        summary = value.get("summary")
-        if (
-            not isinstance(session_key, str)
-            or not session_key
-            or not isinstance(offset, int)
-            or offset < 0
-            or not isinstance(length, int)
-            or length <= 0
-            or not isinstance(summary, dict)
-        ):
-            return None
-        return cls(session_key=session_key, offset=offset, length=length, summary=summary)
+@dataclass(frozen=True)
+class SessionCatalogPage:
+    summaries: list[dict[str, Any]]
+    total: int
 
 
 class SessionCatalogIndexWriteError(OSError):
-    """The session store was replaced but its companion index was not."""
-
-    def __init__(self, entries: dict[str, SessionCatalogEntry], cause: Exception):
-        super().__init__(f"failed to write session catalog index: {cause}")
-        self.entries = entries
+    """The session store was replaced but its SQLite catalog was not."""
 
 
 class SessionCatalogStore:
-    """Keep compact session summaries separate from full session documents.
+    """Keep queryable summaries separate from full session documents.
 
     ``sessions.json`` remains the canonical, backwards-compatible array. The
-    adjacent index records byte ranges for each array item so a single session
-    can be hydrated without parsing every conversation and message at startup.
+    adjacent SQLite database stores byte ranges and compact projections, so
+    startup and list requests do not deserialize every conversation.
     """
 
     def __init__(self, sessions_file: Path):
         self.sessions_file = Path(sessions_file)
-        self.index_file = self.sessions_file.with_name("sessions.index.json")
+        self.index_file = self.sessions_file.with_name("sessions.index.sqlite3")
+        self.pending_index_file = self.index_file.with_suffix(self.index_file.suffix + ".next")
+        self.building_index_file = self.index_file.with_suffix(self.index_file.suffix + ".building")
+        self.legacy_index_file = self.sessions_file.with_name("sessions.index.json")
+        self._lock = threading.RLock()
 
-    def load(self) -> dict[str, SessionCatalogEntry] | None:
-        if not self.sessions_file.exists() or not self.index_file.exists():
-            return None
-        try:
-            with open(self.index_file, encoding="utf-8") as handle:
-                payload = json.load(handle)
-            if not isinstance(payload, dict) or payload.get("version") != CATALOG_VERSION:
-                return None
+    def load(self) -> bool:
+        """Return whether a catalog matching the current sessions file exists."""
+        with self._lock:
+            return self._valid_index_path_unlocked() is not None
 
-            stat = self.sessions_file.stat()
-            if payload.get("source_size") != stat.st_size:
+    def get_entry(self, session_key: str) -> SessionCatalogEntry | None:
+        with self._read_connection() as conn:
+            if conn is None:
                 return None
-            if payload.get("source_mtime_ns") != stat.st_mtime_ns:
-                return None
+            row = conn.execute(
+                """
+                SELECT session_key, byte_offset, byte_length, summary_json
+                FROM sessions WHERE session_key = ?
+                """,
+                (session_key,),
+            ).fetchone()
+        return self._entry_from_row(row)
 
-            raw_entries = payload.get("sessions")
-            if not isinstance(raw_entries, list):
+    def get_entry_by_session_id(self, session_id: str) -> SessionCatalogEntry | None:
+        with self._read_connection() as conn:
+            if conn is None:
                 return None
+            row = conn.execute(
+                """
+                SELECT session_key, byte_offset, byte_length, summary_json
+                FROM sessions WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        return self._entry_from_row(row)
 
-            entries: dict[str, SessionCatalogEntry] = {}
-            for raw_entry in raw_entries:
-                entry = SessionCatalogEntry.from_dict(raw_entry)
-                if entry is None or entry.offset + entry.length > stat.st_size:
-                    return None
-                if entry.session_key in entries:
-                    return None
-                entries[entry.session_key] = entry
-            return entries
-        except (OSError, ValueError, TypeError):
-            return None
+    def get_summaries(self, session_keys: Sequence[str]) -> dict[str, dict[str, Any]]:
+        if not session_keys:
+            return {}
+        result: dict[str, dict[str, Any]] = {}
+        with self._read_connection() as conn:
+            if conn is None:
+                return result
+            for start in range(0, len(session_keys), 500):
+                batch = session_keys[start : start + 500]
+                placeholders = ",".join("?" for _ in batch)
+                rows = conn.execute(
+                    f"SELECT session_key, summary_json FROM sessions "
+                    f"WHERE session_key IN ({placeholders})",
+                    tuple(batch),
+                ).fetchall()
+                for session_key, raw_summary in rows:
+                    summary = self._decode_summary(raw_summary)
+                    if summary is not None:
+                        result[str(session_key)] = summary
+        return result
+
+    def iter_entries(self, *, include_closed: bool = True) -> Iterator[SessionCatalogEntry]:
+        where = "" if include_closed else "WHERE state <> 'closed'"
+        with self._read_connection() as conn:
+            if conn is None:
+                return
+            cursor = conn.execute(
+                f"""
+                SELECT session_key, byte_offset, byte_length, summary_json
+                FROM sessions {where} ORDER BY rowid
+                """
+            )
+            while True:
+                rows = cursor.fetchmany(128)
+                if not rows:
+                    break
+                for row in rows:
+                    entry = self._entry_from_row(row)
+                    if entry is not None:
+                        yield entry
+
+    def list_summaries(
+        self,
+        *,
+        channel: str | None = None,
+        user_id: str | None = None,
+        state: str | None = None,
+        query: str = "",
+        exclude_org_chats: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> SessionCatalogPage:
+        where, params = self._summary_filters(
+            channel=channel,
+            user_id=user_id,
+            state=state,
+            query=query,
+            exclude_org_chats=exclude_org_chats,
+        )
+        with self._read_connection() as conn:
+            if conn is None:
+                return SessionCatalogPage([], 0)
+            total = int(
+                conn.execute(f"SELECT COUNT(*) FROM sessions {where}", tuple(params)).fetchone()[0]
+            )
+            sql = (
+                "SELECT summary_json FROM sessions "
+                f"{where} ORDER BY pinned DESC, timestamp_ms DESC, chat_id DESC"
+            )
+            page_params = list(params)
+            if limit is not None:
+                sql += " LIMIT ? OFFSET ?"
+                page_params.extend((max(0, int(limit)), max(0, int(offset))))
+            rows = conn.execute(sql, tuple(page_params)).fetchall()
+
+        summaries: list[dict[str, Any]] = []
+        for (raw_summary,) in rows:
+            summary = self._decode_summary(raw_summary)
+            if summary is not None:
+                summaries.append(summary)
+        return SessionCatalogPage(summaries, total)
+
+    def counts(self) -> dict[str, Any]:
+        stats: dict[str, Any] = {"total": 0, "active": 0, "idle": 0, "by_channel": {}}
+        with self._read_connection() as conn:
+            if conn is None:
+                return stats
+            rows = conn.execute(
+                """
+                SELECT channel, state, COUNT(*)
+                FROM sessions
+                WHERE state <> 'closed'
+                GROUP BY channel, state
+                """
+            ).fetchall()
+        for channel, state, raw_count in rows:
+            count = int(raw_count)
+            stats["total"] += count
+            stats["by_channel"][str(channel)] = stats["by_channel"].get(str(channel), 0) + count
+            if state == "active":
+                stats["active"] += count
+            elif state in {"idle", "expired"}:
+                stats["idle"] += count
+        return stats
+
+    def contains_many(self, session_keys: Sequence[str]) -> set[str]:
+        return set(self.get_summaries(session_keys))
+
+    def keys_for_channel(self, channel: str) -> list[str]:
+        with self._read_connection() as conn:
+            if conn is None:
+                return []
+            rows = conn.execute(
+                "SELECT session_key FROM sessions WHERE channel = ?",
+                (channel,),
+            ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    def delete(self, session_key: str) -> bool:
+        return self.delete_many([session_key]) > 0
+
+    def delete_many(self, session_keys: Sequence[str]) -> int:
+        if not session_keys:
+            return 0
+        deleted = 0
+        with self._write_connection() as conn:
+            if conn is None:
+                return 0
+            for start in range(0, len(session_keys), 500):
+                batch = session_keys[start : start + 500]
+                placeholders = ",".join("?" for _ in batch)
+                cursor = conn.execute(
+                    f"DELETE FROM sessions WHERE session_key IN ({placeholders})",
+                    tuple(batch),
+                )
+                deleted += max(0, int(cursor.rowcount or 0))
+                conn.execute(
+                    f"DELETE FROM session_search WHERE session_key IN ({placeholders})",
+                    tuple(batch),
+                )
+            conn.commit()
+        return deleted
+
+    def update_summary(self, session_key: str, summary: dict[str, Any]) -> bool:
+        """Update one catalog projection without changing the JSON document offsets."""
+        with self._write_connection() as conn:
+            if conn is None:
+                return False
+            row = conn.execute(
+                "SELECT byte_offset, byte_length FROM sessions WHERE session_key = ?",
+                (session_key,),
+            ).fetchone()
+            if row is None:
+                return False
+
+            values = self._summary_row(session_key, int(row[0]), int(row[1]), summary)
+            conn.execute(
+                """
+                UPDATE sessions SET
+                    session_id = ?, channel = ?, user_id = ?, state = ?, chat_id = ?,
+                    pinned = ?, timestamp_ms = ?, title = ?, last_message = ?,
+                    search_text = ?, summary_json = ?
+                WHERE session_key = ?
+                """,
+                (*values[3:], session_key),
+            )
+            conn.execute("DELETE FROM session_search WHERE session_key = ?", (session_key,))
+            conn.execute(
+                "INSERT INTO session_search (session_key, search_text) VALUES (?, ?)",
+                (session_key, self._summary_search_text(summary)),
+            )
+            conn.commit()
+        return True
 
     def read_document(self, entry: SessionCatalogEntry) -> dict[str, Any] | None:
         try:
@@ -122,56 +324,339 @@ class SessionCatalogStore:
     def write(
         self,
         documents: Iterable[tuple[str, str | dict[str, Any], dict[str, Any]]],
-    ) -> dict[str, SessionCatalogEntry]:
-        parts = ["["]
-        byte_offset = 1
-        entries: dict[str, SessionCatalogEntry] = {}
+    ) -> int:
+        """Atomically replace the JSON store and rebuild its SQLite catalog."""
+        self.sessions_file.parent.mkdir(parents=True, exist_ok=True)
+        sessions_tmp = self.sessions_file.with_suffix(self.sessions_file.suffix + ".tmp")
+        source_replaced = False
 
-        for index, (session_key, document, summary) in enumerate(documents):
-            if session_key in entries:
-                raise ValueError(f"duplicate session key: {session_key}")
-            raw = (
-                document.strip()
-                if isinstance(document, str)
-                else json.dumps(document, ensure_ascii=False, separators=(",", ":"))
-            )
-            if not raw.startswith("{") or not raw.endswith("}"):
-                raise ValueError(f"invalid session document: {session_key}")
-            if index:
-                parts.append(",")
-                byte_offset += 1
-            raw_length = len(raw.encode("utf-8"))
-            entries[session_key] = SessionCatalogEntry(
-                session_key=session_key,
-                offset=byte_offset,
-                length=raw_length,
-                summary=dict(summary),
-            )
-            parts.append(raw)
-            byte_offset += raw_length
+        with self._lock, path_transaction_lock(self.sessions_file):
+            self._remove_sqlite_file(self.building_index_file)
+            source_index = self._valid_index_path_unlocked()
+            conn = sqlite3.connect(str(self.building_index_file))
+            try:
+                if source_index is None:
+                    self._initialize_schema(conn)
+                else:
+                    with closing(sqlite3.connect(str(source_index))) as source_conn:
+                        source_conn.backup(conn)
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("DELETE FROM session_search")
+                conn.execute("DELETE FROM sessions")
+                count = 0
+                byte_offset = 1
+                with open(sessions_tmp, "wb") as handle:
+                    handle.write(b"[")
+                    for session_key, document, summary in documents:
+                        raw = (
+                            document.strip()
+                            if isinstance(document, str)
+                            else json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+                        )
+                        if not raw.startswith("{") or not raw.endswith("}"):
+                            raise ValueError(f"invalid session document: {session_key}")
+                        encoded = raw.encode("utf-8")
+                        if count:
+                            handle.write(b",")
+                            byte_offset += 1
+                        conn.execute(
+                            """
+                            INSERT INTO sessions (
+                                session_key, byte_offset, byte_length, session_id,
+                                channel, user_id, state, chat_id, pinned, timestamp_ms,
+                                title, last_message, search_text, summary_json
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            self._summary_row(session_key, byte_offset, len(encoded), summary),
+                        )
+                        search_text = self._summary_search_text(summary)
+                        conn.execute(
+                            "INSERT INTO session_search (session_key, search_text) VALUES (?, ?)",
+                            (session_key, search_text),
+                        )
+                        handle.write(encoded)
+                        byte_offset += len(encoded)
+                        count += 1
+                    handle.write(b"]\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
 
-        parts.append("]\n")
-        safe_write(
-            self.sessions_file,
-            "".join(parts),
-            backup=True,
-            fsync=True,
-            allow_fallback=False,
+                source_stat = sessions_tmp.stat()
+                conn.executemany(
+                    "INSERT OR REPLACE INTO catalog_meta (key, value) VALUES (?, ?)",
+                    (
+                        ("version", str(CATALOG_VERSION)),
+                        ("source_size", str(source_stat.st_size)),
+                        ("source_mtime_ns", str(source_stat.st_mtime_ns)),
+                    ),
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                sessions_tmp.unlink(missing_ok=True)
+                self._remove_sqlite_file(self.building_index_file)
+                raise
+            finally:
+                conn.close()
+
+            try:
+                self._backup_sessions_file()
+                self._replace_with_retry(sessions_tmp, self.sessions_file)
+                source_replaced = True
+                self._replace_with_retry(self.building_index_file, self.index_file)
+                self._remove_sqlite_file(self.pending_index_file)
+                self.legacy_index_file.unlink(missing_ok=True)
+                return count
+            except Exception as exc:
+                if source_replaced and self.building_index_file.exists():
+                    try:
+                        self._replace_with_retry(
+                            self.building_index_file,
+                            self.pending_index_file,
+                        )
+                    except OSError:
+                        pass
+                if source_replaced:
+                    raise SessionCatalogIndexWriteError(
+                        f"failed to install SQLite session catalog: {exc}"
+                    ) from exc
+                raise
+            finally:
+                sessions_tmp.unlink(missing_ok=True)
+                self._remove_sqlite_file(self.building_index_file)
+
+    @staticmethod
+    def _initialize_schema(conn: sqlite3.Connection) -> None:
+        """Create catalog tables during first-time initialization or migration."""
+        conn.executescript(_SCHEMA_SQL)
+
+    @staticmethod
+    def summary_matches(
+        summary: dict[str, Any],
+        *,
+        channel: str | None = None,
+        user_id: str | None = None,
+        state: str | None = None,
+        query: str = "",
+        exclude_org_chats: bool = False,
+    ) -> bool:
+        summary_state = str(summary.get("state") or "")
+        if summary_state == "expired":
+            summary_state = "idle"
+        if summary_state == "closed":
+            return False
+        if channel and summary.get("channel") != channel:
+            return False
+        if user_id and summary.get("user_id") != user_id:
+            return False
+        if state and summary_state != state:
+            return False
+        if exclude_org_chats and str(summary.get("chat_id") or "").startswith("org_"):
+            return False
+        normalized_query = query.strip().casefold()
+        if normalized_query:
+            searchable = (
+                f"{summary.get('title') or ''}\n{summary.get('last_message') or ''}".casefold()
+            )
+            if normalized_query not in searchable:
+                return False
+        return True
+
+    @staticmethod
+    def summary_sort_key(summary: dict[str, Any]) -> tuple[bool, int, str]:
+        return (
+            bool(summary.get("pinned")),
+            int(summary.get("timestamp") or 0),
+            str(summary.get("chat_id") or ""),
         )
+
+    @contextmanager
+    def _read_connection(self) -> Iterator[sqlite3.Connection | None]:
+        with self._lock:
+            path = self._valid_index_path_unlocked()
+            if path is None:
+                yield None
+                return
+            conn = sqlite3.connect(str(path))
+            try:
+                yield conn
+            finally:
+                conn.close()
+
+    @contextmanager
+    def _write_connection(self) -> Iterator[sqlite3.Connection | None]:
+        with self._lock:
+            path = self._valid_index_path_unlocked()
+            if path is None:
+                yield None
+                return
+            conn = sqlite3.connect(str(path))
+            try:
+                yield conn
+            finally:
+                conn.close()
+
+    def _valid_index_path_unlocked(self) -> Path | None:
+        if self._database_matches_source(self.index_file):
+            return self.index_file
+        if not self._database_matches_source(self.pending_index_file):
+            return None
         try:
-            stat = self.sessions_file.stat()
-            atomic_json_write(
-                self.index_file,
-                {
-                    "version": CATALOG_VERSION,
-                    "source_size": stat.st_size,
-                    "source_mtime_ns": stat.st_mtime_ns,
-                    "sessions": [entry.to_dict() for entry in entries.values()],
-                },
-                indent=None,
-                fsync=True,
-                allow_fallback=False,
-            )
-        except Exception as exc:
-            raise SessionCatalogIndexWriteError(entries, exc) from exc
-        return entries
+            self._replace_with_retry(self.pending_index_file, self.index_file)
+            return self.index_file
+        except OSError:
+            return self.pending_index_file
+
+    def _database_matches_source(self, path: Path) -> bool:
+        if not self.sessions_file.exists() or not path.exists():
+            return False
+        try:
+            source_stat = self.sessions_file.stat()
+            with closing(sqlite3.connect(str(path))) as conn:
+                meta = dict(conn.execute("SELECT key, value FROM catalog_meta").fetchall())
+                if meta.get("version") != str(CATALOG_VERSION):
+                    return False
+                if meta.get("source_size") != str(source_stat.st_size):
+                    return False
+                if meta.get("source_mtime_ns") != str(source_stat.st_mtime_ns):
+                    return False
+                invalid = conn.execute(
+                    """
+                    SELECT 1 FROM sessions
+                    WHERE byte_offset < 0 OR byte_length <= 0
+                       OR byte_offset + byte_length > ?
+                    LIMIT 1
+                    """,
+                    (source_stat.st_size,),
+                ).fetchone()
+                return invalid is None
+        except (OSError, sqlite3.DatabaseError, TypeError, ValueError):
+            return False
+
+    @staticmethod
+    def _entry_from_row(row: tuple[Any, ...] | None) -> SessionCatalogEntry | None:
+        if row is None:
+            return None
+        session_key, offset, length, raw_summary = row
+        summary = SessionCatalogStore._decode_summary(raw_summary)
+        if summary is None:
+            return None
+        return SessionCatalogEntry(
+            session_key=str(session_key),
+            offset=int(offset),
+            length=int(length),
+            summary=summary,
+        )
+
+    @staticmethod
+    def _decode_summary(raw_summary: Any) -> dict[str, Any] | None:
+        try:
+            value = json.loads(str(raw_summary))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    @staticmethod
+    def _summary_row(
+        session_key: str,
+        offset: int,
+        length: int,
+        summary: dict[str, Any],
+    ) -> tuple[Any, ...]:
+        normalized = dict(summary)
+        if normalized.get("state") == "expired":
+            normalized["state"] = "idle"
+        title = str(normalized.get("title") or "")
+        last_message = str(normalized.get("last_message") or "")
+        return (
+            session_key,
+            offset,
+            length,
+            str(normalized.get("session_id") or ""),
+            str(normalized.get("channel") or ""),
+            str(normalized.get("user_id") or ""),
+            str(normalized.get("state") or ""),
+            str(normalized.get("chat_id") or ""),
+            int(bool(normalized.get("pinned"))),
+            int(normalized.get("timestamp") or 0),
+            title,
+            last_message,
+            SessionCatalogStore._summary_search_text(normalized),
+            json.dumps(normalized, ensure_ascii=False, separators=(",", ":")),
+        )
+
+    @staticmethod
+    def _summary_filters(
+        *,
+        channel: str | None,
+        user_id: str | None,
+        state: str | None,
+        query: str,
+        exclude_org_chats: bool,
+    ) -> tuple[str, list[Any]]:
+        clauses = ["state <> 'closed'"]
+        params: list[Any] = []
+        if channel:
+            clauses.append("channel = ?")
+            params.append(channel)
+        if user_id:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if state:
+            clauses.append("CASE WHEN state = 'expired' THEN 'idle' ELSE state END = ?")
+            params.append(state)
+        if exclude_org_chats:
+            clauses.append("chat_id NOT LIKE 'org\\_%' ESCAPE '\\'")
+        normalized_query = query.strip().casefold()
+        if normalized_query:
+            if len(normalized_query) >= 3:
+                clauses.append(
+                    "session_key IN ("
+                    "SELECT session_key FROM session_search WHERE search_text MATCH ?"
+                    ")"
+                )
+                escaped_query = normalized_query.replace('"', '""')
+                params.append(f'"{escaped_query}"')
+            else:
+                clauses.append("instr(search_text, ?) > 0")
+                params.append(normalized_query)
+        return "WHERE " + " AND ".join(clauses), params
+
+    @staticmethod
+    def _summary_search_text(summary: dict[str, Any]) -> str:
+        title = str(summary.get("title") or "")
+        last_message = str(summary.get("last_message") or "")
+        return f"{title}\n{last_message}".casefold()
+
+    def _backup_sessions_file(self) -> None:
+        if not self.sessions_file.exists():
+            return
+        backup_file = self.sessions_file.with_suffix(self.sessions_file.suffix + ".bak")
+        try:
+            shutil.copy2(self.sessions_file, backup_file)
+        except OSError as exc:
+            logger.warning("Failed to create backup %s: %s", backup_file, exc)
+
+    @staticmethod
+    def _replace_with_retry(source: Path, target: Path, retries: int = 3) -> None:
+        last_error: OSError | None = None
+        for attempt in range(retries):
+            try:
+                source.replace(target)
+                return
+            except PermissionError as exc:
+                last_error = exc
+                if attempt < retries - 1:
+                    time.sleep(0.2 * (attempt + 1))
+        if last_error is not None:
+            raise last_error
+
+    @staticmethod
+    def _remove_sqlite_file(path: Path) -> None:
+        for candidate in (
+            path,
+            Path(f"{path}-wal"),
+            Path(f"{path}-shm"),
+            Path(f"{path}-journal"),
+        ):
+            candidate.unlink(missing_ok=True)

--- a/src/openakita/sessions/catalog.py
+++ b/src/openakita/sessions/catalog.py
@@ -1,0 +1,177 @@
+"""Lightweight random-access index for the canonical sessions.json store."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openakita.utils.atomic_io import atomic_json_write, safe_write
+
+CATALOG_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SessionCatalogEntry:
+    session_key: str
+    offset: int
+    length: int
+    summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_key": self.session_key,
+            "offset": self.offset,
+            "length": self.length,
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SessionCatalogEntry | None:
+        if not isinstance(value, dict):
+            return None
+        session_key = value.get("session_key")
+        offset = value.get("offset")
+        length = value.get("length")
+        summary = value.get("summary")
+        if (
+            not isinstance(session_key, str)
+            or not session_key
+            or not isinstance(offset, int)
+            or offset < 0
+            or not isinstance(length, int)
+            or length <= 0
+            or not isinstance(summary, dict)
+        ):
+            return None
+        return cls(session_key=session_key, offset=offset, length=length, summary=summary)
+
+
+class SessionCatalogIndexWriteError(OSError):
+    """The session store was replaced but its companion index was not."""
+
+    def __init__(self, entries: dict[str, SessionCatalogEntry], cause: Exception):
+        super().__init__(f"failed to write session catalog index: {cause}")
+        self.entries = entries
+
+
+class SessionCatalogStore:
+    """Keep compact session summaries separate from full session documents.
+
+    ``sessions.json`` remains the canonical, backwards-compatible array. The
+    adjacent index records byte ranges for each array item so a single session
+    can be hydrated without parsing every conversation and message at startup.
+    """
+
+    def __init__(self, sessions_file: Path):
+        self.sessions_file = Path(sessions_file)
+        self.index_file = self.sessions_file.with_name("sessions.index.json")
+
+    def load(self) -> dict[str, SessionCatalogEntry] | None:
+        if not self.sessions_file.exists() or not self.index_file.exists():
+            return None
+        try:
+            with open(self.index_file, encoding="utf-8") as handle:
+                payload = json.load(handle)
+            if not isinstance(payload, dict) or payload.get("version") != CATALOG_VERSION:
+                return None
+
+            stat = self.sessions_file.stat()
+            if payload.get("source_size") != stat.st_size:
+                return None
+            if payload.get("source_mtime_ns") != stat.st_mtime_ns:
+                return None
+
+            raw_entries = payload.get("sessions")
+            if not isinstance(raw_entries, list):
+                return None
+
+            entries: dict[str, SessionCatalogEntry] = {}
+            for raw_entry in raw_entries:
+                entry = SessionCatalogEntry.from_dict(raw_entry)
+                if entry is None or entry.offset + entry.length > stat.st_size:
+                    return None
+                if entry.session_key in entries:
+                    return None
+                entries[entry.session_key] = entry
+            return entries
+        except (OSError, ValueError, TypeError):
+            return None
+
+    def read_document(self, entry: SessionCatalogEntry) -> dict[str, Any] | None:
+        try:
+            with open(self.sessions_file, "rb") as handle:
+                handle.seek(entry.offset)
+                raw = handle.read(entry.length)
+            value = json.loads(raw.decode("utf-8"))
+            return value if isinstance(value, dict) else None
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+    def read_raw_document(self, entry: SessionCatalogEntry) -> str | None:
+        try:
+            with open(self.sessions_file, "rb") as handle:
+                handle.seek(entry.offset)
+                raw = handle.read(entry.length)
+            return raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    def write(
+        self,
+        documents: Iterable[tuple[str, str | dict[str, Any], dict[str, Any]]],
+    ) -> dict[str, SessionCatalogEntry]:
+        parts = ["["]
+        byte_offset = 1
+        entries: dict[str, SessionCatalogEntry] = {}
+
+        for index, (session_key, document, summary) in enumerate(documents):
+            if session_key in entries:
+                raise ValueError(f"duplicate session key: {session_key}")
+            raw = (
+                document.strip()
+                if isinstance(document, str)
+                else json.dumps(document, ensure_ascii=False, separators=(",", ":"))
+            )
+            if not raw.startswith("{") or not raw.endswith("}"):
+                raise ValueError(f"invalid session document: {session_key}")
+            if index:
+                parts.append(",")
+                byte_offset += 1
+            raw_length = len(raw.encode("utf-8"))
+            entries[session_key] = SessionCatalogEntry(
+                session_key=session_key,
+                offset=byte_offset,
+                length=raw_length,
+                summary=dict(summary),
+            )
+            parts.append(raw)
+            byte_offset += raw_length
+
+        parts.append("]\n")
+        safe_write(
+            self.sessions_file,
+            "".join(parts),
+            backup=True,
+            fsync=True,
+            allow_fallback=False,
+        )
+        try:
+            stat = self.sessions_file.stat()
+            atomic_json_write(
+                self.index_file,
+                {
+                    "version": CATALOG_VERSION,
+                    "source_size": stat.st_size,
+                    "source_mtime_ns": stat.st_mtime_ns,
+                    "sessions": [entry.to_dict() for entry in entries.values()],
+                },
+                indent=None,
+                fsync=True,
+                allow_fallback=False,
+            )
+        except Exception as exc:
+            raise SessionCatalogIndexWriteError(entries, exc) from exc
+        return entries

--- a/src/openakita/sessions/manager.py
+++ b/src/openakita/sessions/manager.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from openakita.utils.atomic_io import atomic_json_write
 
-from .catalog import SessionCatalogEntry, SessionCatalogIndexWriteError, SessionCatalogStore
+from .catalog import SessionCatalogIndexWriteError, SessionCatalogPage, SessionCatalogStore
 from .session import Session, SessionConfig, SessionState, is_duplicate_message
 from .user import UserManager
 
@@ -98,7 +98,6 @@ class SessionManager:
         self._sessions_lock = threading.RLock()
         self._save_sessions_lock = threading.RLock()
         self._catalog_store = SessionCatalogStore(self.storage_path / "sessions.json")
-        self._session_catalog: dict[str, SessionCatalogEntry] = {}
 
         # 通道注册表：记录每个 IM 通道最后已知的 chat_id / user_id
         # 不受 session 过期清理影响，用于定时任务等场景回溯通道目标
@@ -203,6 +202,13 @@ class SessionManager:
         if not self._save_sessions():
             self._dirty = True
 
+    def persist_summary(self, session: Session) -> bool:
+        """Persist a lightweight projection while leaving the history document untouched."""
+        return self._catalog_store.update_summary(
+            session.session_key,
+            self._catalog_summary_from_session(session),
+        )
+
     def _dispatch_hook_fire_and_forget(self, hook_name: str, **kwargs) -> None:
         """Dispatch a plugin hook from sync context (best-effort, non-blocking)."""
         if self._plugin_hooks is None:
@@ -281,12 +287,13 @@ class SessionManager:
                 with self._sessions_lock:
                     if session_key in self._sessions:
                         continue
-                    entry = self._session_catalog.get(session_key)
+                    entry = self._catalog_store.get_entry(session_key)
                 item = self._catalog_store.read_document(entry) if entry is not None else None
             if item is None:
                 continue
             try:
                 session = Session.from_dict(item)
+                self._apply_catalog_summary_to_session(session, entry.summary)
                 if session.state == SessionState.EXPIRED:
                     session.mark_idle()
                 self._clean_large_content_in_messages(session.context.messages)
@@ -462,8 +469,7 @@ class SessionManager:
         可以通过此方法恢复，避免创建空白会话导致上下文丢失。
         """
         with self._save_sessions_lock:
-            with self._sessions_lock:
-                entry = self._session_catalog.get(session_key)
+            entry = self._catalog_store.get_entry(session_key)
             item = self._catalog_store.read_document(entry) if entry is not None else None
         if entry is not None:
             if item is None:
@@ -471,6 +477,7 @@ class SessionManager:
                 return None
             try:
                 session = Session.from_dict(item)
+                self._apply_catalog_summary_to_session(session, entry.summary)
                 if session.session_key != session_key or session.state == SessionState.CLOSED:
                     return None
                 if session.state == SessionState.EXPIRED:
@@ -559,21 +566,19 @@ class SessionManager:
             for session in self._sessions.values():
                 if session.id == session_id:
                     return session
-            catalog_entries = list(self._session_catalog.values())
-        for entry in catalog_entries:
-            if entry.summary.get("session_id") != session_id:
-                continue
-            recovered = self._try_recover_session_from_disk(entry.session_key)
-            if recovered is None:
-                return None
-            with self._sessions_lock:
-                existing = self._sessions.get(entry.session_key)
-                if existing is not None:
-                    return existing
-                self._sessions[entry.session_key] = recovered
-                self._attach_manager(recovered)
-            return recovered
-        return None
+        entry = self._catalog_store.get_entry_by_session_id(session_id)
+        if entry is None:
+            return None
+        recovered = self._try_recover_session_from_disk(entry.session_key)
+        if recovered is None:
+            return None
+        with self._sessions_lock:
+            existing = self._sessions.get(entry.session_key)
+            if existing is not None:
+                return existing
+            self._sessions[entry.session_key] = recovered
+            self._attach_manager(recovered)
+        return recovered
 
     def _create_session(
         self,
@@ -625,11 +630,11 @@ class SessionManager:
                 closed_session.close()
                 del self._sessions[session_key]
                 removed = True
-            if self._session_catalog.pop(session_key, None) is not None:
-                removed = True
-            if removed:
-                self.mark_dirty()
-                logger.info(f"Closed session: {session_key}")
+        if self._catalog_store.delete(session_key):
+            removed = True
+        if removed:
+            self.mark_dirty()
+            logger.info(f"Closed session: {session_key}")
         if closed_session is not None:
             self._dispatch_hook_fire_and_forget(
                 "on_session_end",
@@ -682,49 +687,150 @@ class SessionManager:
         user_id: str | None = None,
         state: SessionState | None = None,
     ) -> list[dict[str, Any]]:
-        """List compact persisted projections without hydrating message history."""
-        with self._sessions_lock:
-            summaries = {key: dict(entry.summary) for key, entry in self._session_catalog.items()}
-            loaded_sessions = list(self._sessions.items())
-        for session_key, session in loaded_sessions:
-            summaries[session_key] = self._catalog_summary_from_session(session)
+        """List all compact projections without hydrating message history.
 
-        result: list[dict[str, Any]] = []
-        for summary in summaries.values():
-            if summary.get("state") == SessionState.EXPIRED.value:
-                summary["state"] = SessionState.IDLE.value
-            if channel and summary.get("channel") != channel:
-                continue
-            if user_id and summary.get("user_id") != user_id:
-                continue
-            if state and summary.get("state") != state.value:
-                continue
-            if summary.get("state") == SessionState.CLOSED.value:
-                continue
-            result.append(summary)
-        return result
+        This eager compatibility API is reserved for maintenance callers. UI
+        requests should use :meth:`list_session_summaries_page` so SQLite can
+        apply filtering, ordering, and pagination before rows enter Python.
+        """
+        requested_state = state.value if state else None
+        catalog_page = self._catalog_store.list_summaries(
+            channel=channel,
+            user_id=user_id,
+            state=requested_state,
+        )
+        summaries = {
+            str(summary.get("session_key") or ""): summary for summary in catalog_page.summaries
+        }
+        loaded = self._loaded_summary_overrides()
+        for session_key, summary in loaded.items():
+            summaries.pop(session_key, None)
+            if self._catalog_store.summary_matches(
+                summary,
+                channel=channel,
+                user_id=user_id,
+                state=requested_state,
+            ):
+                summaries[session_key] = summary
+        return sorted(
+            summaries.values(),
+            key=self._catalog_store.summary_sort_key,
+            reverse=True,
+        )
+
+    def list_session_summaries_page(
+        self,
+        *,
+        channel: str | None = None,
+        user_id: str | None = None,
+        state: SessionState | None = None,
+        query: str = "",
+        exclude_org_chats: bool = False,
+        limit: int = 60,
+        offset: int = 0,
+    ) -> SessionCatalogPage:
+        """Return one ordered page while keeping the full catalog on disk."""
+        requested_state = state.value if state else None
+        loaded = self._loaded_summary_overrides()
+        loaded_keys = list(loaded)
+
+        # Replacing loaded rows can move at most len(loaded) records across the
+        # requested page boundary. Fetching that small prefix keeps offset
+        # pagination exact without materializing the complete SQLite catalog.
+        prefix_limit = max(0, int(offset)) + max(0, int(limit)) + len(loaded)
+        catalog_page = self._catalog_store.list_summaries(
+            channel=channel,
+            user_id=user_id,
+            state=requested_state,
+            query=query,
+            exclude_org_chats=exclude_org_chats,
+            limit=prefix_limit,
+            offset=0,
+        )
+        persisted_loaded = self._catalog_store.get_summaries(loaded_keys)
+
+        total = catalog_page.total
+        for session_key, summary in loaded.items():
+            old_summary = persisted_loaded.get(session_key)
+            if old_summary and self._catalog_store.summary_matches(
+                old_summary,
+                channel=channel,
+                user_id=user_id,
+                state=requested_state,
+                query=query,
+                exclude_org_chats=exclude_org_chats,
+            ):
+                total -= 1
+            if self._catalog_store.summary_matches(
+                summary,
+                channel=channel,
+                user_id=user_id,
+                state=requested_state,
+                query=query,
+                exclude_org_chats=exclude_org_chats,
+            ):
+                total += 1
+
+        candidates = [
+            summary
+            for summary in catalog_page.summaries
+            if str(summary.get("session_key") or "") not in loaded
+        ]
+        candidates.extend(
+            summary
+            for summary in loaded.values()
+            if self._catalog_store.summary_matches(
+                summary,
+                channel=channel,
+                user_id=user_id,
+                state=requested_state,
+                query=query,
+                exclude_org_chats=exclude_org_chats,
+            )
+        )
+        candidates.sort(key=self._catalog_store.summary_sort_key, reverse=True)
+        page_start = max(0, int(offset))
+        page_end = page_start + max(0, int(limit))
+        return SessionCatalogPage(candidates[page_start:page_end], max(0, total))
+
+    def _loaded_summary_overrides(self) -> dict[str, dict[str, Any]]:
+        with self._sessions_lock:
+            loaded_sessions = list(self._sessions.items())
+        return {
+            session_key: self._catalog_summary_from_session(session)
+            for session_key, session in loaded_sessions
+        }
 
     def get_session_count(self) -> dict[str, int]:
         """获取会话统计"""
-        all_summaries = self.list_session_summaries()
-
-        stats = {
-            "total": len(all_summaries),
-            "active": 0,
-            "idle": 0,
-            "by_channel": {},
-        }
-
-        for summary in all_summaries:
-            if summary.get("state") == SessionState.ACTIVE.value:
-                stats["active"] += 1
-            elif summary.get("state") == SessionState.IDLE.value:
-                stats["idle"] += 1
-
-            channel = str(summary.get("channel") or "")
-            stats["by_channel"][channel] = stats["by_channel"].get(channel, 0) + 1
-
+        stats = self._catalog_store.counts()
+        loaded = self._loaded_summary_overrides()
+        persisted_loaded = self._catalog_store.get_summaries(list(loaded))
+        for session_key, summary in loaded.items():
+            old_summary = persisted_loaded.get(session_key)
+            if old_summary is not None:
+                self._adjust_session_counts(stats, old_summary, -1)
+            self._adjust_session_counts(stats, summary, 1)
         return stats
+
+    @staticmethod
+    def _adjust_session_counts(stats: dict[str, Any], summary: dict[str, Any], delta: int) -> None:
+        state = str(summary.get("state") or "")
+        if state == SessionState.EXPIRED.value:
+            state = SessionState.IDLE.value
+        if state == SessionState.CLOSED.value:
+            return
+        stats["total"] += delta
+        if state == SessionState.ACTIVE.value:
+            stats["active"] += delta
+        elif state == SessionState.IDLE.value:
+            stats["idle"] += delta
+        channel = str(summary.get("channel") or "")
+        new_count = stats["by_channel"].get(channel, 0) + delta
+        if new_count > 0:
+            stats["by_channel"][channel] = new_count
+        else:
+            stats["by_channel"].pop(channel, None)
 
     async def cleanup_expired(self) -> int:
         """Evict reloadable cold sessions from memory without hiding or deleting them."""
@@ -735,15 +841,15 @@ class SessionManager:
                 return 0
 
         with self._sessions_lock:
-            cold_keys = [
-                key
-                for key, session in self._sessions.items()
-                if session.is_expired() and key in self._session_catalog
-            ]
+            expired_keys = [key for key, session in self._sessions.items() if session.is_expired()]
+        reloadable_keys = self._catalog_store.contains_many(expired_keys)
 
+        with self._sessions_lock:
+            cold_keys = [key for key in expired_keys if key in reloadable_keys]
             for key in cold_keys:
-                del self._sessions[key]
-                logger.debug("Evicted cold session from memory: %s", key)
+                if key in self._sessions:
+                    del self._sessions[key]
+                    logger.debug("Evicted cold session from memory: %s", key)
 
         if cold_keys:
             logger.info("Evicted %d cold sessions from memory", len(cold_keys))
@@ -762,15 +868,12 @@ class SessionManager:
             loaded_keys = [
                 key for key, session in self._sessions.items() if session.channel == channel_name
             ]
-            catalog_keys = [
-                key
-                for key, entry in self._session_catalog.items()
-                if entry.summary.get("channel") == channel_name
-            ]
-            keys_to_remove = set(loaded_keys) | set(catalog_keys)
+        catalog_keys = self._catalog_store.keys_for_channel(channel_name)
+        keys_to_remove = set(loaded_keys) | set(catalog_keys)
+        with self._sessions_lock:
             for key in keys_to_remove:
                 self._sessions.pop(key, None)
-                self._session_catalog.pop(key, None)
+        self._catalog_store.delete_many(list(keys_to_remove))
 
         if channel_name in self._channel_registry:
             del self._channel_registry[channel_name]
@@ -809,13 +912,13 @@ class SessionManager:
 
                 if self._dirty:
                     self._dirty = False
-                    if not self._save_sessions():
+                    if not await asyncio.to_thread(self._save_sessions):
                         self._dirty = True
 
             except asyncio.CancelledError:
                 # 退出前最后保存一次
                 if self._dirty:
-                    self._save_sessions()
+                    await asyncio.to_thread(self._save_sessions)
                 break
             except Exception as e:
                 logger.error(f"Error in save loop: {e}")
@@ -880,6 +983,7 @@ class SessionManager:
             "created_at": session.created_at.isoformat(),
             "last_active": session.last_active.isoformat(),
             "title": stored_title or fallback_title or "对话",
+            "conversation_title": stored_title or None,
             "title_generated": bool(stored_title and session.get_metadata("title_generated")),
             "title_manually_set": bool(stored_title and session.get_metadata("title_manually_set")),
             "pinned": bool(session.get_metadata("pinned")),
@@ -899,25 +1003,42 @@ class SessionManager:
             "working_directory": session.working_directory,
         }
 
+    @staticmethod
+    def _apply_catalog_summary_to_session(session: Session, summary: dict[str, Any]) -> None:
+        """Restore catalog metadata that may be newer than the history document."""
+        if "conversation_title" in summary:
+            conversation_title = summary.get("conversation_title")
+            if conversation_title:
+                session.set_metadata("conversation_title", conversation_title)
+            else:
+                session.metadata.pop("conversation_title", None)
+            session.set_metadata("title_generated", bool(summary.get("title_generated")))
+            session.set_metadata("title_manually_set", bool(summary.get("title_manually_set")))
+        session.set_metadata("pinned", bool(summary.get("pinned")))
+        session.set_metadata("selected_endpoint", summary.get("endpoint_id") or "")
+        session.set_metadata("endpoint_policy", summary.get("endpoint_policy") or "prefer")
+        session.set_metadata(
+            "ui_org_state",
+            {
+                "orgMode": bool(summary.get("org_mode") and summary.get("org_id")),
+                "orgId": summary.get("org_id") or "",
+                "orgNodeId": summary.get("org_node_id") or "",
+            },
+        )
+
     def _load_sessions(self) -> None:
         """Load the compact catalog and defer full session hydration until use."""
         sessions_file = self.storage_path / "sessions.json"
         backup_file = self.storage_path / "sessions.json.bak"
         temp_file = self.storage_path / "sessions.json.tmp"
 
-        catalog = self._catalog_store.load()
-        if catalog is not None:
-            self._session_catalog = catalog
+        if self._catalog_store.load():
             self._sessions_loaded = True
-            visible_count = sum(
-                1
-                for entry in catalog.values()
-                if entry.summary.get("state") != SessionState.CLOSED.value
-            )
+            stats = self._catalog_store.counts()
             logger.info(
                 "Indexed %d sessions from storage (%d currently visible; histories deferred)",
-                len(catalog),
-                visible_count,
+                self._catalog_store.list_summaries(limit=0).total,
+                stats["total"],
             )
             return
 
@@ -1005,7 +1126,7 @@ class SessionManager:
             self._save_channel_registry()
 
         try:
-            self._session_catalog = self._catalog_store.write(documents)
+            self._catalog_store.write(documents)
         except Exception as exc:
             logger.error("Failed to build lazy session catalog: %s", exc, exc_info=True)
             self._sessions = fallback_loaded
@@ -1234,50 +1355,87 @@ class SessionManager:
             try:
                 with self._sessions_lock:
                     loaded = dict(self._sessions)
-                    catalog = dict(self._session_catalog)
 
-                documents: list[tuple[str, str | dict[str, Any], dict[str, Any]]] = []
-                for session_key, entry in catalog.items():
-                    session = loaded.pop(session_key, None)
-                    if session is not None:
-                        documents.append(
-                            (
+                catalog_available = self._catalog_store.load()
+                fallback_documents: dict[
+                    str,
+                    tuple[dict[str, Any], dict[str, Any]],
+                ] = {}
+                sessions_file = self.storage_path / "sessions.json"
+                if sessions_file.exists() and not catalog_available:
+                    raw_sessions = self._try_load_sessions_file(sessions_file)
+                    if raw_sessions is None:
+                        raise OSError(
+                            "session catalog is unavailable and sessions.json is unreadable"
+                        )
+                    logger.warning(
+                        "Session catalog unavailable during save; rebuilding it from sessions.json"
+                    )
+                    for item in raw_sessions:
+                        if not isinstance(item, dict):
+                            continue
+                        candidate_id = str(item.get("session_key") or item.get("id") or "")
+                        if not _is_safe_session_id(candidate_id):
+                            continue
+                        session = Session.from_dict(item)
+                        if session.state == SessionState.EXPIRED:
+                            session.mark_idle()
+                        self._clean_large_content_in_messages(session.context.messages)
+                        fallback_documents[session.session_key] = (
+                            session.to_dict(),
+                            self._catalog_summary_from_session(session),
+                        )
+
+                persisted_count = 0
+
+                def iter_documents():
+                    nonlocal persisted_count
+                    if catalog_available:
+                        base_documents = (
+                            (entry.session_key, entry, entry.summary)
+                            for entry in self._catalog_store.iter_entries()
+                        )
+                    else:
+                        base_documents = (
+                            (session_key, document, summary)
+                            for session_key, (document, summary) in fallback_documents.items()
+                        )
+
+                    for session_key, document, summary in base_documents:
+                        session = loaded.pop(session_key, None)
+                        if session is not None:
+                            persisted_count += 1
+                            yield (
                                 session_key,
                                 session.to_dict(),
                                 self._catalog_summary_from_session(session),
                             )
-                        )
-                        continue
-                    raw = self._catalog_store.read_raw_document(entry)
-                    if raw is None:
-                        raise OSError(f"failed to read deferred session: {session_key}")
-                    documents.append((session_key, raw, entry.summary))
+                            continue
+                        if catalog_available:
+                            raw = self._catalog_store.read_raw_document(document)
+                            if raw is None:
+                                raise OSError(f"failed to read deferred session: {session_key}")
+                            document = raw
+                        persisted_count += 1
+                        yield (session_key, document, summary)
 
-                for session_key, session in loaded.items():
-                    documents.append(
-                        (
+                    for session_key, session in loaded.items():
+                        persisted_count += 1
+                        yield (
                             session_key,
                             session.to_dict(),
                             self._catalog_summary_from_session(session),
                         )
-                    )
 
-                updated_catalog = self._catalog_store.write(documents)
-                with self._sessions_lock:
-                    self._session_catalog = updated_catalog
+                self._catalog_store.write(iter_documents())
                 logger.debug(
                     "Saved %d sessions to storage (%d histories remain deferred)",
-                    len(documents),
-                    max(0, len(documents) - len(self._sessions)),
+                    persisted_count,
+                    max(0, persisted_count - len(self._sessions)),
                 )
                 return True
 
             except SessionCatalogIndexWriteError as exc:
-                # sessions.json already contains the new byte layout. Keep the
-                # in-memory offsets aligned so a retry can safely copy deferred
-                # documents even though the companion index still needs repair.
-                with self._sessions_lock:
-                    self._session_catalog = exc.entries
                 logger.error("Error saving session catalog index: %s", exc)
                 return False
             except Exception as e:

--- a/src/openakita/sessions/manager.py
+++ b/src/openakita/sessions/manager.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import shutil
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +20,7 @@ from typing import Any
 
 from openakita.utils.atomic_io import atomic_json_write
 
+from .catalog import SessionCatalogEntry, SessionCatalogIndexWriteError, SessionCatalogStore
 from .session import Session, SessionConfig, SessionState, is_duplicate_message
 from .user import UserManager
 
@@ -95,6 +97,8 @@ class SessionManager:
         self._sessions: dict[str, Session] = {}
         self._sessions_lock = threading.RLock()
         self._save_sessions_lock = threading.RLock()
+        self._catalog_store = SessionCatalogStore(self.storage_path / "sessions.json")
+        self._session_catalog: dict[str, SessionCatalogEntry] = {}
 
         # 通道注册表：记录每个 IM 通道最后已知的 chat_id / user_id
         # 不受 session 过期清理影响，用于定时任务等场景回溯通道目标
@@ -163,7 +167,7 @@ class SessionManager:
             should_backfill = _ff_enabled("session_backfill_on_start_v1")
         except Exception:
             should_backfill = False
-        if should_backfill and self._turn_loader is not None:
+        if should_backfill and self._turn_loader is not None and self._sessions:
             try:
                 import threading
 
@@ -268,6 +272,32 @@ class SessionManager:
 
         if not self._turn_loader:
             return 0
+        # This explicit maintenance API keeps its historical eager semantics.
+        # Normal startup remains lazy; only callers that request a full
+        # backfill hydrate every currently visible catalog entry here.
+        for summary in self.list_session_summaries():
+            session_key = str(summary["session_key"])
+            with self._save_sessions_lock:
+                with self._sessions_lock:
+                    if session_key in self._sessions:
+                        continue
+                    entry = self._session_catalog.get(session_key)
+                item = self._catalog_store.read_document(entry) if entry is not None else None
+            if item is None:
+                continue
+            try:
+                session = Session.from_dict(item)
+                if session.state == SessionState.EXPIRED:
+                    session.mark_idle()
+                self._clean_large_content_in_messages(session.context.messages)
+            except Exception as exc:
+                logger.warning("Session backfill hydration failed for %s: %s", session_key, exc)
+                continue
+            with self._sessions_lock:
+                if session_key not in self._sessions:
+                    self._sessions[session_key] = session
+                    self._attach_manager(session)
+
         total_backfilled = 0
         for session in self._sessions.values():
             try:
@@ -426,11 +456,34 @@ class SessionManager:
             pass
 
     def _try_recover_session_from_disk(self, session_key: str) -> "Session | None":
-        """尝试从 sessions.json 中恢复指定 session_key 的会话。
+        """Load one indexed session document without parsing the full store.
 
         当会话已从内存中移除（如空闲清理、内存压力）但磁盘上仍有记录时，
         可以通过此方法恢复，避免创建空白会话导致上下文丢失。
         """
+        with self._save_sessions_lock:
+            with self._sessions_lock:
+                entry = self._session_catalog.get(session_key)
+            item = self._catalog_store.read_document(entry) if entry is not None else None
+        if entry is not None:
+            if item is None:
+                logger.warning("Failed to read indexed session document: %s", session_key)
+                return None
+            try:
+                session = Session.from_dict(item)
+                if session.session_key != session_key or session.state == SessionState.CLOSED:
+                    return None
+                if session.state == SessionState.EXPIRED:
+                    session.mark_idle()
+                self._clean_large_content_in_messages(session.context.messages)
+                self._hydrate_from_store(session, max_turns=50)
+                return session
+            except Exception as exc:
+                logger.warning("Failed to hydrate indexed session %s: %s", session_key, exc)
+                return None
+
+        # Legacy fallback for a missing or invalid index. A successful startup
+        # migration normally makes this path unnecessary.
         sessions_file = self.storage_path / "sessions.json"
         data = self._try_load_sessions_file(sessions_file)
         if not data:
@@ -441,7 +494,9 @@ class SessionManager:
                 continue
             try:
                 session = Session.from_dict(item)
-                if session.session_key == session_key and not session.is_expired():
+                if session.session_key == session_key and session.state != SessionState.CLOSED:
+                    if session.state == SessionState.EXPIRED:
+                        session.mark_idle()
                     self._clean_large_content_in_messages(session.context.messages)
                     self._hydrate_from_store(session, max_turns=50)
                     return session
@@ -504,6 +559,20 @@ class SessionManager:
             for session in self._sessions.values():
                 if session.id == session_id:
                     return session
+            catalog_entries = list(self._session_catalog.values())
+        for entry in catalog_entries:
+            if entry.summary.get("session_id") != session_id:
+                continue
+            recovered = self._try_recover_session_from_disk(entry.session_key)
+            if recovered is None:
+                return None
+            with self._sessions_lock:
+                existing = self._sessions.get(entry.session_key)
+                if existing is not None:
+                    return existing
+                self._sessions[entry.session_key] = recovered
+                self._attach_manager(recovered)
+            return recovered
         return None
 
     def _create_session(
@@ -549,11 +618,16 @@ class SessionManager:
     def close_session(self, session_key: str) -> bool:
         """关闭会话"""
         closed_session = None
+        removed = False
         with self._sessions_lock:
             if session_key in self._sessions:
                 closed_session = self._sessions[session_key]
                 closed_session.close()
                 del self._sessions[session_key]
+                removed = True
+            if self._session_catalog.pop(session_key, None) is not None:
+                removed = True
+            if removed:
                 self.mark_dirty()
                 logger.info(f"Closed session: {session_key}")
         if closed_session is not None:
@@ -563,8 +637,7 @@ class SessionManager:
                 session_key=session_key,
                 reason="close",
             )
-            return True
-        return False
+        return removed
 
     def list_sessions(
         self,
@@ -580,56 +653,102 @@ class SessionManager:
             user_id: 过滤用户
             state: 过滤状态
         """
-        with self._sessions_lock:
-            sessions = list(self._sessions.values())
-
-        if channel:
-            sessions = [s for s in sessions if s.channel == channel]
-        if user_id:
-            sessions = [s for s in sessions if s.user_id == user_id]
-        if state:
-            sessions = [s for s in sessions if s.state == state]
+        summaries = self.list_session_summaries(channel=channel, user_id=user_id, state=state)
+        sessions: list[Session] = []
+        for summary in summaries:
+            session_key = str(summary["session_key"])
+            with self._sessions_lock:
+                existing = self._sessions.get(session_key)
+            if existing is not None:
+                sessions.append(existing)
+                continue
+            session = self._try_recover_session_from_disk(session_key)
+            if session is None:
+                continue
+            with self._sessions_lock:
+                existing = self._sessions.get(session_key)
+                if existing is None:
+                    self._sessions[session_key] = session
+                    self._attach_manager(session)
+                else:
+                    session = existing
+            sessions.append(session)
 
         return sessions
 
+    def list_session_summaries(
+        self,
+        channel: str | None = None,
+        user_id: str | None = None,
+        state: SessionState | None = None,
+    ) -> list[dict[str, Any]]:
+        """List compact persisted projections without hydrating message history."""
+        with self._sessions_lock:
+            summaries = {key: dict(entry.summary) for key, entry in self._session_catalog.items()}
+            loaded_sessions = list(self._sessions.items())
+        for session_key, session in loaded_sessions:
+            summaries[session_key] = self._catalog_summary_from_session(session)
+
+        result: list[dict[str, Any]] = []
+        for summary in summaries.values():
+            if summary.get("state") == SessionState.EXPIRED.value:
+                summary["state"] = SessionState.IDLE.value
+            if channel and summary.get("channel") != channel:
+                continue
+            if user_id and summary.get("user_id") != user_id:
+                continue
+            if state and summary.get("state") != state.value:
+                continue
+            if summary.get("state") == SessionState.CLOSED.value:
+                continue
+            result.append(summary)
+        return result
+
     def get_session_count(self) -> dict[str, int]:
         """获取会话统计"""
-        with self._sessions_lock:
-            all_sessions = list(self._sessions.values())
+        all_summaries = self.list_session_summaries()
 
         stats = {
-            "total": len(all_sessions),
+            "total": len(all_summaries),
             "active": 0,
             "idle": 0,
             "by_channel": {},
         }
 
-        for session in all_sessions:
-            if session.state == SessionState.ACTIVE:
+        for summary in all_summaries:
+            if summary.get("state") == SessionState.ACTIVE.value:
                 stats["active"] += 1
-            elif session.state == SessionState.IDLE:
+            elif summary.get("state") == SessionState.IDLE.value:
                 stats["idle"] += 1
 
-            channel = session.channel
+            channel = str(summary.get("channel") or "")
             stats["by_channel"][channel] = stats["by_channel"].get(channel, 0) + 1
 
         return stats
 
     async def cleanup_expired(self) -> int:
-        """清理过期会话"""
+        """Evict reloadable cold sessions from memory without hiding or deleting them."""
+        if self._dirty:
+            await asyncio.to_thread(self.flush)
+            if self._dirty:
+                logger.warning("Skipped cold session eviction because persistence failed")
+                return 0
+
         with self._sessions_lock:
-            expired_keys = [key for key, session in self._sessions.items() if session.is_expired()]
+            cold_keys = [
+                key
+                for key, session in self._sessions.items()
+                if session.is_expired() and key in self._session_catalog
+            ]
 
-            for key in expired_keys:
-                session = self._sessions[key]
-                session.mark_expired()
+            for key in cold_keys:
                 del self._sessions[key]
-                logger.debug(f"Cleaned up expired session: {key}")
+                logger.debug("Evicted cold session from memory: %s", key)
 
-        if expired_keys:
-            logger.info(f"Cleaned up {len(expired_keys)} expired sessions")
+        if cold_keys:
+            logger.info("Evicted %d cold sessions from memory", len(cold_keys))
 
-        return len(expired_keys)
+        return len(cold_keys)
 
     def purge_channel(self, channel_name: str) -> int:
         """清理指定通道的所有会话和注册表数据。
@@ -640,11 +759,18 @@ class SessionManager:
             被清理的会话数量
         """
         with self._sessions_lock:
-            keys_to_remove = [
+            loaded_keys = [
                 key for key, session in self._sessions.items() if session.channel == channel_name
             ]
+            catalog_keys = [
+                key
+                for key, entry in self._session_catalog.items()
+                if entry.summary.get("channel") == channel_name
+            ]
+            keys_to_remove = set(loaded_keys) | set(catalog_keys)
             for key in keys_to_remove:
-                del self._sessions[key]
+                self._sessions.pop(key, None)
+                self._session_catalog.pop(key, None)
 
         if channel_name in self._channel_registry:
             del self._channel_registry[channel_name]
@@ -660,7 +786,7 @@ class SessionManager:
         return len(keys_to_remove)
 
     async def _cleanup_loop(self) -> None:
-        """定期清理循环（每 24 小时清理 30 天未活跃的僵尸 session）"""
+        """Evict loaded sessions idle for 30 days from memory every 24 hours."""
         while self._running:
             try:
                 await asyncio.sleep(3600 * 24)
@@ -694,11 +820,106 @@ class SessionManager:
             except Exception as e:
                 logger.error(f"Error in save loop: {e}")
 
+    @staticmethod
+    def _catalog_summary_from_session(session: Session) -> dict[str, Any]:
+        truncation_prefixes = ("[用户规则（必须遵守）]", "[历史背景，非当前任务]")
+        visible: list[dict[str, Any]] = []
+        deduped: list[dict[str, Any]] = []
+        for message in session.context.messages:
+            content = message.get("content", "")
+            if (
+                message.get("role") == "system"
+                and isinstance(content, str)
+                and content.startswith(truncation_prefixes)
+            ):
+                continue
+            if not message.get("marker_type") and is_duplicate_message(deduped, message):
+                continue
+            visible.append(message)
+            deduped.append(message)
+
+        user_messages = [message for message in visible if message.get("role") == "user"]
+        first_content = user_messages[0].get("content", "") if user_messages else ""
+        fallback_title = first_content[:30] if isinstance(first_content, str) else ""
+        if session.channel == "desktop" and session.get_metadata("source_channel"):
+            fallback_title = session.chat_name or session.display_name or fallback_title
+
+        stored_title = session.get_metadata("conversation_title")
+        stored_title = stored_title.strip() if isinstance(stored_title, str) else ""
+        last_content = visible[-1].get("content", "") if visible else ""
+        last_message = last_content[:100] if isinstance(last_content, str) else ""
+
+        timestamp = int(session.last_active.timestamp() * 1000)
+        for message in reversed(visible):
+            raw_timestamp = message.get("timestamp")
+            if not raw_timestamp:
+                continue
+            try:
+                timestamp = int(datetime.fromisoformat(str(raw_timestamp)).timestamp() * 1000)
+                break
+            except (TypeError, ValueError):
+                continue
+
+        ui_org_state = session.get_metadata("ui_org_state")
+        if not isinstance(ui_org_state, dict):
+            ui_org_state = {}
+        selected_endpoint = session.get_metadata("selected_endpoint") or ""
+        return {
+            "session_key": session.session_key,
+            "session_id": session.id,
+            "channel": session.channel,
+            "bot_instance_id": session.bot_instance_id or session.channel,
+            "chat_id": session.chat_id,
+            "user_id": session.user_id,
+            "thread_id": session.thread_id,
+            "state": (
+                SessionState.IDLE.value
+                if session.state == SessionState.EXPIRED
+                else session.state.value
+            ),
+            "created_at": session.created_at.isoformat(),
+            "last_active": session.last_active.isoformat(),
+            "title": stored_title or fallback_title or "对话",
+            "title_generated": bool(stored_title and session.get_metadata("title_generated")),
+            "title_manually_set": bool(stored_title and session.get_metadata("title_manually_set")),
+            "pinned": bool(session.get_metadata("pinned")),
+            "last_message": last_message,
+            "timestamp": timestamp,
+            "message_count": len(visible),
+            "agent_profile_id": session.context.agent_profile_id or "default",
+            "endpoint_id": selected_endpoint or None,
+            "endpoint_policy": (
+                session.get_metadata("endpoint_policy") or "prefer"
+                if selected_endpoint
+                else "prefer"
+            ),
+            "org_mode": bool(ui_org_state.get("orgMode") and ui_org_state.get("orgId")),
+            "org_id": ui_org_state.get("orgId") or None,
+            "org_node_id": ui_org_state.get("orgNodeId") or None,
+            "working_directory": session.working_directory,
+        }
+
     def _load_sessions(self) -> None:
-        """从文件加载会话，主文件失败时自动回退到 .tmp / .bak 备份。"""
+        """Load the compact catalog and defer full session hydration until use."""
         sessions_file = self.storage_path / "sessions.json"
         backup_file = self.storage_path / "sessions.json.bak"
         temp_file = self.storage_path / "sessions.json.tmp"
+
+        catalog = self._catalog_store.load()
+        if catalog is not None:
+            self._session_catalog = catalog
+            self._sessions_loaded = True
+            visible_count = sum(
+                1
+                for entry in catalog.values()
+                if entry.summary.get("state") != SessionState.CLOSED.value
+            )
+            logger.info(
+                "Indexed %d sessions from storage (%d currently visible; histories deferred)",
+                len(catalog),
+                visible_count,
+            )
+            return
 
         data = self._try_load_sessions_file(sessions_file)
 
@@ -718,15 +939,22 @@ class SessionManager:
         if data is None and backup_file.exists():
             logger.warning("Main sessions.json failed or missing, trying .bak backup")
             data = self._try_load_sessions_file(backup_file)
+            if data is not None:
+                try:
+                    shutil.copy2(backup_file, sessions_file)
+                except OSError as exc:
+                    logger.warning("Failed to restore sessions.json backup: %s", exc)
 
         if data is None:
             self._sessions_loaded = True
             return
 
-        skipped_expired = 0
+        hidden_closed = 0
         skipped_error = 0
         skipped_invalid_id = 0
         invalid_id_samples: list[str] = []
+        documents: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+        fallback_loaded: dict[str, Session] = {}
         for item in data:
             try:
                 if not isinstance(item, dict):
@@ -744,18 +972,15 @@ class SessionManager:
                         invalid_id_samples.append(_candidate_id[:64])
                     continue
                 session = Session.from_dict(item)
-                if not session.is_expired() and session.state != SessionState.CLOSED:
-                    msg_count = len(session.context.messages)
-                    self._clean_large_content_in_messages(session.context.messages)
-                    self._sessions[session.session_key] = session
-                    if msg_count > 0:
-                        logger.debug(
-                            f"Loaded session {session.session_key}: "
-                            f"{msg_count} messages preserved "
-                            f"(last_active: {session.last_active})"
-                        )
+                if session.state == SessionState.EXPIRED:
+                    session.mark_idle()
+                self._clean_large_content_in_messages(session.context.messages)
+                summary = self._catalog_summary_from_session(session)
+                documents.append((session.session_key, session.to_dict(), summary))
+                if session.state == SessionState.CLOSED:
+                    hidden_closed += 1
                 else:
-                    skipped_expired += 1
+                    fallback_loaded[session.session_key] = session
 
                 session_ts = session.last_active.isoformat()
                 existing = self._channel_registry.get(session.channel)
@@ -779,9 +1004,17 @@ class SessionManager:
         if self._channel_registry:
             self._save_channel_registry()
 
-        parts = [f"Loaded {len(self._sessions)} sessions from storage"]
-        if skipped_expired:
-            parts.append(f"skipped {skipped_expired} expired")
+        try:
+            self._session_catalog = self._catalog_store.write(documents)
+        except Exception as exc:
+            logger.error("Failed to build lazy session catalog: %s", exc, exc_info=True)
+            self._sessions = fallback_loaded
+            for session in self._sessions.values():
+                self._attach_manager(session)
+
+        parts = [f"Indexed {len(documents)} sessions from storage"]
+        if hidden_closed:
+            parts.append(f"hid {hidden_closed} closed")
         if skipped_error:
             parts.append(f"skipped {skipped_error} errors")
         if skipped_invalid_id:
@@ -991,27 +1224,62 @@ class SessionManager:
 
     def _save_sessions(self) -> bool:
         """
-        保存会话到文件（原子写入）
+        Persist loaded sessions while copying deferred documents unchanged.
 
-        使用临时文件 + 重命名的方式，确保写入过程中断不会损坏原文件。
-        返回 True 表示保存成功，False 表示失败（调用方应重试）。
+        The full JSON array remains backwards compatible. The adjacent catalog
+        is regenerated with byte offsets so future startups do not deserialize
+        every session and message.
         """
         with self._save_sessions_lock:
-            sessions_file = self.storage_path / "sessions.json"
             try:
                 with self._sessions_lock:
-                    sessions = list(self._sessions.values())
-                data = [session.to_dict() for session in sessions]
-                atomic_json_write(
-                    sessions_file,
-                    data,
-                    indent=None,
-                    fsync=True,
-                    allow_fallback=False,
+                    loaded = dict(self._sessions)
+                    catalog = dict(self._session_catalog)
+
+                documents: list[tuple[str, str | dict[str, Any], dict[str, Any]]] = []
+                for session_key, entry in catalog.items():
+                    session = loaded.pop(session_key, None)
+                    if session is not None:
+                        documents.append(
+                            (
+                                session_key,
+                                session.to_dict(),
+                                self._catalog_summary_from_session(session),
+                            )
+                        )
+                        continue
+                    raw = self._catalog_store.read_raw_document(entry)
+                    if raw is None:
+                        raise OSError(f"failed to read deferred session: {session_key}")
+                    documents.append((session_key, raw, entry.summary))
+
+                for session_key, session in loaded.items():
+                    documents.append(
+                        (
+                            session_key,
+                            session.to_dict(),
+                            self._catalog_summary_from_session(session),
+                        )
+                    )
+
+                updated_catalog = self._catalog_store.write(documents)
+                with self._sessions_lock:
+                    self._session_catalog = updated_catalog
+                logger.debug(
+                    "Saved %d sessions to storage (%d histories remain deferred)",
+                    len(documents),
+                    max(0, len(documents) - len(self._sessions)),
                 )
-                logger.debug(f"Saved {len(data)} sessions to storage (atomic fsync)")
                 return True
 
+            except SessionCatalogIndexWriteError as exc:
+                # sessions.json already contains the new byte layout. Keep the
+                # in-memory offsets aligned so a retry can safely copy deferred
+                # documents even though the companion index still needs repair.
+                with self._sessions_lock:
+                    self._session_catalog = exc.entries
+                logger.error("Error saving session catalog index: %s", exc)
+                return False
             except Exception as e:
                 logger.error(f"Failed to save sessions: {e}", exc_info=True)
                 return False

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -724,17 +724,17 @@ class Session:
             self.state = SessionState.ACTIVE
 
     def reactivate(self) -> None:
-        """把空闲会话标回活跃，但**不**改动 ``last_active``。
+        """把空闲或旧版过期会话标回活跃，但**不**改动 ``last_active``。
 
         供 ``get_session`` 等查询路径使用：被访问的会话可以从 IDLE 恢复成
         ACTIVE，但"被访问"本身不算一次新的会话活动，不应改写它在会话列表
         里的时间与排序位置。
         """
-        if self.state == SessionState.IDLE:
+        if self.state in (SessionState.IDLE, SessionState.EXPIRED):
             self.state = SessionState.ACTIVE
 
     def is_expired(self) -> bool:
-        """仅在超长不活跃时标记过期（30 天冷归档）"""
+        """Return whether this loaded object is eligible for cold-memory eviction."""
         elapsed = (datetime.now() - self.last_active).total_seconds() / 60
         return elapsed > 60 * 24 * 30
 

--- a/tests/regression/test_new_features.py
+++ b/tests/regression/test_new_features.py
@@ -151,7 +151,12 @@ class TestSessionManager:
 
         # 重新加载
         manager2 = SessionManager(storage_path=temp_storage)
-        assert len(manager2._sessions) >= 1
+        assert manager2._sessions == {}
+        restored = manager2.get_session(
+            "telegram", "chat_001", "user_001", create_if_missing=False
+        )
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "测试持久化"
 
         loaded = manager2.get_session("telegram", "chat_001", "user_001", create_if_missing=False)
         if loaded:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,6 +1,7 @@
 """L1 Unit Tests: Session state machine, message management."""
 
 import json
+import sqlite3
 import threading
 import time
 from datetime import datetime, timedelta
@@ -182,35 +183,106 @@ class TestAgentProfileScopedHistory:
 
 
 class TestSessionPersistence:
-    def test_save_sessions_uses_strict_atomic_writes(self, tmp_path, monkeypatch):
-        from openakita.sessions import catalog as catalog_module
-        from openakita.utils.atomic_io import safe_write as real_safe_write
-
+    def test_save_sessions_creates_queryable_sqlite_catalog(self, tmp_path):
         manager = SessionManager(storage_path=tmp_path / "sessions")
         session = manager.get_session("cli", "chat-1", "user-1")
         session.add_message("user", "hello")
-        calls = {}
-
-        def spy(path, content, **kwargs):
-            calls["path"] = path
-            calls["content"] = content
-            calls["kwargs"] = kwargs
-            real_safe_write(path, content, **kwargs)
-
-        monkeypatch.setattr(catalog_module, "safe_write", spy)
 
         assert manager._save_sessions() is True
 
-        assert calls["path"] == tmp_path / "sessions" / "sessions.json"
-        assert calls["kwargs"]["fsync"] is True
-        assert calls["kwargs"]["allow_fallback"] is False
-        assert json.loads(calls["content"])[0]["context"]["messages"][0]["content"] == "hello"
-        assert (tmp_path / "sessions" / "sessions.index.json").exists()
+        sessions_file = tmp_path / "sessions" / "sessions.json"
+        index_file = tmp_path / "sessions" / "sessions.index.sqlite3"
+        assert (
+            json.loads(sessions_file.read_text(encoding="utf-8"))[0]["context"]["messages"][0][
+                "content"
+            ]
+            == "hello"
+        )
+        assert index_file.exists()
+        with sqlite3.connect(index_file) as conn:
+            row = conn.execute(
+                "SELECT channel, chat_id, title, byte_offset, byte_length FROM sessions"
+            ).fetchone()
+        assert row[:3] == ("cli", "chat-1", "hello")
+        assert row[3] >= 1
+        assert row[4] > 0
+
+    def test_incremental_summary_update_preserves_history_document(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "chat-1", "desktop_user")
+        session.add_message("user", "history remains readable")
+        session.set_metadata("conversation_title", "Original title")
+        assert manager._save_sessions() is True
+
+        sessions_file = storage_path / "sessions.json"
+        original_bytes = sessions_file.read_bytes()
+        original_stat = sessions_file.stat()
+        original_entry = manager._catalog_store.get_entry(session.session_key)
+        assert original_entry is not None
+
+        session.set_metadata("conversation_title", "Updated searchable title")
+        session.set_metadata("selected_endpoint", "minimax")
+        session.set_metadata("endpoint_policy", "strict")
+        session.set_metadata(
+            "ui_org_state",
+            {"orgMode": True, "orgId": "org_ops", "orgNodeId": "pm"},
+        )
+
+        assert manager.persist_summary(session) is True
+
+        updated_entry = manager._catalog_store.get_entry(session.session_key)
+        assert updated_entry is not None
+        assert (updated_entry.offset, updated_entry.length) == (
+            original_entry.offset,
+            original_entry.length,
+        )
+        assert sessions_file.read_bytes() == original_bytes
+        assert sessions_file.stat().st_mtime_ns == original_stat.st_mtime_ns
+        assert (
+            manager._catalog_store.read_document(updated_entry)["context"]["messages"][0]["content"]
+            == "history remains readable"
+        )
+        assert manager._catalog_store.list_summaries(query="updated searchable").total == 1
+        assert manager._catalog_store.list_summaries(query="original title").total == 0
+
+        reloaded = SessionManager(storage_path=storage_path)
+        restored = reloaded.get_session(
+            "desktop", "chat-1", "desktop_user", create_if_missing=False
+        )
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "history remains readable"
+        assert restored.get_metadata("conversation_title") == "Updated searchable title"
+        assert restored.get_metadata("selected_endpoint") == "minimax"
+        assert restored.get_metadata("endpoint_policy") == "strict"
+        assert restored.get_metadata("ui_org_state") == {
+            "orgMode": True,
+            "orgId": "org_ops",
+            "orgNodeId": "pm",
+        }
+
+    def test_existing_catalog_schema_is_reused_on_full_save(self, tmp_path, monkeypatch):
+        manager = SessionManager(storage_path=tmp_path / "sessions")
+        session = manager.get_session("desktop", "chat-1", "desktop_user")
+        session.add_message("user", "first")
+
+        initialize_calls = 0
+        real_initialize = manager._catalog_store._initialize_schema
+
+        def recording_initialize(conn):
+            nonlocal initialize_calls
+            initialize_calls += 1
+            return real_initialize(conn)
+
+        monkeypatch.setattr(manager._catalog_store, "_initialize_schema", recording_initialize)
+
+        assert manager._save_sessions() is True
+        session.add_message("assistant", "second")
+        assert manager._save_sessions() is True
+
+        assert initialize_calls == 1
 
     def test_save_sessions_serializes_concurrent_writes(self, tmp_path, monkeypatch):
-        from openakita.sessions import catalog as catalog_module
-        from openakita.utils.atomic_io import safe_write as real_safe_write
-
         manager = SessionManager(storage_path=tmp_path / "sessions")
         session = manager.get_session("cli", "chat-1", "user-1")
         session.add_message("user", "hello")
@@ -221,14 +293,16 @@ class TestSessionPersistence:
         active_writes = 0
         max_active_writes = 0
 
-        def spy(path, content, **kwargs):
+        real_write = manager._catalog_store.write
+
+        def spy(documents):
             nonlocal active_writes, max_active_writes
             with counter_lock:
                 active_writes += 1
                 max_active_writes = max(max_active_writes, active_writes)
             try:
                 time.sleep(0.001)
-                real_safe_write(path, content, **kwargs)
+                return real_write(documents)
             finally:
                 with counter_lock:
                     active_writes -= 1
@@ -239,7 +313,7 @@ class TestSessionPersistence:
                 if not manager._save_sessions():
                     failures.append((worker_id, i))
 
-        monkeypatch.setattr(catalog_module, "safe_write", spy)
+        monkeypatch.setattr(manager._catalog_store, "write", spy)
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
         for thread in threads:
             thread.start()
@@ -267,9 +341,6 @@ class TestSessionPersistence:
     def test_index_write_failure_keeps_deferred_offsets_aligned_for_retry(
         self, tmp_path, monkeypatch
     ):
-        from openakita.sessions import catalog as catalog_module
-        from openakita.utils.atomic_io import atomic_json_write as real_atomic_json_write
-
         storage_path = tmp_path / "sessions"
         manager = SessionManager(storage_path=storage_path)
         first = manager.get_session("desktop", "first", "desktop_user")
@@ -284,18 +355,28 @@ class TestSessionPersistence:
         )
         assert restored_first is not None
         restored_first.add_message("assistant", "a much longer response that moves later offsets")
-        old_second_offset = reloaded._session_catalog["desktop:second:desktop_user"].offset
+        second_key = "desktop:second:desktop_user"
+        old_entry = reloaded._catalog_store.get_entry(second_key)
+        assert old_entry is not None
 
-        def fail_index_write(*_args, **_kwargs):
-            raise OSError("index unavailable")
+        real_replace = reloaded._catalog_store._replace_with_retry
+        failed = False
 
-        monkeypatch.setattr(catalog_module, "atomic_json_write", fail_index_write)
+        def fail_primary_install(source, target, retries=3):
+            nonlocal failed
+            if source == reloaded._catalog_store.building_index_file and not failed:
+                failed = True
+                raise PermissionError("index unavailable")
+            return real_replace(source, target, retries)
+
+        monkeypatch.setattr(reloaded._catalog_store, "_replace_with_retry", fail_primary_install)
 
         assert reloaded._save_sessions() is False
-        new_second_offset = reloaded._session_catalog["desktop:second:desktop_user"].offset
-        assert new_second_offset > old_second_offset
+        new_entry = reloaded._catalog_store.get_entry(second_key)
+        assert new_entry is not None
+        assert new_entry.offset > old_entry.offset
 
-        monkeypatch.setattr(catalog_module, "atomic_json_write", real_atomic_json_write)
+        monkeypatch.setattr(reloaded._catalog_store, "_replace_with_retry", real_replace)
         assert reloaded._save_sessions() is True
 
         retried = SessionManager(storage_path=storage_path)
@@ -326,6 +407,7 @@ class TestSessionPersistence:
         reloaded = SessionManager(storage_path=storage_path)
 
         assert reloaded._sessions == {}
+        assert not hasattr(reloaded, "_session_catalog")
         assert hydration_calls == 0
         assert {item["chat_id"] for item in reloaded.list_session_summaries()} == {
             "first",
@@ -431,7 +513,7 @@ class TestSessionPersistence:
         session.add_message("user", "fallback history")
         session.last_active = datetime.now() - timedelta(days=90)
         assert manager._save_sessions() is True
-        (storage_path / "sessions.index.json").unlink()
+        (storage_path / "sessions.index.sqlite3").unlink()
 
         def fail_catalog_write(*_args, **_kwargs):
             raise OSError("index unavailable")
@@ -442,6 +524,56 @@ class TestSessionPersistence:
         restored = reloaded.get_session("desktop", "cold", "desktop_user", create_if_missing=False)
         assert restored is not None
         assert restored.context.messages[0]["content"] == "fallback history"
+
+    def test_legacy_json_index_is_removed_when_sqlite_catalog_is_built(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "legacy", "desktop_user")
+        session.add_message("user", "legacy catalog")
+        assert manager._save_sessions() is True
+
+        sqlite_index = storage_path / "sessions.index.sqlite3"
+        legacy_index = storage_path / "sessions.index.json"
+        sqlite_index.unlink()
+        legacy_index.write_text('{"version":1,"sessions":[]}', encoding="utf-8")
+
+        reloaded = SessionManager(storage_path=storage_path)
+
+        assert sqlite_index.exists()
+        assert not legacy_index.exists()
+        assert [summary["chat_id"] for summary in reloaded.list_session_summaries()] == ["legacy"]
+
+    def test_save_rebuilds_corrupt_sqlite_catalog_without_dropping_deferred_sessions(
+        self, tmp_path
+    ):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        first = manager.get_session("desktop", "first", "desktop_user")
+        first.add_message("user", "first history")
+        second = manager.get_session("desktop", "second", "desktop_user")
+        second.add_message("user", "second history")
+        assert manager._save_sessions() is True
+
+        reloaded = SessionManager(storage_path=storage_path)
+        restored_first = reloaded.get_session(
+            "desktop", "first", "desktop_user", create_if_missing=False
+        )
+        assert restored_first is not None
+        restored_first.add_message("assistant", "updated first history")
+        (storage_path / "sessions.index.sqlite3").write_bytes(b"not a sqlite database")
+
+        assert reloaded._save_sessions() is True
+
+        restarted = SessionManager(storage_path=storage_path)
+        restored_second = restarted.get_session(
+            "desktop", "second", "desktop_user", create_if_missing=False
+        )
+        assert restored_second is not None
+        assert restored_second.context.messages[0]["content"] == "second history"
+        assert {item["chat_id"] for item in restarted.list_session_summaries()} == {
+            "first",
+            "second",
+        }
 
 
 class TestSessionState:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3,7 +3,7 @@
 import json
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -182,29 +182,34 @@ class TestAgentProfileScopedHistory:
 
 
 class TestSessionPersistence:
-    def test_save_sessions_uses_strict_atomic_json_write(self, tmp_path, monkeypatch):
+    def test_save_sessions_uses_strict_atomic_writes(self, tmp_path, monkeypatch):
+        from openakita.sessions import catalog as catalog_module
+        from openakita.utils.atomic_io import safe_write as real_safe_write
+
         manager = SessionManager(storage_path=tmp_path / "sessions")
         session = manager.get_session("cli", "chat-1", "user-1")
         session.add_message("user", "hello")
         calls = {}
 
-        def spy(path, data, **kwargs):
+        def spy(path, content, **kwargs):
             calls["path"] = path
-            calls["data"] = data
+            calls["content"] = content
             calls["kwargs"] = kwargs
+            real_safe_write(path, content, **kwargs)
 
-        monkeypatch.setattr("openakita.sessions.manager.atomic_json_write", spy)
+        monkeypatch.setattr(catalog_module, "safe_write", spy)
 
         assert manager._save_sessions() is True
 
         assert calls["path"] == tmp_path / "sessions" / "sessions.json"
-        assert calls["kwargs"]["indent"] is None
         assert calls["kwargs"]["fsync"] is True
         assert calls["kwargs"]["allow_fallback"] is False
-        assert calls["data"][0]["context"]["messages"][0]["content"] == "hello"
+        assert json.loads(calls["content"])[0]["context"]["messages"][0]["content"] == "hello"
+        assert (tmp_path / "sessions" / "sessions.index.json").exists()
 
     def test_save_sessions_serializes_concurrent_writes(self, tmp_path, monkeypatch):
-        from openakita.utils.atomic_io import atomic_json_write as real_atomic_json_write
+        from openakita.sessions import catalog as catalog_module
+        from openakita.utils.atomic_io import safe_write as real_safe_write
 
         manager = SessionManager(storage_path=tmp_path / "sessions")
         session = manager.get_session("cli", "chat-1", "user-1")
@@ -216,14 +221,14 @@ class TestSessionPersistence:
         active_writes = 0
         max_active_writes = 0
 
-        def spy(path, data, **kwargs):
+        def spy(path, content, **kwargs):
             nonlocal active_writes, max_active_writes
             with counter_lock:
                 active_writes += 1
                 max_active_writes = max(max_active_writes, active_writes)
             try:
                 time.sleep(0.001)
-                real_atomic_json_write(path, data, **kwargs)
+                real_safe_write(path, content, **kwargs)
             finally:
                 with counter_lock:
                     active_writes -= 1
@@ -234,9 +239,7 @@ class TestSessionPersistence:
                 if not manager._save_sessions():
                     failures.append((worker_id, i))
 
-        from openakita.sessions import manager as manager_module
-
-        monkeypatch.setattr(manager_module, "atomic_json_write", spy)
+        monkeypatch.setattr(catalog_module, "safe_write", spy)
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
         for thread in threads:
             thread.start()
@@ -260,6 +263,185 @@ class TestSessionPersistence:
         manager.persist()
 
         assert manager._dirty is True
+
+    def test_index_write_failure_keeps_deferred_offsets_aligned_for_retry(
+        self, tmp_path, monkeypatch
+    ):
+        from openakita.sessions import catalog as catalog_module
+        from openakita.utils.atomic_io import atomic_json_write as real_atomic_json_write
+
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        first = manager.get_session("desktop", "first", "desktop_user")
+        first.add_message("user", "short")
+        second = manager.get_session("desktop", "second", "desktop_user")
+        second.add_message("user", "second history")
+        assert manager._save_sessions() is True
+
+        reloaded = SessionManager(storage_path=storage_path)
+        restored_first = reloaded.get_session(
+            "desktop", "first", "desktop_user", create_if_missing=False
+        )
+        assert restored_first is not None
+        restored_first.add_message("assistant", "a much longer response that moves later offsets")
+        old_second_offset = reloaded._session_catalog["desktop:second:desktop_user"].offset
+
+        def fail_index_write(*_args, **_kwargs):
+            raise OSError("index unavailable")
+
+        monkeypatch.setattr(catalog_module, "atomic_json_write", fail_index_write)
+
+        assert reloaded._save_sessions() is False
+        new_second_offset = reloaded._session_catalog["desktop:second:desktop_user"].offset
+        assert new_second_offset > old_second_offset
+
+        monkeypatch.setattr(catalog_module, "atomic_json_write", real_atomic_json_write)
+        assert reloaded._save_sessions() is True
+
+        retried = SessionManager(storage_path=storage_path)
+        restored_second = retried.get_session(
+            "desktop", "second", "desktop_user", create_if_missing=False
+        )
+        assert restored_second is not None
+        assert restored_second.context.messages[0]["content"] == "second history"
+
+    def test_restart_defers_full_session_hydration_until_lookup(self, tmp_path, monkeypatch):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        first = manager.get_session("desktop", "first", "desktop_user")
+        first.add_message("user", "first history")
+        second = manager.get_session("desktop", "second", "desktop_user")
+        second.add_message("user", "second history")
+        assert manager._save_sessions() is True
+
+        original_from_dict = Session.from_dict
+        hydration_calls = 0
+
+        def recording_from_dict(data):
+            nonlocal hydration_calls
+            hydration_calls += 1
+            return original_from_dict(data)
+
+        monkeypatch.setattr(Session, "from_dict", recording_from_dict)
+        reloaded = SessionManager(storage_path=storage_path)
+
+        assert reloaded._sessions == {}
+        assert hydration_calls == 0
+        assert {item["chat_id"] for item in reloaded.list_session_summaries()} == {
+            "first",
+            "second",
+        }
+
+        restored = reloaded.get_session("desktop", "first", "desktop_user", create_if_missing=False)
+
+        assert restored is not None
+        assert hydration_calls == 1
+        assert restored.context.messages[0]["content"] == "first history"
+        assert list(reloaded._sessions) == ["desktop:first:desktop_user"]
+
+    def test_get_session_by_id_caches_a_deferred_session(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "first", "desktop_user")
+        session.add_message("user", "first history")
+        session_id = session.id
+        assert manager._save_sessions() is True
+
+        reloaded = SessionManager(storage_path=storage_path)
+        restored = reloaded.get_session_by_id(session_id)
+
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "first history"
+        assert reloaded._sessions[restored.session_key] is restored
+
+    def test_cold_session_remains_available_and_hydrates_on_demand(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "cold", "desktop_user")
+        session.add_message("user", "old history")
+        session.last_active = datetime.now() - timedelta(days=90)
+        assert manager._save_sessions() is True
+
+        reloaded = SessionManager(storage_path=storage_path)
+
+        assert reloaded._sessions == {}
+        assert [summary["chat_id"] for summary in reloaded.list_session_summaries()] == ["cold"]
+
+        restored = reloaded.get_session("desktop", "cold", "desktop_user", create_if_missing=False)
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "old history"
+
+    def test_legacy_expired_session_reactivates_when_opened(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "legacy-expired", "desktop_user")
+        session.add_message("user", "legacy history")
+        session.last_active = datetime.now() - timedelta(days=90)
+        session.mark_expired()
+        assert manager._save_sessions() is True
+
+        reloaded = SessionManager(storage_path=storage_path)
+        summaries = reloaded.list_session_summaries()
+        assert summaries[0]["state"] == SessionState.IDLE.value
+
+        restored = reloaded.get_session(
+            "desktop", "legacy-expired", "desktop_user", create_if_missing=False
+        )
+        assert restored is not None
+        assert restored.state == SessionState.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_cold_cleanup_evicts_memory_but_keeps_session_reloadable(self, tmp_path):
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "cold", "desktop_user")
+        session.add_message("user", "reload me")
+        session.last_active = datetime.now() - timedelta(days=90)
+        assert manager._save_sessions() is True
+
+        assert await manager.cleanup_expired() == 1
+        assert manager._sessions == {}
+        assert [summary["chat_id"] for summary in manager.list_session_summaries()] == ["cold"]
+
+        restored = manager.get_session("desktop", "cold", "desktop_user", create_if_missing=False)
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "reload me"
+
+    @pytest.mark.asyncio
+    async def test_cold_cleanup_keeps_loaded_session_when_persistence_fails(
+        self, tmp_path, monkeypatch
+    ):
+        manager = SessionManager(storage_path=tmp_path / "sessions")
+        session = manager.get_session("desktop", "cold", "desktop_user")
+        session.add_message("user", "unsaved history")
+        session.last_active = datetime.now() - timedelta(days=90)
+        manager.mark_dirty()
+        monkeypatch.setattr(manager, "_save_sessions", lambda: False)
+
+        assert await manager.cleanup_expired() == 0
+        assert manager._sessions[session.session_key] is session
+        assert manager._dirty is True
+
+    def test_catalog_build_failure_keeps_cold_sessions_available(self, tmp_path, monkeypatch):
+        from openakita.sessions.catalog import SessionCatalogStore
+
+        storage_path = tmp_path / "sessions"
+        manager = SessionManager(storage_path=storage_path)
+        session = manager.get_session("desktop", "cold", "desktop_user")
+        session.add_message("user", "fallback history")
+        session.last_active = datetime.now() - timedelta(days=90)
+        assert manager._save_sessions() is True
+        (storage_path / "sessions.index.json").unlink()
+
+        def fail_catalog_write(*_args, **_kwargs):
+            raise OSError("index unavailable")
+
+        monkeypatch.setattr(SessionCatalogStore, "write", fail_catalog_write)
+        reloaded = SessionManager(storage_path=storage_path)
+
+        restored = reloaded.get_session("desktop", "cold", "desktop_user", create_if_missing=False)
+        assert restored is not None
+        assert restored.context.messages[0]["content"] == "fallback history"
 
 
 class TestSessionState:

--- a/tests/unit/test_sessions_history_route.py
+++ b/tests/unit/test_sessions_history_route.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -202,6 +204,101 @@ def test_session_list_returns_conversation_ui_state(tmp_path):
     assert body["sessions"][0]["orgMode"] is True
     assert body["sessions"][0]["orgId"] == "org_company"
     assert body["sessions"][0]["orgNodeId"] == "pm"
+
+
+def test_session_list_pages_catalog_without_hydrating_histories(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    for index in range(5):
+        session = manager.get_session("desktop", f"conv-{index}", "desktop_user")
+        session.add_message("user", f"catalog message {index}")
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+    client = TestClient(app)
+
+    first = client.get("/api/sessions", params={"limit": 2, "offset": 0}).json()
+    second = client.get("/api/sessions", params={"limit": 2, "offset": 2}).json()
+
+    assert first["ready"] is True
+    assert first["total"] == 5
+    assert first["has_more"] is True
+    assert first["next_offset"] == 2
+    assert len(first["sessions"]) == 2
+    assert second["next_offset"] == 4
+    assert len(second["sessions"]) == 2
+    assert {item["id"] for item in first["sessions"]}.isdisjoint(
+        {item["id"] for item in second["sessions"]}
+    )
+    assert reloaded._sessions == {}
+
+
+def test_session_list_includes_cold_catalog_entries_without_hydrating(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    session = manager.get_session("desktop", "cold", "desktop_user")
+    session.add_message("user", "old history")
+    session.last_active = datetime.now() - timedelta(days=90)
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+
+    body = TestClient(app).get("/api/sessions").json()
+
+    assert body["total"] == 1
+    assert body["sessions"][0]["id"] == "cold"
+    assert reloaded._sessions == {}
+
+
+def test_session_list_pages_put_old_pinned_sessions_first(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    old_pinned = manager.get_session("desktop", "old-pinned", "desktop_user")
+    old_pinned.add_message("user", "old but pinned")
+    old_pinned.context.messages[-1]["timestamp"] = "2020-01-01T00:00:00"
+    old_pinned.set_metadata("pinned", True)
+    recent = manager.get_session("desktop", "recent", "desktop_user")
+    recent.add_message("user", "recent")
+    recent.context.messages[-1]["timestamp"] = "2026-01-01T00:00:00"
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+
+    body = TestClient(app).get("/api/sessions", params={"limit": 1}).json()
+
+    assert body["sessions"][0]["id"] == "old-pinned"
+    assert body["sessions"][0]["pinned"] is True
+    assert reloaded._sessions == {}
+
+
+def test_session_list_searches_deferred_catalog_summaries(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    first = manager.get_session("desktop", "matching", "desktop_user")
+    first.add_message("user", "unique deferred phrase")
+    second = manager.get_session("desktop", "other", "desktop_user")
+    second.add_message("user", "unrelated")
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+
+    body = TestClient(app).get("/api/sessions", params={"q": "deferred phrase"}).json()
+
+    assert body["total"] == 1
+    assert [item["id"] for item in body["sessions"]] == ["matching"]
+    assert reloaded._sessions == {}
 
 
 def test_update_session_ui_state_persists_conversation_selection(tmp_path):

--- a/tests/unit/test_sessions_history_route.py
+++ b/tests/unit/test_sessions_history_route.py
@@ -1,8 +1,10 @@
+import asyncio
 from datetime import datetime, timedelta
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from openakita.api.routes import sessions as sessions_routes
 from openakita.api.routes.sessions import router
 from openakita.sessions import SessionManager
 
@@ -236,6 +238,89 @@ def test_session_list_pages_catalog_without_hydrating_histories(tmp_path):
     assert reloaded._sessions == {}
 
 
+def test_session_list_uses_sqlite_page_query_instead_of_eager_summary_list(tmp_path, monkeypatch):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    for index in range(5):
+        session = manager.get_session("desktop", f"conv-{index}", "desktop_user")
+        session.add_message("user", f"catalog message {index}")
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    monkeypatch.setattr(
+        reloaded,
+        "list_session_summaries",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("eager list used")),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+
+    body = TestClient(app).get("/api/sessions", params={"limit": 2}).json()
+
+    assert body["total"] == 5
+    assert len(body["sessions"]) == 2
+    assert reloaded._sessions == {}
+
+
+def test_session_list_merges_loaded_overrides_into_sqlite_pagination(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    for index in range(4):
+        session = manager.get_session("desktop", f"conv-{index}", "desktop_user")
+        session.add_message("user", f"catalog message {index}")
+        session.context.messages[-1]["timestamp"] = f"2026-01-0{index + 1}T00:00:00"
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    promoted = reloaded.get_session("desktop", "conv-0", "desktop_user", create_if_missing=False)
+    assert promoted is not None
+    promoted.set_metadata("pinned", True)
+    new_session = reloaded.get_session("desktop", "new", "desktop_user")
+    new_session.add_message("user", "not persisted yet")
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+    client = TestClient(app)
+
+    first = client.get("/api/sessions", params={"limit": 2, "offset": 0}).json()
+    second = client.get("/api/sessions", params={"limit": 2, "offset": 2}).json()
+
+    assert first["total"] == 5
+    assert first["sessions"][0]["id"] == "conv-0"
+    assert first["sessions"][0]["pinned"] is True
+    assert {item["id"] for item in first["sessions"]}.isdisjoint(
+        {item["id"] for item in second["sessions"]}
+    )
+
+
+def test_session_list_sqlite_filters_search_and_org_conversations(tmp_path):
+    storage_path = tmp_path / "sessions"
+    manager = SessionManager(storage_path=storage_path)
+    matching = manager.get_session("desktop", "matching", "desktop_user")
+    matching.add_message("user", "Unique MixedCase Phrase 中文会话")
+    unrelated = manager.get_session("desktop", "other", "desktop_user")
+    unrelated.add_message("user", "unrelated")
+    org_session = manager.get_session("desktop", "org_hidden", "desktop_user")
+    org_session.add_message("user", "Unique MixedCase Phrase")
+    manager.persist()
+
+    reloaded = SessionManager(storage_path=storage_path)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.session_manager = reloaded
+
+    body = TestClient(app).get("/api/sessions", params={"q": "mixedcase phrase"}).json()
+    chinese = TestClient(app).get("/api/sessions", params={"q": "中文会"}).json()
+    short_query = TestClient(app).get("/api/sessions", params={"q": "中文"}).json()
+
+    assert body["total"] == 1
+    assert [item["id"] for item in body["sessions"]] == ["matching"]
+    assert [item["id"] for item in chinese["sessions"]] == ["matching"]
+    assert [item["id"] for item in short_query["sessions"]] == ["matching"]
+
+
 def test_session_list_includes_cold_catalog_entries_without_hydrating(tmp_path):
     storage_path = tmp_path / "sessions"
     manager = SessionManager(storage_path=storage_path)
@@ -301,13 +386,23 @@ def test_session_list_searches_deferred_catalog_summaries(tmp_path):
     assert reloaded._sessions == {}
 
 
-def test_update_session_ui_state_persists_conversation_selection(tmp_path):
+def test_update_session_ui_state_persists_conversation_selection(tmp_path, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     manager = SessionManager(storage_path=tmp_path)
     session = manager.get_session("desktop", "conv1", "desktop_user")
     session.add_message("user", "hello")
+    manager.persist()
     app.state.session_manager = manager
+
+    sessions_file = tmp_path / "sessions.json"
+    original_bytes = sessions_file.read_bytes()
+    original_mtime_ns = sessions_file.stat().st_mtime_ns
+
+    def unexpected_full_persist():
+        raise AssertionError("ui-state must not rewrite the full session document")
+
+    monkeypatch.setattr(manager, "persist", unexpected_full_persist)
 
     resp = TestClient(app).post(
         "/api/sessions/conv1/ui-state",
@@ -326,6 +421,46 @@ def test_update_session_ui_state_persists_conversation_selection(tmp_path):
         "orgId": "org_ops",
         "orgNodeId": "",
     }
+    summary = manager._catalog_store.get_entry(session.session_key).summary
+    assert summary["endpoint_id"] == "minimax"
+    assert summary["org_mode"] is True
+    assert summary["org_id"] == "org_ops"
+    assert sessions_file.read_bytes() == original_bytes
+    assert sessions_file.stat().st_mtime_ns == original_mtime_ns
+
+    reloaded = SessionManager(storage_path=tmp_path)
+    restored = reloaded.get_session("desktop", "conv1", "desktop_user", create_if_missing=False)
+    assert restored is not None
+    assert restored.context.messages[0]["content"] == "hello"
+    assert restored.get_metadata("selected_endpoint") == "minimax"
+    assert restored.get_metadata("ui_org_state") == {
+        "orgMode": True,
+        "orgId": "org_ops",
+        "orgNodeId": "",
+    }
+
+
+def test_create_session_dispatches_full_persistence_to_thread_pool(tmp_path, monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+    manager = SessionManager(storage_path=tmp_path)
+    app.state.session_manager = manager
+    dispatched = []
+    real_to_thread = asyncio.to_thread
+
+    async def recording_to_thread(func, *args, **kwargs):
+        dispatched.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(sessions_routes.asyncio, "to_thread", recording_to_thread)
+
+    response = TestClient(app).post("/api/sessions", json={"conversationId": "threaded-save"})
+
+    assert response.status_code == 200
+    assert any(
+        getattr(func, "__self__", None) is manager and getattr(func, "__name__", "") == "persist"
+        for func in dispatched
+    )
 
 
 def test_update_session_ui_state_does_not_create_empty_session(tmp_path):


### PR DESCRIPTION
## Summary

- Virtualize and page desktop session navigation so large histories do not require rendering or loading every conversation at startup.
- Replace the JSON summary index with a queryable SQLite catalog while preserving lazy random-access hydration of canonical session documents.
- Update UI metadata incrementally and move full session persistence off the FastAPI event loop to prevent intermittent conversation-switch stalls.

## Tests

- `uv run --no-sync pytest tests/unit/test_session.py tests/unit/test_sessions_history_route.py tests/unit/test_chat_background_save.py tests/unit/test_chat_org_command_stream.py tests/unit/test_policy_v2_c8b3_session_allowlist.py tests/integration/test_api_chat.py -q`
- `uv run --no-sync pytest tests/component/test_session_persistence.py tests/integration/test_session_lifecycle.py tests/unit/test_session_working_directory.py -q`
- `uv run --no-sync ruff check src/openakita/api/routes/chat.py src/openakita/api/routes/sessions.py src/openakita/sessions/catalog.py src/openakita/sessions/manager.py tests/unit/test_session.py tests/unit/test_sessions_history_route.py`
- `uv run --no-sync ruff format --check src/openakita/api/routes/chat.py src/openakita/api/routes/sessions.py src/openakita/sessions/catalog.py src/openakita/sessions/manager.py tests/unit/test_session.py tests/unit/test_sessions_history_route.py`
