### PR TITLE
update the SignPath smoke workflow to exercise release signing

### DIFF
--- a/.github/workflows/signpath-smoke.yml
+++ b/.github/workflows/signpath-smoke.yml
@@ -124,9 +124,9 @@ jobs:
 
           $organizationId = "30d23f0d-92e9-4732-b944-3d9e62c8ef45"
           $projectSlug = "openakita"
-          $policySlug = "test-signing"
+          $policySlug = "release-signing"
           $artifactConfigurationSlug = "initial"
-          $certificateSlug = "test_certificate_2026"
+          $certificateSlug = "release_certificate_2026"
           $baseUrl = "https://app.signpath.io/api/v1/$organizationId"
           $headers = @{ Authorization = "Bearer $env:SIGNPATH_API_TOKEN" }
 
@@ -163,7 +163,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: 30d23f0d-92e9-4732-b944-3d9e62c8ef45
           project-slug: openakita
-          signing-policy-slug: test-signing
+          signing-policy-slug: release-signing
           artifact-configuration-slug: initial
           github-artifact-id: ${{ steps.upload_unsigned_fixture.outputs.artifact-id }}
           wait-for-completion: true


### PR DESCRIPTION
## Summary

- switch the SignPath smoke preflight check to the `release-signing` policy
- verify the `release_certificate_2026` certificate is available
- submit the smoke fixture through the release signing policy while retaining the existing API token and artifact configuration

## Why

The production SignPath certificate and signing policy have been provisioned, but the smoke workflow still exercised the self-signed test configuration. Updating the smoke path lets maintainers validate the same signing policy used for release artifacts.

## Validation

- parsed `.github/workflows/signpath-smoke.yml` with PyYAML in an isolated Python 3.11 environment
- verified the expected release policy and certificate values and the absence of the legacy test values
- ran `git diff --check`
