### PR TITLE
Fix organization command isolation and terminal delivery reporting

### DIFF
--- a/apps/setup-center/src/views/ChatView.tsx
+++ b/apps/setup-center/src/views/ChatView.tsx
@@ -105,6 +105,13 @@ import {
   persistStorageValueWithMessageEviction,
   retryStorageWriteAfterMessageEviction,
 } from "./chat/utils/storageRecovery";
+import {
+  clearActiveOrgCommand,
+  getActiveOrgCommand,
+  setActiveOrgCommand,
+  type ActiveOrgCommand,
+  type ActiveOrgCommandsByConversation,
+} from "./chat/utils/orgCommandState";
 import { useMdModules } from "./chat/hooks/useMdModules";
 import { useMessageReducer, useConversationReducer } from "./chat/hooks/useMessages";
 import { useQueryGuard } from "./chat/hooks/useQueryGuard";
@@ -1355,9 +1362,32 @@ export function ChatView({
   const [orgMenuOpen, setOrgMenuOpen] = useState(false);
   const orgMenuRef = useRef<HTMLDivElement | null>(null);
   const isOrgConvSwitchRef = useRef(false);
-  const [orgCommandPending, setOrgCommandPending] = useState(false);
-  const orgCommandPendingRef = useRef(false);
-  const activeOrgCommandRef = useRef<{ orgId: string; commandId: string } | null>(null);
+  // Organization commands are independent turns, just like ordinary streams.
+  // Keep their synchronous guard/cancel target scoped to the owning conversation
+  // so one long-running organization cannot lock every other chat tab.
+  const [activeOrgCommandsByConversation, setActiveOrgCommandsByConversation] =
+    useState<ActiveOrgCommandsByConversation>(() => new Map());
+  const activeOrgCommandsRef = useRef<ActiveOrgCommandsByConversation>(
+    activeOrgCommandsByConversation,
+  );
+  const updateActiveOrgCommand = useCallback((
+    conversationId: string,
+    command: ActiveOrgCommand | null,
+    expectedCommandId?: string,
+  ) => {
+    const current = activeOrgCommandsRef.current;
+    const next = command
+      ? setActiveOrgCommand(current, conversationId, command)
+      : clearActiveOrgCommand(current, conversationId, expectedCommandId);
+    if (next === current) return;
+    activeOrgCommandsRef.current = next;
+    setActiveOrgCommandsByConversation(next);
+  }, []);
+  const activeOrgCommand = getActiveOrgCommand(
+    activeOrgCommandsByConversation,
+    activeConvId,
+  );
+  const orgCommandPending = activeOrgCommand !== null;
 
   useEffect(() => {
     if (!orgMenuOpen) return;
@@ -3692,9 +3722,8 @@ export function ChatView({
       notifyError(t("chat.uploadFailedRetry", "有附件处理失败，请重新选择或稍后重试"));
       return;
     }
-    if (orgCommandPendingRef.current) return;
-
     const resolvedConvId = targetConvId || activeConvIdRef.current;
+    if (getActiveOrgCommand(activeOrgCommandsRef.current, resolvedConvId)) return;
     const targetIsStreaming = resolvedConvId ? !!streamContexts.current.get(resolvedConvId)?.isStreaming : false;
     if (targetIsStreaming) return;
 
@@ -4370,7 +4399,7 @@ export function ChatView({
       let resumeAttempts = 0;
       const MAX_RESUME_ATTEMPTS = 3;
       const tryAttachLiveResume = async () => {
-        if (!thisConvId || orgCommandPendingRef.current) return null;
+        if (!thisConvId || getActiveOrgCommand(activeOrgCommandsRef.current, thisConvId)) return null;
         if (abort.signal.aborted || sctx.userStopped || gracefulDone) return null;
         if (resumeAttempts >= MAX_RESUME_ATTEMPTS) return null;
         resumeAttempts++;
@@ -4487,9 +4516,7 @@ export function ChatView({
                 const orgId = (event as any).org_id as string | undefined;
                 const commandId = (event as any).command_id as string | undefined;
                 if (orgId && commandId) {
-                  activeOrgCommandRef.current = { orgId, commandId };
-                  orgCommandPendingRef.current = true;
-                  setOrgCommandPending(true);
+                  updateActiveOrgCommand(thisConvId, { orgId, commandId });
                 }
                 currentStreamStatus = t("chat.orgProcessing", "组织正在处理中...");
                 // 把"命令已下发"写进 timeline 而不是 currentContent，
@@ -4524,9 +4551,8 @@ export function ChatView({
                 break;
               }
               case "org_command_done": {
-                activeOrgCommandRef.current = null;
-                orgCommandPendingRef.current = false;
-                setOrgCommandPending(false);
+                const commandId = (event as any).command_id as string | undefined;
+                updateActiveOrgCommand(thisConvId, null, commandId);
                 currentOrgTimeline = [
                   ...currentOrgTimeline,
                   {
@@ -5833,7 +5859,7 @@ export function ChatView({
         return updated;
       });
     }
-  }, [pendingAttachments, isCurrentConvStreaming, activeConvId, chatMode, selectedEndpoint, selectedEndpointPolicy, apiBase, slashCommands, endpoints.length, thinkingMode, thinkingDepth, t, setInputValue]);
+  }, [pendingAttachments, isCurrentConvStreaming, activeConvId, chatMode, selectedEndpoint, selectedEndpointPolicy, apiBase, slashCommands, endpoints.length, thinkingMode, thinkingDepth, t, setInputValue, updateActiveOrgCommand]);
 
   const startupReattachDoneRef = useRef(false);
   useEffect(() => {
@@ -6102,8 +6128,10 @@ export function ChatView({
   const closeLightbox = useCallback(() => setLightbox(null), []);
 
   const handleCancelTask = useCallback(() => {
-    if (orgCommandPendingRef.current && activeOrgCommandRef.current) {
-      const { orgId, commandId } = activeOrgCommandRef.current;
+    const conversationId = activeConvIdRef.current;
+    const command = getActiveOrgCommand(activeOrgCommandsRef.current, conversationId);
+    if (command) {
+      const { orgId, commandId } = command;
       safeFetch(`${apiBaseRef.current}/api/v2/orgs/${orgId}/commands/${commandId}/cancel`, {
         method: "POST",
       }).catch(() => {

--- a/apps/setup-center/src/views/chat/utils/__tests__/orgCommandState.test.ts
+++ b/apps/setup-center/src/views/chat/utils/__tests__/orgCommandState.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearActiveOrgCommand,
+  getActiveOrgCommand,
+  setActiveOrgCommand,
+  type ActiveOrgCommandsByConversation,
+} from "../orgCommandState";
+
+describe("organization command state", () => {
+  it("isolates pending commands by conversation", () => {
+    let commands: ActiveOrgCommandsByConversation = new Map();
+    commands = setActiveOrgCommand(commands, "conversation-a", {
+      orgId: "org-a",
+      commandId: "command-a",
+    });
+
+    expect(getActiveOrgCommand(commands, "conversation-a")).toEqual({
+      orgId: "org-a",
+      commandId: "command-a",
+    });
+    expect(getActiveOrgCommand(commands, "conversation-b")).toBeNull();
+
+    commands = setActiveOrgCommand(commands, "conversation-b", {
+      orgId: "org-b",
+      commandId: "command-b",
+    });
+    commands = clearActiveOrgCommand(commands, "conversation-a", "command-a");
+
+    expect(getActiveOrgCommand(commands, "conversation-a")).toBeNull();
+    expect(getActiveOrgCommand(commands, "conversation-b")).toEqual({
+      orgId: "org-b",
+      commandId: "command-b",
+    });
+  });
+
+  it("does not let a stale terminal event clear a newer command", () => {
+    let commands: ActiveOrgCommandsByConversation = setActiveOrgCommand(
+      new Map(),
+      "conversation-a",
+      { orgId: "org-a", commandId: "command-new" },
+    );
+
+    const unchanged = clearActiveOrgCommand(commands, "conversation-a", "command-old");
+
+    expect(unchanged).toBe(commands);
+    expect(getActiveOrgCommand(unchanged, "conversation-a")?.commandId).toBe("command-new");
+
+    commands = clearActiveOrgCommand(commands, "conversation-a", "command-new");
+    expect(getActiveOrgCommand(commands, "conversation-a")).toBeNull();
+  });
+});

--- a/apps/setup-center/src/views/chat/utils/orgCommandState.ts
+++ b/apps/setup-center/src/views/chat/utils/orgCommandState.ts
@@ -1,0 +1,38 @@
+export interface ActiveOrgCommand {
+  orgId: string;
+  commandId: string;
+}
+
+export type ActiveOrgCommandsByConversation = ReadonlyMap<string, ActiveOrgCommand>;
+
+export function getActiveOrgCommand(
+  commands: ActiveOrgCommandsByConversation,
+  conversationId: string | null | undefined,
+): ActiveOrgCommand | null {
+  if (!conversationId) return null;
+  return commands.get(conversationId) ?? null;
+}
+
+export function setActiveOrgCommand(
+  commands: ActiveOrgCommandsByConversation,
+  conversationId: string,
+  command: ActiveOrgCommand,
+): ActiveOrgCommandsByConversation {
+  const next = new Map(commands);
+  next.set(conversationId, command);
+  return next;
+}
+
+export function clearActiveOrgCommand(
+  commands: ActiveOrgCommandsByConversation,
+  conversationId: string,
+  expectedCommandId?: string,
+): ActiveOrgCommandsByConversation {
+  const current = commands.get(conversationId);
+  if (!current || (expectedCommandId && current.commandId !== expectedCommandId)) {
+    return commands;
+  }
+  const next = new Map(commands);
+  next.delete(conversationId);
+  return next;
+}

--- a/docs/adr/0004-dual-ledger-supervisor.md
+++ b/docs/adr/0004-dual-ledger-supervisor.md
@@ -73,7 +73,8 @@ Five required fields, each with both `answer` and `reason`:
 }
 ```
 
-Parsing is strict; `runtime/ledger.py` retries up to 10 times on bad JSON
+Parsing is strict; the supervisor makes one initial attempt plus at most two
+retries on bad JSON
 before falling through to a single hard error. We use the model's
 `structured_output=True` mode when the provider supports it.
 

--- a/src/openakita/orgs/command_service.py
+++ b/src/openakita/orgs/command_service.py
@@ -178,12 +178,15 @@ def delivery_language_directive(text: str) -> str:
 def _project_manifest_file_attachments(
     delivery_manifest: dict[str, Any] | None,
     artifact_records: tuple[Any, ...],
+    *,
+    root_artifact_path: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
     """Hydrate declared deliverables with their runtime-registered local files.
 
     Nodes commonly submit only ``asset_ids`` / ``task_ids`` in the final
     manifest. The artifact ledger is the authoritative mapping from those IDs
-    to downloaded files, so terminal consumers should not need to repeat that
+    to downloaded files, while ``root_artifact_path`` is the runtime-designated
+    final root report. Terminal consumers should not need to repeat either
     lookup independently.
     """
     if delivery_manifest is None:
@@ -193,6 +196,46 @@ def _project_manifest_file_attachments(
     raw_artifacts = delivery_manifest.get("artifacts")
     if not isinstance(raw_artifacts, list):
         return projected, []
+
+    working_artifacts = list(raw_artifacts)
+    root_target_index: int | None = None
+    root_artifact_path = str(root_artifact_path or "").strip() or None
+    if root_artifact_path is not None:
+        root_key = root_artifact_path.lower().replace("\\", "/")
+        preferred_kinds = ("text", "document")
+        for index, raw_artifact in enumerate(working_artifacts):
+            if not isinstance(raw_artifact, dict):
+                continue
+            declared_paths = raw_artifact.get("paths")
+            if isinstance(declared_paths, list) and any(
+                str(path).strip().lower().replace("\\", "/") == root_key
+                for path in declared_paths
+            ):
+                root_target_index = index
+                break
+        if root_target_index is None:
+            for preferred_kind in preferred_kinds:
+                for index in range(len(working_artifacts) - 1, -1, -1):
+                    raw_artifact = working_artifacts[index]
+                    if not isinstance(raw_artifact, dict):
+                        continue
+                    kind = str(raw_artifact.get("kind") or "").strip().lower()
+                    status = str(raw_artifact.get("status") or "ready").strip().lower()
+                    if kind == preferred_kind and status == "ready":
+                        root_target_index = index
+                        break
+                if root_target_index is not None:
+                    break
+        if root_target_index is None:
+            working_artifacts.append(
+                {
+                    "kind": "text",
+                    "status": "ready",
+                    "name": Path(root_artifact_path).name,
+                    "paths": [],
+                }
+            )
+            root_target_index = len(working_artifacts) - 1
 
     attachments: list[dict[str, Any]] = []
     seen_paths: set[str] = set()
@@ -204,7 +247,7 @@ def _project_manifest_file_attachments(
             return []
         return [str(value).strip() for value in values if str(value).strip()]
 
-    for raw_artifact in raw_artifacts:
+    for index, raw_artifact in enumerate(working_artifacts):
         if not isinstance(raw_artifact, dict):
             projected_artifacts.append(raw_artifact)
             continue
@@ -214,6 +257,8 @@ def _project_manifest_file_attachments(
         asset_ids = set(string_values(artifact.get("asset_ids")))
         task_ids = set(string_values(artifact.get("task_ids")))
         paths = string_values(artifact.get("paths"))
+        if index == root_target_index and root_artifact_path is not None:
+            paths.append(root_artifact_path)
 
         for record in artifact_records:
             record_kinds = {str(value).strip().lower() for value in record.asset_kinds}
@@ -2888,6 +2933,25 @@ class OrgCommandService:
             return None
         return body[:12000] if body else None
 
+    def _root_final_artifact_path(self, command_id: str, root_node_id: str) -> str | None:
+        """Return the existing final artifact recorded for this command's root."""
+        store = getattr(self._runtime, "_root_final_artifact", None)
+        if not isinstance(store, dict):
+            return None
+        record = store.get(command_id)
+        if not isinstance(record, (list, tuple)) or len(record) != 2:
+            return None
+        node_id, raw_path = record
+        if str(node_id) != root_node_id:
+            return None
+        file_path = str(raw_path or "").strip()
+        if not file_path:
+            return None
+        try:
+            return file_path if Path(file_path).is_file() else None
+        except OSError:
+            return None
+
     def _degraded_reason(self, command_id: str, outcome_value: str | None) -> str:
         """Human/machine reason a delivered command hit a limit (test16).
 
@@ -2933,6 +2997,9 @@ class OrgCommandService:
         delivery_manifest = getattr(outcome, "delivery_manifest", None)
         if not isinstance(delivery_manifest, dict):
             delivery_manifest = None
+        command = self._commands.get(command_id, {})
+        org_id = str(command.get("org_id") or "")
+        root_node_id = str(command.get("root_node_id") or "")
         artifact_records: tuple[Any, ...] = ()
         manifest_media_failures: list[dict[str, Any]] = []
         if delivery_manifest is not None:
@@ -2943,9 +3010,6 @@ class OrgCommandService:
                 validate_manifest_media_delivery,
             )
 
-            command = self._commands.get(command_id, {})
-            org_id = str(command.get("org_id") or "")
-            root_node_id = str(command.get("root_node_id") or "")
             artifact_records = artifact_ledger.get(org_id, command_id)
             try:
                 reflected_manifest = DeliveryManifest.from_mapping(
@@ -2969,9 +3033,18 @@ class OrgCommandService:
                     }
                 ]
 
+        root_artifact_path = None
+        if (
+            delivery_manifest is not None
+            and delivery_manifest.get("state") == "complete"
+            and delivery_manifest.get("final") is True
+        ):
+            root_artifact_path = self._root_final_artifact_path(command_id, root_node_id)
+
         delivery_manifest, file_attachments = _project_manifest_file_attachments(
             delivery_manifest,
             artifact_records,
+            root_artifact_path=root_artifact_path,
         )
 
         # test16 semantic root-cause: OUT_OF_TURNS / REPLAN_BUDGET_EXHAUSTED /
@@ -3021,7 +3094,18 @@ class OrgCommandService:
         elif outcome_value == FinalOutcome.CANCELLED.value:
             status, phase, error = "cancelled", "cancelled", None
         elif outcome_value in _limit_exits:
-            degraded_reason = self._degraded_reason(command_id, outcome_value)
+            # A normal FAILED outcome can now describe a structural supervisor
+            # endpoint error (auth, model missing, incompatible protocol). It
+            # is not a budget degradation. Only actual budget verdicts or a
+            # watchdog-stamped FAILED outcome receive ``degraded_reason``.
+            cancelled_by = (self._command_outcomes.get(command_id) or {}).get(
+                "cancelled_by"
+            )
+            if outcome_value != FinalOutcome.FAILED.value or cancelled_by in {
+                "hard_ceiling",
+                "soft_ceiling",
+            }:
+                degraded_reason = self._degraded_reason(command_id, outcome_value)
             if root_final_present:
                 # 交付完整 + 撞上限 -> completed, with a timeout note.
                 status, phase, error = "done", "partial", None

--- a/src/openakita/runtime/llm_supervisor_brain.py
+++ b/src/openakita/runtime/llm_supervisor_brain.py
@@ -40,7 +40,7 @@ Dry-run simplifications (intentional, RC-5 Phase B)
   directory is supplied we normalise a role-style answer to a concrete
   ``node_id`` via :meth:`LLMSupervisorBrain.resolve_next_speaker`; on any
   ambiguity we leave the model's answer untouched and let the Supervisor's
-  existing 10x JSON-retry path own correctness. A complete role/address
+  bounded JSON-retry path own correctness. A complete role/address
   resolver is the next-phase gap (#2).
 * The three orchestrator prompts are adapted from AutoGen Magentic-One
   ``_prompts.py`` (see ``_rc5_biz/prototype/prompts/``) but otherwise kept
@@ -491,7 +491,7 @@ class LLMSupervisorBrain(SupervisorBrain):
         """Best-effort rewrite of ``next_speaker`` from role -> node_id.
 
         Never raises: any parse / shape issue returns ``raw`` unchanged so
-        the Supervisor's own strict parser + 10x retry path stays the single
+        the Supervisor's own strict parser + bounded retry path stays the single
         source of correctness. Only a clean JSON object whose
         ``next_speaker.answer`` resolves to a different concrete node id is
         rewritten in place.

--- a/src/openakita/runtime/llm_supervisor_client.py
+++ b/src/openakita/runtime/llm_supervisor_client.py
@@ -23,10 +23,9 @@ Design notes
   §3). We lock onto the dedicated no-thinking endpoint
   (``settings.orgs_supervisor_llm_endpoint``) via a **per-conversation**
   override so the process-wide default model is never clobbered, and pass
-  ``enable_thinking=False`` as defence-in-depth. If the endpoint is absent on
-  this deployment (the endpoint config is git-ignored runtime state), we log
-  once and fall back to default routing with ``enable_thinking=False`` --
-  never crashing the submit path.
+  ``enable_thinking=False`` as defence-in-depth. If a configured endpoint is
+  absent, the adapter raises a structural configuration error instead of
+  silently routing the supervisor prompt to an incompatible default model.
 * **Cancel bridge (RC-4).** ``cancel_event`` is forwarded straight into
   ``LLMClient.chat`` so a user "stop" aborts the in-flight ``httpx`` request
   immediately (validated by the Q2 cancel probe).
@@ -35,11 +34,10 @@ Design notes
 from __future__ import annotations
 
 import asyncio
-import logging
 import uuid
 from typing import TYPE_CHECKING
 
-from openakita.llm.types import Message
+from openakita.llm.types import ConfigurationError, Message
 
 if TYPE_CHECKING:  # pragma: no cover -- import-cycle / type-only
     from openakita.llm.client import LLMClient
@@ -48,8 +46,6 @@ __all__ = [
     "DEFAULT_SUPERVISOR_LLM_ENDPOINT",
     "GatewaySupervisorLLMClient",
 ]
-
-logger = logging.getLogger(__name__)
 
 #: The no-thinking endpoint the orchestration brain prefers. Matches the
 #: endpoint provisioned in RC-5 sprint S1 (``_endpoint_config_change.md``).
@@ -85,18 +81,23 @@ class GatewaySupervisorLLMClient:
         self._max_tokens = max_tokens
         self._conversation_id = conversation_id or f"orgsup-{uuid.uuid4().hex[:12]}"
         self._endpoint_locked = False
+        self._endpoint_lock_error: str | None = None
 
     def _ensure_endpoint_lock(self) -> None:
-        """Best-effort one-time lock onto the no-thinking endpoint.
+        """Require a one-time lock onto the configured no-thinking endpoint.
 
         Uses a per-conversation override (``conversation_id``) so flipping the
         orchestration model never affects the global default client used by
-        chat / agents. Failures (endpoint missing, switch refused) are logged
-        once and swallowed -- the call then proceeds on default routing.
+        chat / agents. A configured endpoint is required: lock failures are
+        cached and raised so the supervisor terminates with a precise error
+        instead of trying another model with an incompatible output format.
         """
-        if self._endpoint_locked or not self._endpoint:
+        if not self._endpoint:
             return
-        self._endpoint_locked = True  # mark first so we only try once
+        if self._endpoint_lock_error is not None:
+            raise ConfigurationError(self._endpoint_lock_error)
+        if self._endpoint_locked:
+            return
         try:
             ok, msg = self._client.switch_model(
                 self._endpoint,
@@ -105,20 +106,18 @@ class GatewaySupervisorLLMClient:
                 reason="rc5 org orchestration brain (no-thinking)",
             )
             if not ok:
-                logger.warning(
-                    "GatewaySupervisorLLMClient: could not lock endpoint %r "
-                    "(%s); falling back to default routing with "
-                    "enable_thinking=False",
-                    self._endpoint,
-                    msg,
+                self._endpoint_lock_error = (
+                    f"指定的 Supervisor 端点 {self._endpoint!r} 不可用：{msg}"
                 )
-        except Exception:  # noqa: BLE001 -- endpoint lock must never crash submit
-            logger.warning(
-                "GatewaySupervisorLLMClient: switch_model(%r) raised; "
-                "falling back to default routing",
-                self._endpoint,
-                exc_info=True,
+                raise ConfigurationError(self._endpoint_lock_error)
+        except ConfigurationError:
+            raise
+        except Exception as exc:  # noqa: BLE001 -- convert to a structural failure
+            self._endpoint_lock_error = (
+                f"指定的 Supervisor 端点 {self._endpoint!r} 无法锁定：{exc}"
             )
+            raise ConfigurationError(self._endpoint_lock_error) from exc
+        self._endpoint_locked = True
 
     async def complete(
         self,

--- a/src/openakita/runtime/supervisor.py
+++ b/src/openakita/runtime/supervisor.py
@@ -57,6 +57,104 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+def _format_supervisor_llm_failure(exc: Exception) -> str | None:
+    """Return a user-facing reason for an LLM endpoint failure.
+
+    The supervisor must distinguish transport/model failures from malformed
+    progress-ledger output.  Only the latter belongs to the JSON retry loop;
+    endpoint, authentication, and protocol failures terminate the command
+    immediately with an actionable reason.
+    """
+
+    # Imported lazily because ``runtime.supervisor`` is loaded early by the
+    # agent package and a top-level LLM import would widen an existing cycle.
+    from ..llm.types import (
+        AllEndpointsFailedError,
+        AuthenticationError,
+        ConfigurationError,
+        LLMError,
+        UnsupportedMediaError,
+    )
+
+    chain: list[BaseException] = []
+    current: BaseException | None = exc
+    while current is not None and current not in chain:
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+
+    llm_errors = [item for item in chain if isinstance(item, LLMError)]
+    if not llm_errors:
+        return None
+
+    categories: set[str] = set()
+    structural = False
+    status_code: int | None = None
+    for item in llm_errors:
+        if status_code is None:
+            raw_status = getattr(item, "status_code", None)
+            if isinstance(raw_status, int):
+                status_code = raw_status
+        if isinstance(item, AllEndpointsFailedError):
+            categories.update(str(value).lower() for value in item.error_categories)
+            structural = structural or item.is_structural
+
+    detail = str(exc).strip() or type(exc).__name__
+    detail = " ".join(detail.split())[:1200]
+    lowered = detail.lower()
+    http_suffix = f"（HTTP {status_code}）" if status_code is not None else ""
+
+    if "content_safety" in categories or any(
+        marker in lowered
+        for marker in ("data_inspection", "content_filter", "inappropriate content")
+    ):
+        prefix = "Supervisor 编排请求被端点内容安全策略拒绝"
+    elif status_code == 404 or any(
+        marker in lowered
+        for marker in (
+            "modelnotfound",
+            "model not found",
+            "endpoint not found",
+            "目标模型不存在",
+            "端点不存在",
+        )
+    ):
+        prefix = "Supervisor 指定的编排端点或模型不可用"
+    elif (
+        any(isinstance(item, AuthenticationError) for item in llm_errors)
+        or "auth" in categories
+        or status_code in {401, 403}
+    ):
+        prefix = "Supervisor 编排端点认证失败，请检查 API Key 和模型权限"
+    elif any(isinstance(item, ConfigurationError) for item in llm_errors):
+        prefix = "Supervisor 编排端点配置不可用"
+    elif (
+        any(isinstance(item, UnsupportedMediaError) for item in llm_errors)
+        or structural
+        or "structural" in categories
+        or status_code in {400, 405, 410, 413, 415, 422}
+        or any(
+            marker in lowered
+            for marker in (
+                "does not support",
+                "not supported",
+                "unsupported",
+                "invalid_request",
+                "invalid parameter",
+                "invalid_parameter",
+                "协议不兼容",
+                "不支持",
+            )
+        )
+    ):
+        prefix = "Supervisor 编排端点与请求协议不兼容"
+    elif "quota" in categories:
+        prefix = "Supervisor 编排端点配额不足"
+    else:
+        prefix = "Supervisor 编排模型调用失败"
+
+    return f"{prefix}{http_suffix}：{detail}"
+
+
 # ---------------------------------------------------------------------------
 # Outcome enumeration
 # ---------------------------------------------------------------------------
@@ -225,7 +323,7 @@ class _SupervisorConfig:
     max_stalls: int = 3
     max_turns: int = 30
     max_replans: int = 5
-    progress_ledger_max_retries: int = 10
+    progress_ledger_max_retries: int = 2
     progress_ledger_timeout_s: float = 60.0
 
 
@@ -264,7 +362,7 @@ class Supervisor:
         max_stalls: int = 3,
         max_turns: int = 30,
         max_replans: int = 5,
-        progress_ledger_max_retries: int = 10,
+        progress_ledger_max_retries: int = 2,
         progress_ledger_timeout_s: float = 60.0,
         wall_clock_soft_budget_s: float = 0.0,
         deliver_includes_recent_outputs: bool = True,
@@ -330,7 +428,7 @@ class Supervisor:
             max_stalls=max_stalls,
             max_turns=max_turns,
             max_replans=max_replans,
-            progress_ledger_max_retries=progress_ledger_max_retries,
+            progress_ledger_max_retries=max(0, int(progress_ledger_max_retries)),
             progress_ledger_timeout_s=max(0.01, float(progress_ledger_timeout_s)),
         )
         self.stall_detector = StallDetector(max_stalls=max_stalls, max_turns=max_turns)
@@ -453,6 +551,27 @@ class Supervisor:
             # checkpoint so the command stays resumable instead of crashing
             # with an uncaught exception.
             return await self._terminate(FinalOutcome.CANCELLED, exc.reason or "cancelled")
+        except ProgressLedgerParseError as exc:
+            reason = (
+                "Supervisor 输出格式错误，"
+                f"重试 {self.cfg.progress_ledger_max_retries} 次后仍无法解析：{exc}"
+            )
+            logger.warning(
+                "Supervisor progress ledger parsing exhausted for command=%s: %s",
+                self.command_id,
+                exc,
+            )
+            return await self._terminate(FinalOutcome.FAILED, reason)
+        except Exception as exc:
+            reason = _format_supervisor_llm_failure(exc)
+            if reason is None:
+                raise
+            logger.warning(
+                "Supervisor LLM endpoint failed for command=%s: %s",
+                self.command_id,
+                exc,
+            )
+            return await self._terminate(FinalOutcome.FAILED, reason)
         except asyncio.CancelledError:
             # v23 RC-4 fix: the d1275851 ``cancel_event`` bridge only
             # reaches ``SupervisorBrain`` (production
@@ -1237,7 +1356,11 @@ class Supervisor:
                     turn_id=self.stall_detector.n_turns + 1,
                 )
         last_error: ProgressLedgerParseError | None = None
-        for attempt in range(self.cfg.progress_ledger_max_retries):
+        # ``progress_ledger_max_retries`` means retries *after* the initial
+        # attempt.  The default of 2 therefore permits at most three LLM calls,
+        # replacing the historical ten-call parse storm.
+        attempts = self.cfg.progress_ledger_max_retries + 1
+        for attempt in range(attempts):
             self.cancel_token.raise_if_cancelled()
             started = time.monotonic()
             await self.stream.emit(
@@ -1329,7 +1452,8 @@ class Supervisor:
         # Out of retries — promote to a hard supervisor failure.
         raise ProgressLedgerParseError(
             f"progress ledger could not be parsed after "
-            f"{self.cfg.progress_ledger_max_retries} attempts: {last_error}"
+            f"{attempts} attempts ({self.cfg.progress_ledger_max_retries} retries): "
+            f"{last_error}"
         )
 
     def _progress_timeout_fallback(self, elapsed_s: float) -> ProgressLedger:

--- a/src/openakita/runtime/supervisor_factory.py
+++ b/src/openakita/runtime/supervisor_factory.py
@@ -359,7 +359,7 @@ def build_supervisor_for_command(
     max_stalls: int = 3,
     max_turns: int = 30,
     max_replans: int = 5,
-    progress_ledger_max_retries: int = 10,
+    progress_ledger_max_retries: int = 2,
     progress_ledger_timeout_s: float = 60.0,
     wall_clock_soft_budget_s: float = 0.0,
     force_root_finalization: bool = False,

--- a/tests/runtime/orgs/test_supervisor_hard_ceiling.py
+++ b/tests/runtime/orgs/test_supervisor_hard_ceiling.py
@@ -337,6 +337,62 @@ async def test_disk_report_without_manifest_at_ceiling_stays_error(monkeypatch) 
     cmd = svc._commands[cid]
     assert cmd["status"] == "error"
     assert cmd["result"]["partial"] is False
+    assert cmd["result"]["delivery_manifest"] is None
+    assert "file_attachments" not in cmd["result"]
+
+
+def test_reflect_projects_root_final_artifact_into_delivery_result(tmp_path) -> None:
+    from openakita.runtime.supervisor import FinalOutcome, SupervisorOutcome
+
+    svc = _make_service(supervisor=_SleepForeverSupervisor())
+    cid = "cmd_root_final_projection"
+    _seed_running_command(svc, cid)
+    final_file = tmp_path / "final.md"
+    final_file.write_text("# Final report\n\nComplete result.", encoding="utf-8")
+    svc._runtime._root_final_artifact = {cid: ("root1", str(final_file))}
+    outcome = SupervisorOutcome(
+        outcome=FinalOutcome.DONE,
+        final_message="Final report",
+        final_checkpoint_id="cp",
+        n_turns=2,
+        n_replans=0,
+        reason="",
+        deliverable="Final report",
+        delivery_manifest={
+            "state": "complete",
+            "final": True,
+            "artifacts": [
+                {
+                    "kind": "document",
+                    "status": "ready",
+                    "name": "Supporting document",
+                    "paths": [],
+                },
+                {
+                    "kind": "text",
+                    "status": "ready",
+                    "name": "Final report",
+                    "paths": [],
+                },
+            ],
+        },
+    )
+
+    svc._reflect_supervisor_outcome(cid, _SleepForeverSupervisor(), outcome)
+
+    result = svc._commands[cid]["result"]
+    assert svc._commands[cid]["status"] == "done"
+    assert result["delivery_manifest"]["artifacts"][0]["paths"] == []
+    assert result["delivery_manifest"]["artifacts"][1]["paths"] == [str(final_file)]
+    assert result["file_attachments"] == [
+        {
+            "filename": "final.md",
+            "file_path": str(final_file),
+            "file_size": final_file.stat().st_size,
+            "kind": "text",
+            "name": "Final report",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/orgs/test_supervisor_http_takeover.py
+++ b/tests/runtime/orgs/test_supervisor_http_takeover.py
@@ -353,3 +353,43 @@ async def test_cancel_all_for_org_cancels_every_supervisor() -> None:
         terminal = await asyncio.wait_for(queues[cid].get(), timeout=0.5)
         assert terminal["type"] == "org_command_done"
         assert terminal["error"] == "组织已停止，当前任务已取消。"
+
+
+@pytest.mark.asyncio
+async def test_failed_supervisor_reason_is_published_to_user() -> None:
+    failure_reason = (
+        "Supervisor 指定的编排端点或模型不可用（HTTP 404）：target model not found"
+    )
+
+    class _ExplicitFailureSupervisor(_FakeSupervisor):
+        async def run(self) -> SupervisorOutcome:
+            return SupervisorOutcome(
+                outcome=FinalOutcome.FAILED,
+                final_message=failure_reason,
+                final_checkpoint_id=self.last_checkpoint_id,
+                n_turns=0,
+                n_replans=0,
+                reason=failure_reason,
+            )
+
+    svc, _used = _make_service(supervisors=[_ExplicitFailureSupervisor()])
+    submitted = await svc.submit(OrgCommandRequest(org_id="o1", content="run"))
+    command_id = submitted["command_id"]
+    summary = svc.subscribe_summary(
+        command_id,
+        surface="desktop_chat",
+        target="chat-endpoint-failure",
+    )
+    task = svc._inflight_tasks.get(command_id)
+    assert task is not None
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    status = svc.get_status("o1", command_id)
+    assert status is not None
+    assert status["status"] == "error"
+    assert status["error"] == failure_reason
+    assert "degraded_reason" not in status["result"]
+    terminal = await asyncio.wait_for(summary.get(), timeout=0.5)
+    assert terminal["type"] == "org_command_done"
+    assert terminal["error"] == failure_reason

--- a/tests/runtime/test_llm_supervisor_client.py
+++ b/tests/runtime/test_llm_supervisor_client.py
@@ -1,0 +1,62 @@
+"""Tests for the gateway-backed supervisor LLM endpoint lock."""
+
+from __future__ import annotations
+
+import pytest
+
+from openakita.llm.types import ConfigurationError
+from openakita.runtime.llm_supervisor_client import GatewaySupervisorLLMClient
+
+
+class _MissingEndpointGateway:
+    def __init__(self) -> None:
+        self.switch_calls: list[dict[str, object]] = []
+        self.chat_calls = 0
+
+    def switch_model(
+        self,
+        endpoint_name: str,
+        *,
+        conversation_id: str | None = None,
+        policy: str = "prefer",
+        reason: str = "",
+    ) -> tuple[bool, str]:
+        self.switch_calls.append(
+            {
+                "endpoint_name": endpoint_name,
+                "conversation_id": conversation_id,
+                "policy": policy,
+                "reason": reason,
+            }
+        )
+        return False, f"endpoint {endpoint_name!r} does not exist"
+
+    async def chat(self, **_kwargs):
+        self.chat_calls += 1
+        raise AssertionError("default routing must not run")
+
+
+async def test_missing_required_supervisor_endpoint_does_not_use_default_model() -> None:
+    gateway = _MissingEndpointGateway()
+    client = GatewaySupervisorLLMClient(
+        gateway,  # type: ignore[arg-type]
+        endpoint="supervisor-json-model",
+        conversation_id="orgsup-test",
+    )
+
+    with pytest.raises(ConfigurationError, match="Supervisor 端点.*不可用"):
+        await client.complete(
+            role="progress_ledger",
+            system="system",
+            user="user",
+        )
+
+    assert gateway.chat_calls == 0
+    assert gateway.switch_calls == [
+        {
+            "endpoint_name": "supervisor-json-model",
+            "conversation_id": "orgsup-test",
+            "policy": "require",
+            "reason": "rc5 org orchestration brain (no-thinking)",
+        }
+    ]

--- a/tests/runtime/test_supervisor.py
+++ b/tests/runtime/test_supervisor.py
@@ -19,6 +19,7 @@ from collections.abc import Awaitable, Callable
 import pytest
 
 from openakita.agent.errors import UserCancelledError
+from openakita.llm.types import AllEndpointsFailedError, AuthenticationError, LLMError
 from openakita.runtime.cancel_token import CancellationToken
 from openakita.runtime.checkpoint import CheckpointStatus, MemoryCheckpointer
 from openakita.runtime.ledger import ProgressLedger
@@ -330,6 +331,94 @@ async def test_supervisor_retries_bad_progress_json() -> None:
     assert out.outcome is FinalOutcome.DONE
     # Brain emitted progress 3 times (2 bad + 1 good).
     assert brain.progress_calls == 3
+
+
+async def test_supervisor_fails_after_two_bad_progress_json_retries() -> None:
+    bus = StreamBus(strict=True)
+    store = MemoryCheckpointer()
+    brain = FakeBrain(
+        progress_responses=[
+            "bad initial response",
+            "bad retry one",
+            "bad retry two",
+            _ledger_json(satisfied=True),
+        ]
+    )
+    deliver, _ = _make_deliver()
+
+    sup = Supervisor(
+        command_id="cmd_bad_json",
+        org_id="org_1",
+        root_node_id="node_root",
+        task="t",
+        brain=brain,
+        deliver=deliver,
+        stream=bus,
+        checkpointer=store,
+    )
+
+    out = await sup.run()
+
+    assert out.outcome is FinalOutcome.FAILED
+    assert brain.progress_calls == 3
+    assert "Supervisor 输出格式错误" in out.final_message
+    assert "重试 2 次" in out.final_message
+    checkpoint = await store.aget(out.final_checkpoint_id)  # type: ignore[arg-type]
+    assert checkpoint is not None
+    assert checkpoint.metadata.status is CheckpointStatus.FAILED
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_message"),
+    [
+        (
+            AuthenticationError("invalid API key", status_code=401),
+            "Supervisor 编排端点认证失败",
+        ),
+        (
+            LLMError("target model not found", status_code=404),
+            "Supervisor 指定的编排端点或模型不可用",
+        ),
+        (
+            AllEndpointsFailedError(
+                "required endpoint does not support this request protocol",
+                is_structural=True,
+                error_categories={"structural"},
+            ),
+            "Supervisor 编排端点与请求协议不兼容",
+        ),
+    ],
+)
+async def test_supervisor_short_circuits_structural_llm_failures(
+    failure: Exception,
+    expected_message: str,
+) -> None:
+    class StructuralFailureBrain(FakeBrain):
+        async def emit_progress_ledger(self, **_kwargs) -> str:
+            self.progress_calls += 1
+            raise failure
+
+    bus = StreamBus(strict=True)
+    store = MemoryCheckpointer()
+    brain = StructuralFailureBrain()
+    deliver, _ = _make_deliver()
+    sup = Supervisor(
+        command_id="cmd_structural_failure",
+        org_id="org_1",
+        root_node_id="node_root",
+        task="t",
+        brain=brain,
+        deliver=deliver,
+        stream=bus,
+        checkpointer=store,
+    )
+
+    out = await sup.run()
+
+    assert out.outcome is FinalOutcome.FAILED
+    assert brain.progress_calls == 1
+    assert expected_message in out.final_message
+    assert str(failure) in out.final_message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Scope organization command pending state, active command IDs, and cancellation targets by `conversationId` so concurrent conversations no longer block or cancel each other.
- Retry malformed supervisor output at most twice, short-circuit structural endpoint failures, and expose actionable errors instead of a generic failure.
- Project the root node's final artifact path into the delivery manifest and `file_attachments` so clients can download the actual result.

## Tests

- `uv run --no-sync pytest tests/runtime/orgs -q` (543 passed)
- `uv run --no-sync pytest tests/runtime/orgs/test_supervisor_http_takeover.py tests/runtime/orgs/test_command_project_progress.py tests/runtime/orgs/test_delivery_manifest.py tests/runtime/test_supervisor.py tests/runtime/test_llm_supervisor_client.py -q` (34 passed)
- `npm run test:run -- src/views/chat/utils/__tests__/orgCommandState.test.ts` (2 passed)

Fixes #822