### PR TITLE
fix IM artifact delivery across channel and desktop conversations

### DIFF
--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -1557,6 +1557,7 @@ class MessageGateway:
         source_message_id: str | None = None,
         chain_summary: list | None = None,
         tool_summary: str | None = None,
+        artifacts: list[dict] | None = None,
     ) -> None:
         """Mirror IM turns into the normal desktop chat list.
 
@@ -1580,6 +1581,8 @@ class MessageGateway:
             chat_name=label,
         )
         mirror.context.agent_profile_id = session.context.agent_profile_id
+        if session.working_directory:
+            mirror.working_directory = session.working_directory
         mirror.set_metadata("source_channel", session.channel)
         mirror.set_metadata("source_bot_instance_id", session.bot_instance_id or session.channel)
         mirror.set_metadata("source_chat_id", session.chat_id)
@@ -1605,8 +1608,20 @@ class MessageGateway:
             meta["chain_summary"] = chain_summary
         if tool_summary:
             meta["tool_summary"] = tool_summary
+        if artifacts:
+            prepared_artifacts = self._prepare_desktop_mirror_artifacts(
+                mirror,
+                artifacts,
+            )
+            if prepared_artifacts:
+                meta["artifacts"] = prepared_artifacts
 
         added = mirror.add_message(role=role, content=mirrored_content, **meta)
+        if not added and meta.get("artifacts"):
+            # Text-only dedup must not discard a newly delivered attachment
+            # when consecutive image generations use the same final wording.
+            mirror.append_marker(role=role, content=mirrored_content, **meta)
+            added = True
         if not added:
             return
         self.session_manager.mark_dirty()
@@ -1622,6 +1637,82 @@ class MessageGateway:
                 "source_session_id": session.session_key,
             },
         )
+
+    @staticmethod
+    def _prepare_desktop_mirror_artifacts(
+        mirror: Session,
+        artifacts: list[dict],
+    ) -> list[dict]:
+        """Create desktop-safe artifact projections for an IM mirror turn."""
+        import shutil
+        import urllib.parse
+
+        from ..core.working_directory import session_working_directory
+
+        try:
+            workspace_root = session_working_directory(mirror, require_available=True).resolve()
+        except Exception as exc:
+            logger.warning("Failed to resolve desktop mirror workspace: %s", exc)
+            return []
+
+        prepared: list[dict] = []
+        seen: set[tuple[str, str]] = set()
+        for raw in artifacts:
+            if not isinstance(raw, dict):
+                continue
+            raw_path = str(raw.get("path") or "").strip()
+            if not raw_path:
+                continue
+            try:
+                source = Path(raw_path).resolve(strict=True)
+                if not source.is_file():
+                    continue
+                projected = source
+                if not source.is_relative_to(workspace_root):
+                    output_dir = workspace_root / "data" / "output"
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    digest = str(raw.get("sha256") or "").strip()[:12]
+                    filename = (
+                        f"{source.stem}_{digest}{source.suffix}" if digest else source.name
+                    )
+                    projected = output_dir / filename
+                    if projected.exists() and digest:
+                        pass
+                    elif projected.exists():
+                        counter = 1
+                        while projected.exists():
+                            projected = output_dir / f"{source.stem}_{counter}{source.suffix}"
+                            counter += 1
+                        shutil.copy2(source, projected)
+                    else:
+                        shutil.copy2(source, projected)
+                    projected = projected.resolve()
+            except Exception as exc:
+                logger.warning("Failed to prepare mirrored artifact %s: %s", raw_path, exc)
+                continue
+
+            artifact_type = str(raw.get("artifact_type") or raw.get("type") or "file")
+            key = (artifact_type, str(projected).lower().replace("\\", "/"))
+            if key in seen:
+                continue
+            seen.add(key)
+            file_url = (
+                "/api/files?path="
+                + urllib.parse.quote(str(projected), safe="")
+                + "&conversation_id="
+                + urllib.parse.quote(mirror.chat_id, safe="")
+            )
+            prepared.append(
+                {
+                    "artifact_type": artifact_type,
+                    "file_url": file_url,
+                    "path": str(projected),
+                    "name": str(raw.get("name") or projected.name),
+                    "caption": str(raw.get("caption") or ""),
+                    "size": projected.stat().st_size,
+                }
+            )
+        return prepared
 
     # ==================== 自然语言意图检测 ====================
 
@@ -4531,6 +4622,9 @@ class MessageGateway:
                         logger.debug(f"[Gateway] Tool trace summary ({len(_tool_summary)} chars)")
             except Exception:
                 pass
+            _desktop_artifacts = list(
+                session.get_metadata("_pending_desktop_artifacts") or []
+            )
             _msg_meta: dict = {"bot_instance_id": bot_namespace}
             if _chain_summary:
                 _msg_meta["chain_summary"] = _chain_summary
@@ -4543,7 +4637,10 @@ class MessageGateway:
                 content=response_text,
                 chain_summary=_chain_summary,
                 tool_summary=_tool_summary,
+                artifacts=_desktop_artifacts,
             )
+            if _desktop_artifacts:
+                session.set_metadata("_pending_desktop_artifacts", [])
             self.session_manager.persist()
             _notify_im_event(
                 "im:new_message",

--- a/src/openakita/core/_agent_runtime.py
+++ b/src/openakita/core/_agent_runtime.py
@@ -4597,9 +4597,9 @@ class Agent:
             logger.warning(f"[Memory] Failed to align memory session: {e}")
 
         # 2. IM context setup（协程隔离）
-        from .im_context import set_im_context
+        from .im_context import ensure_im_context
 
-        im_tokens = set_im_context(
+        im_tokens = ensure_im_context(
             session=session if gateway else None,
             gateway=gateway,
         )
@@ -6276,6 +6276,17 @@ class Agent:
             yield {"type": "preparation_stage", "stage": "analyzing_intent"}
             _prepare_events: asyncio.Queue[dict] = asyncio.Queue()
 
+            # _prepare_session_context runs in a child task so preparation-stage
+            # events can be emitted while it works. ContextVar changes made only
+            # in that child do not propagate back to this task, where tools run.
+            # Install the IM context here first; the child inherits it.
+            from .im_context import ensure_im_context
+
+            im_tokens = ensure_im_context(
+                session=session if gateway else None,
+                gateway=gateway,
+            )
+
             def _queue_prepare_stage(stage: str) -> None:
                 _prepare_events.put_nowait({"type": "preparation_stage", "stage": stage})
 
@@ -6320,7 +6331,7 @@ class Agent:
                     session_type,
                     task_monitor,
                     conversation_id,
-                    im_tokens,
+                    _prepare_im_tokens,
                 ) = await _prepare_task
             except UserCancelledError:
                 logger.info(

--- a/src/openakita/core/im_context.py
+++ b/src/openakita/core/im_context.py
@@ -34,6 +34,15 @@ def set_im_context(*, session: Any | None, gateway: Any | None) -> tuple[Any, An
     return tok1, tok2
 
 
+def ensure_im_context(
+    *, session: Any | None, gateway: Any | None
+) -> tuple[Any, Any] | None:
+    """Install an IM context unless this task already carries the same one."""
+    if current_im_session.get() is session and current_im_gateway.get() is gateway:
+        return None
+    return set_im_context(session=session, gateway=gateway)
+
+
 def reset_im_context(tokens: tuple[Any, Any]) -> None:
     tok1, tok2 = tokens
     current_im_session.reset(tok1)

--- a/src/openakita/tools/handlers/im_channel.py
+++ b/src/openakita/tools/handlers/im_channel.py
@@ -703,9 +703,12 @@ class IMChannelHandler:
 
         artifacts = self._normalize_artifacts(params.get("artifacts"))
         receipts = []
+        desktop_mirror_artifacts: list[dict] = []
 
         # 会话内去重（仅运行时有效，不落盘）
-        session = getattr(self.agent, "_current_session", None)
+        from ...core.im_context import get_im_session
+
+        session = get_im_session() or getattr(self.agent, "_current_session", None)
         dedupe_set: set[str] = set()
         try:
             if session and hasattr(session, "get_metadata"):
@@ -748,6 +751,7 @@ class IMChannelHandler:
                 "status": "failed",
                 "error_code": "",
                 "name": name,
+                "caption": caption,
                 "mime": mime,
                 "size": size,
                 "sha256": sha256,
@@ -806,6 +810,17 @@ class IMChannelHandler:
 
             if receipt.get("status") == "delivered" and dedupe_key:
                 dedupe_set.add(dedupe_key)
+            if receipt.get("status") == "delivered" and path:
+                desktop_mirror_artifacts.append(
+                    {
+                        "artifact_type": art_type,
+                        "path": path,
+                        "name": name or Path(path).name,
+                        "caption": caption,
+                        "size": size,
+                        "sha256": sha256,
+                    }
+                )
 
         # 保存回 session metadata（下划线开头：不落盘，仅运行时）
         try:
@@ -813,6 +828,32 @@ class IMChannelHandler:
                 session.set_metadata("_delivered_dedupe_keys", list(dedupe_set))
         except Exception:
             pass
+
+        # The IM adapter owns remote delivery, while the desktop chat mirrors
+        # the same turn from the local file. Keep this private and transient;
+        # MessageGateway consumes it when it writes the assistant mirror turn.
+        if session and desktop_mirror_artifacts:
+            try:
+                pending = list(session.get_metadata("_pending_desktop_artifacts") or [])
+                seen = {
+                    (
+                        str(item.get("artifact_type") or item.get("type") or ""),
+                        str(item.get("path") or "").lower().replace("\\", "/"),
+                    )
+                    for item in pending
+                    if isinstance(item, dict)
+                }
+                for item in desktop_mirror_artifacts:
+                    key = (
+                        str(item.get("artifact_type") or item.get("type") or ""),
+                        str(item.get("path") or "").lower().replace("\\", "/"),
+                    )
+                    if key not in seen:
+                        pending.append(item)
+                        seen.add(key)
+                session.set_metadata("_pending_desktop_artifacts", pending)
+            except Exception as exc:
+                logger.warning("Failed to queue desktop artifact mirror: %s", exc)
 
         ok = (
             all(r.get("status") in ("delivered", "skipped") for r in receipts)

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -551,6 +551,65 @@ class TestMessageGatewayDesktopMirror:
         assert mirror.context.messages[1]["role"] == "assistant"
         assert mirror.context.messages[1]["tool_summary"] == "checked"
 
+    def test_mirrors_im_artifact_into_desktop_conversation(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        image = workspace / "generated.png"
+        image.write_bytes(b"image-data")
+        session_manager = SessionManager(storage_path=tmp_path / "sessions")
+        gateway = MessageGateway(session_manager=session_manager)
+        im_session = session_manager.get_session(
+            "wechat:customer",
+            "chat-1",
+            "user-1",
+            bot_instance_id="wechat:customer",
+        )
+        im_session.working_directory = str(workspace)
+
+        gateway._mirror_im_message_to_desktop(
+            im_session,
+            role="assistant",
+            content="图片已发送",
+            artifacts=[
+                {
+                    "artifact_type": "image",
+                    "path": str(image),
+                    "name": "海景图.png",
+                    "caption": "有花有草的海景图",
+                }
+            ],
+        )
+
+        mirror_id = gateway._desktop_mirror_id_for_im(im_session)
+        mirror = session_manager.get_session(
+            "desktop",
+            mirror_id,
+            "desktop_user",
+            create_if_missing=False,
+        )
+        assert mirror is not None
+        artifact = mirror.context.messages[-1]["artifacts"][0]
+        assert artifact["artifact_type"] == "image"
+        assert artifact["path"] == str(image.resolve())
+        assert artifact["name"] == "海景图.png"
+        assert artifact["caption"] == "有花有草的海景图"
+        assert artifact["size"] == len(b"image-data")
+        assert "conversation_id=" + mirror_id in artifact["file_url"]
+
+        second_image = workspace / "generated-2.png"
+        second_image.write_bytes(b"second-image")
+        gateway._mirror_im_message_to_desktop(
+            im_session,
+            role="assistant",
+            content="图片已发送",
+            artifacts=[{"artifact_type": "image", "path": str(second_image)}],
+        )
+
+        assert len(mirror.context.messages) == 2
+        assert mirror.context.messages[-1]["artifacts"][0]["path"] == str(
+            second_image.resolve()
+        )
+
     def test_desktop_mirror_splits_same_chat_by_bot_instance(self, tmp_path):
         session_manager = SessionManager(storage_path=tmp_path / "sessions")
         gateway = MessageGateway(session_manager=session_manager)

--- a/tests/unit/test_agent_prepare_context_compression.py
+++ b/tests/unit/test_agent_prepare_context_compression.py
@@ -8,6 +8,7 @@ from openakita.agent.core import Agent
 from openakita.agent.errors import UserCancelledError
 from openakita.core._context_runtime import _CancelledError as _CtxCancelledError
 from openakita.core.agent_state import AgentState
+from openakita.core.im_context import get_im_gateway, get_im_session, reset_im_context
 
 
 class _FakeContextManager:
@@ -207,6 +208,61 @@ async def test_chat_with_session_stream_reports_preparation_stages() -> None:
         {"type": "text_delta", "content": "✅ 好的，已停止当前任务。"},
         {"type": "done"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_chat_with_session_stream_keeps_im_context_after_prepare_task() -> None:
+    agent = _make_chat_agent()
+    session = SimpleNamespace(channel="wechat:test")
+    gateway = object()
+    context_seen: list[str] = []
+
+    async def _prepare_session_context(**kwargs):
+        assert get_im_session() is session
+        assert get_im_gateway() is gateway
+        context_seen.append("prepare")
+        return [], "im", None, "session-1", None
+
+    checks = 0
+
+    def _is_session_cancelled(_session_id):
+        nonlocal checks
+        checks += 1
+        if checks >= 2:
+            assert get_im_session() is session
+            assert get_im_gateway() is gateway
+            context_seen.append("after_prepare")
+            return True
+        return False
+
+    def _cleanup_im_context(tokens):
+        if tokens is not None:
+            reset_im_context(tokens)
+
+    agent._prepare_session_context = _prepare_session_context
+    agent._is_session_cancelled = _is_session_cancelled
+    agent._consume_pending_cancel = lambda _session_id: None
+    agent._build_slow_compiler_hint = lambda _session_id: None
+    agent._cleanup_session_state = _cleanup_im_context
+
+    events = [
+        event
+        async for event in agent.chat_with_session_stream(
+            message="生成并发送一张图片",
+            session_messages=[],
+            session_id="session-1",
+            session=session,
+            gateway=gateway,
+        )
+    ]
+
+    assert context_seen == ["prepare", "after_prepare"]
+    assert events[-2:] == [
+        {"type": "text_delta", "content": "✅ 好的，已停止当前任务。"},
+        {"type": "done"},
+    ]
+    assert get_im_session() is None
+    assert get_im_gateway() is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_im_channel_handler.py
+++ b/tests/unit/test_im_channel_handler.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -10,6 +12,17 @@ from openakita.tools.handlers.im_channel import IMChannelHandler
 class _FakeAgent:
     def __init__(self, workspace_dir):
         self.workspace_dir = str(workspace_dir)
+
+
+class _MetadataSession:
+    def __init__(self):
+        self.metadata = {}
+
+    def get_metadata(self, key, default=None):
+        return self.metadata.get(key, default)
+
+    def set_metadata(self, key, value):
+        self.metadata[key] = value
 
 
 def test_normalize_delivery_params_accepts_legacy_recipients():
@@ -131,3 +144,60 @@ async def test_deliver_artifacts_desktop_reports_missing_artifacts(tmp_path):
     assert payload["ok"] is False
     assert payload["error_code"] == "missing_artifacts"
     assert payload["receipts"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "wechat:customer",
+        "telegram:customer",
+        "feishu:customer",
+        "dingtalk:customer",
+        "wework_ws:customer",
+        "qqbot:customer",
+        "onebot:customer",
+    ],
+)
+async def test_successful_im_image_delivery_queues_desktop_mirror(tmp_path, channel):
+    image = tmp_path / "generated.png"
+    image.write_bytes(b"image-data")
+    session = _MetadataSession()
+    agent = _FakeAgent(tmp_path)
+    agent._current_session = session
+    handler = IMChannelHandler(agent)
+    handler._get_adapter_and_chat_id = lambda: (
+        SimpleNamespace(),
+        "chat-1",
+        channel,
+        "reply-1",
+        "user-1",
+    )
+    handler._send_image = AsyncMock(return_value="✅ 已发送图片 (message_id=media-1)")
+
+    result = await handler._deliver_artifacts(
+        {
+            "artifacts": [
+                {
+                    "type": "image",
+                    "path": str(image),
+                    "caption": "海景图",
+                }
+            ]
+        }
+    )
+
+    payload = json.loads(result)
+    assert payload["ok"] is True
+    assert payload["receipts"][0]["status"] == "delivered"
+    handler._send_image.assert_awaited_once()
+    assert session.get_metadata("_pending_desktop_artifacts") == [
+        {
+            "artifact_type": "image",
+            "path": str(image),
+            "name": "generated.png",
+            "caption": "海景图",
+            "size": len(b"image-data"),
+            "sha256": payload["receipts"][0]["sha256"],
+        }
+    ]

--- a/tests/unit/test_im_context.py
+++ b/tests/unit/test_im_context.py
@@ -1,12 +1,11 @@
 """L1 Unit Tests: IM context variable management."""
 
-import pytest
-
 from openakita.core.im_context import (
-    get_im_session,
+    ensure_im_context,
     get_im_gateway,
-    set_im_context,
+    get_im_session,
     reset_im_context,
+    set_im_context,
 )
 
 
@@ -41,3 +40,14 @@ class TestIMContext:
         reset_im_context(t2)
         assert get_im_session() == "outer"
         reset_im_context(t1)
+
+    def test_ensure_reuses_matching_context(self):
+        session = object()
+        gateway = object()
+        tokens = set_im_context(session=session, gateway=gateway)
+        try:
+            assert ensure_im_context(session=session, gateway=gateway) is None
+            assert get_im_session() is session
+            assert get_im_gateway() is gateway
+        finally:
+            reset_im_context(tokens)


### PR DESCRIPTION
## Summary

- Preserve the originating IM context throughout streamed execution so generated artifacts reach the requesting channel.
- Mirror successfully delivered IM artifacts into the corresponding desktop conversation so both surfaces display the same image.

## Tests

- `uv run --no-sync pytest tests/unit/test_im_context.py tests/unit/test_agent_prepare_context_compression.py tests/unit/test_im_channel_handler.py tests/integration/test_gateway.py` (62 passed)
- `uv run --no-sync ruff check src/openakita/core/im_context.py src/openakita/core/_agent_runtime.py src/openakita/tools/handlers/im_channel.py src/openakita/channels/gateway.py tests/unit/test_im_context.py tests/unit/test_agent_prepare_context_compression.py tests/unit/test_im_channel_handler.py tests/integration/test_gateway.py`

Fixes #819
