### PR TITLE
fix desktop hydration for IM mirror image artifacts

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -2749,9 +2749,15 @@ export function ChatView({
             .then((d2) => {
               if (!d2?.messages?.length || activeConvIdRef.current !== convId) return;
               if (displayedMessagesConvIdRef.current !== convId) return;
+              const isImMirrorUpdate = d.source === "im_mirror";
+              const backendMessages = isImMirrorUpdate
+                ? mapBackendHistoryToMessages(d2.messages)
+                : null;
               renderConversationMessages(
                 convId,
-                patchMessagesWithBackend(latestMessagesRef.current, d2.messages),
+                backendMessages
+                  ? chooseHydratedMessages(latestMessagesRef.current, backendMessages)
+                  : patchMessagesWithBackend(latestMessagesRef.current, d2.messages),
               );
             })
             .catch(() => {});

--- a/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts
@@ -91,3 +91,42 @@ describe("completion action hydration", () => {
     ]);
   });
 });
+
+describe("IM mirror hydration", () => {
+  it("appends a backend-only assistant message with its delivered image", () => {
+    const local: ChatMessage[] = [
+      {
+        id: "user-local",
+        historyIndex: 0,
+        role: "user",
+        content: "[来自微信] 生成一张海景图",
+        timestamp: 1,
+      },
+    ];
+    const backend: ChatMessage[] = [
+      local[0],
+      {
+        id: "assistant-backend",
+        historyIndex: 1,
+        role: "assistant",
+        content: "[回复到微信] 已生成并发送海景图",
+        timestamp: 2,
+        artifacts: [
+          {
+            artifact_type: "image",
+            file_url: "/api/files?path=generated.png&conversation_id=wechat-mirror",
+            path: "C:/workspace/generated.png",
+            name: "generated.png",
+            caption: "海景图",
+          },
+        ],
+      },
+    ];
+
+    const hydrated = chooseHydratedMessages(local, backend);
+
+    expect(hydrated).toHaveLength(2);
+    expect(hydrated[1].content).toContain("已生成并发送海景图");
+    expect(hydrated[1].artifacts).toEqual(backend[1].artifacts);
+  });
+});


### PR DESCRIPTION
## Summary

- Rehydrate IM mirror updates from authoritative backend history so newly mirrored assistant turns appear immediately in desktop chat.
- Preserve delivered image artifact metadata during real-time desktop synchronization and cover the behavior with a regression test.

## Tests

- `npm run test:run` (39 files, 122 tests passed)
- `npx tsc -b --pretty false`
- `npm run build`
- `npx eslint src/views/ChatView.tsx src/views/chat/utils/__tests__/chatHelpers.hydration.test.ts --max-warnings=9999` (0 errors)
