### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/apps/setup-center/src/providers.ts
+++ b/apps/setup-center/src/providers.ts
@@ -88,6 +88,12 @@ export function isOpenRouterProvider(providerSlug: string | null, baseUrl: strin
   return slug === "openrouter" || base.includes("openrouter.ai");
 }
 
+export function isOrcaRouterProvider(providerSlug: string | null, baseUrl: string): boolean {
+  const slug = (providerSlug || "").toLowerCase();
+  const base = (baseUrl || "").toLowerCase();
+  return slug === "orcarouter" || base.includes("orcarouter.ai");
+}
+
 function openRouterRouterModels(): ListedModel[] {
   return [
     {
@@ -99,6 +105,21 @@ function openRouterRouterModels(): ListedModel[] {
       id: "openrouter/free",
       name: "OpenRouter Free Models Router",
       capabilities: { ...inferCapabilities("openrouter/free", "openrouter"), tools: true },
+    },
+  ];
+}
+
+function orcaRouterRouterModels(): ListedModel[] {
+  return [
+    {
+      id: "orcarouter/auto",
+      name: "OrcaRouter Auto Router",
+      capabilities: { ...inferCapabilities("orcarouter/auto", "orcarouter"), tools: true },
+    },
+    {
+      id: "orcarouter/free",
+      name: "OrcaRouter Free Models Router",
+      capabilities: { ...inferCapabilities("orcarouter/free", "orcarouter"), tools: true },
     },
   ];
 }
@@ -304,7 +325,11 @@ export async function fetchModelsDirectly(params: {
     throw new Error(`API ${resp.status}: ${resp.body.slice(0, 200)}`);
   }
   const data = JSON.parse(resp.body);
-  const routerModels = isOpenRouterProvider(providerSlug, baseUrl) ? openRouterRouterModels() : [];
+  const routerModels = isOpenRouterProvider(providerSlug, baseUrl)
+    ? openRouterRouterModels()
+    : isOrcaRouterProvider(providerSlug, baseUrl)
+      ? orcaRouterRouterModels()
+      : [];
   const seen = new Set(routerModels.map((m) => m.id));
   const apiModels = (data.data ?? [])
     .map((m: any) => ({

--- a/data/llm_endpoints.json.example
+++ b/data/llm_endpoints.json.example
@@ -2,7 +2,7 @@
   "_doc": "OpenAkita LLM 端点配置文件 - 复制为 llm_endpoints.json 后使用",
   "_doc_fields": {
     "name": "端点名称（唯一标识）",
-    "provider": "供应商标识：anthropic / openai / dashscope / dashscope-intl / kimi-cn / kimi-int / minimax-cn / minimax-int / deepseek / openrouter / siliconflow / siliconflow-intl / volcengine / zhipu-cn / zhipu-int 等",
+    "provider": "供应商标识：anthropic / openai / dashscope / dashscope-intl / kimi-cn / kimi-int / minimax-cn / minimax-int / deepseek / openrouter / orcarouter / siliconflow / siliconflow-intl / volcengine / zhipu-cn / zhipu-int 等",
     "api_type": "API 协议类型：anthropic 或 openai（OpenAI 兼容格式）",
     "base_url": "API 基地址",
     "api_key_env": "API Key 对应的环境变量名（在 .env 中配置实际值）",

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -51,6 +51,9 @@ DEEPSEEK_API_KEY=
 # OpenRouter（聚合多家模型）
 # 申请地址: https://openrouter.ai/
 OPENROUTER_API_KEY=
+# OrcaRouter（聚合多家模型）
+# 申请地址: https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
 
 # SiliconFlow（开源模型）
 # 申请地址: https://siliconflow.cn/

--- a/src/openakita/llm/capabilities.py
+++ b/src/openakita/llm/capabilities.py
@@ -756,6 +756,9 @@ MODEL_CAPABILITIES = {
     "openrouter": {
         # OpenRouter 会从 API 返回能力信息，此处为备用
     },
+    "orcarouter": {
+        # OrcaRouter 会从 API 返回 input_modalities，此处为备用
+    },
     "siliconflow": {
         # 硅基流动 - 主要提供开源模型
         # 天然思考模型（始终思考，不支持 enable_thinking 切换）
@@ -983,6 +986,7 @@ URL_TO_PROVIDER = {
     "api.z.ai": "zhipu",
     "generativelanguage.googleapis.com": "google",
     "openrouter.ai": "openrouter",
+    "api.orcarouter.ai": "orcarouter",
     "api.siliconflow.cn": "siliconflow",
     "api.siliconflow.com": "siliconflow",
     "yunwu.ai": "yunwu",

--- a/src/openakita/llm/endpoint_validation.py
+++ b/src/openakita/llm/endpoint_validation.py
@@ -56,6 +56,8 @@ def missing_api_key_message(endpoint: dict[str, Any]) -> str:
         if model in {"openrouter/free", "openrouter/auto"} or model.endswith(":free"):
             return "OpenRouter 免费/自动路由也需要 API Key，请在端点配置中填写 OPENROUTER_API_KEY。"
         return "OpenRouter 端点需要 API Key，请在端点配置中填写 OPENROUTER_API_KEY。"
+    if provider == "orcarouter" or "orcarouter.ai" in str(endpoint.get("base_url") or "").lower():
+        return "OrcaRouter 端点需要 API Key，请在端点配置中填写 ORCAROUTER_API_KEY。"
     return "远程模型端点需要 API Key；本地 Ollama/LM Studio 才可以留空。"
 
 

--- a/src/openakita/llm/pricing.py
+++ b/src/openakita/llm/pricing.py
@@ -87,6 +87,12 @@ _BUILTIN_PRICES: dict[str, dict[str, _BuiltinPrice]] = {
         "gpt-4o": _BuiltinPrice(2.5, 10.0, "USD"),
         "llama-3.1-70b": _BuiltinPrice(0.5, 0.75, "USD"),
     },
+    "orcarouter": {
+        # OrcaRouter 的 /models 会返回真实定价，此处只放常用模型兜底（按家族前缀子串匹配）
+        "gpt-4o": _BuiltinPrice(2.5, 10.0, "USD"),
+        "claude-sonnet-4.6": _BuiltinPrice(3.0, 15.0, "USD"),
+        "deepseek-v4-pro": _BuiltinPrice(0.442, 0.884, "USD"),
+    },
 }
 
 

--- a/src/openakita/llm/registries/__init__.py
+++ b/src/openakita/llm/registries/__init__.py
@@ -28,6 +28,7 @@ from .anthropic import AnthropicRegistry
 from .base import ModelInfo, ProviderInfo, ProviderRegistry
 from .dashscope import DashScopeRegistry
 from .openrouter import OpenRouterRegistry
+from .orcarouter import OrcaRouterRegistry
 from .siliconflow import SiliconFlowRegistry
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "DashScopeRegistry",
     "ModelInfo",
     "OpenRouterRegistry",
+    "OrcaRouterRegistry",
     "ProviderInfo",
     "ProviderRegistry",
     "SiliconFlowRegistry",
@@ -58,6 +60,7 @@ _CLASS_MODULE_MAP: dict[str, str] = {
     "MiniMaxInternationalRegistry": ".minimax",
     "DeepSeekRegistry": ".deepseek",
     "OpenRouterRegistry": ".openrouter",
+    "OrcaRouterRegistry": ".orcarouter",
     "SiliconFlowRegistry": ".siliconflow",
     "SiliconFlowInternationalRegistry": ".siliconflow",
     "VolcEngineRegistry": ".volcengine",

--- a/src/openakita/llm/registries/orcarouter.py
+++ b/src/openakita/llm/registries/orcarouter.py
@@ -1,0 +1,124 @@
+"""
+OrcaRouter 服务商注册表
+
+OrcaRouter 的 API 返回 input_modalities 能力信息，可直接解析。
+"""
+
+from .base import ModelInfo, ProviderInfo, ProviderRegistry, create_registry_client
+
+_ROUTER_MODELS = (
+    ModelInfo(
+        id="orcarouter/auto",
+        name="OrcaRouter Auto Router",
+        capabilities={
+            "text": True,
+            "vision": True,
+            "video": False,
+            "tools": True,
+            "thinking": False,
+        },
+    ),
+    ModelInfo(
+        id="orcarouter/free",
+        name="OrcaRouter Free Models Router",
+        capabilities={
+            "text": True,
+            "vision": True,
+            "video": False,
+            "tools": True,
+            "thinking": False,
+        },
+    ),
+)
+
+
+class OrcaRouterRegistry(ProviderRegistry):
+    """OrcaRouter 注册表"""
+
+    info = ProviderInfo(
+        name="OrcaRouter",
+        slug="orcarouter",
+        api_type="openai",
+        default_base_url="https://api.orcarouter.ai/v1",
+        api_key_env_suggestion="ORCAROUTER_API_KEY",
+        supports_model_list=True,
+        supports_capability_api=True,  # OrcaRouter 返回 input_modalities
+    )
+
+    async def list_models(self, api_key: str) -> list[ModelInfo]:
+        """获取 OrcaRouter 模型列表"""
+        try:
+            async with create_registry_client(self.info.default_base_url) as client:
+                resp = await client.get(
+                    f"{self.info.default_base_url}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+            models = list(_ROUTER_MODELS)
+            seen = {m.id for m in models}
+            for m in data.get("data", []):
+                model_id = m.get("id", "")
+                if not model_id or model_id in seen:
+                    continue
+                seen.add(model_id)
+                architecture = m.get("architecture") or {}
+                models.append(
+                    ModelInfo(
+                        id=model_id,
+                        name=m.get("name") or model_id,
+                        capabilities=self._parse_capabilities(architecture, model_id),
+                        context_window=m.get("context_length"),
+                        pricing=m.get("pricing"),
+                    )
+                )
+            return sorted(models, key=lambda x: x.name)
+
+        except Exception:
+            return list(_ROUTER_MODELS)
+
+    def _parse_capabilities(self, architecture: dict, model_id: str) -> dict:
+        """从 OrcaRouter 的架构信息解析能力"""
+        input_modalities = architecture.get("input_modalities", []) if architecture else []
+        caps = {
+            "text": True,
+            "vision": "image" in input_modalities,
+            "video": "video" in input_modalities,
+            "tools": False,
+            "thinking": False,
+            "audio": "audio" in input_modalities,
+            "pdf": "file" in input_modalities,
+        }
+
+        model_lower = model_id.lower()
+
+        # Thinking 能力：OrcaRouter API 不返回，基于模型名推断
+        thinking = any(
+            kw in model_lower
+            for kw in ["o1", "o3", "o4", "r1", "qwq", "thinking", "reasoner", "opus"]
+        )
+        caps["thinking"] = thinking
+
+        # Tools 能力：OrcaRouter API 不返回 supported_parameters，按模型名关键词推断
+        # （推理模型 o1/o3/o4/r1 等同样支持函数调用）
+        if thinking or any(
+            kw in model_lower
+            for kw in [
+                "qwen",
+                "gpt",
+                "claude",
+                "deepseek",
+                "kimi",
+                "glm",
+                "gemini",
+                "moonshot",
+                "minimax",
+                "doubao",
+                "grok",
+                "mistral",
+            ]
+        ):
+            caps["tools"] = True
+
+        return caps

--- a/src/openakita/llm/registries/providers.json
+++ b/src/openakita/llm/registries/providers.json
@@ -120,6 +120,16 @@
     "registry_class": "OpenRouterRegistry"
   },
   {
+    "name": "OrcaRouter",
+    "slug": "orcarouter",
+    "api_type": "openai",
+    "default_base_url": "https://api.orcarouter.ai/v1",
+    "api_key_env_suggestion": "ORCAROUTER_API_KEY",
+    "supports_model_list": true,
+    "supports_capability_api": true,
+    "registry_class": "OrcaRouterRegistry"
+  },
+  {
     "name": "硅基流动 SiliconFlow（中国区）",
     "slug": "siliconflow",
     "api_type": "openai",

--- a/src/openakita/setup_center/bridge.py
+++ b/src/openakita/setup_center/bridge.py
@@ -79,6 +79,11 @@ async def _list_models_openai(api_key: str, base_url: str, provider_slug: str | 
         b = (base_url or "").strip().lower()
         return slug == "openrouter" or "openrouter.ai" in b
 
+    def _is_orcarouter_provider() -> bool:
+        slug = (provider_slug or "").strip().lower()
+        b = (base_url or "").strip().lower()
+        return slug == "orcarouter" or "orcarouter.ai" in b
+
     def _openrouter_router_models() -> list[dict]:
         return [
             {
@@ -91,6 +96,22 @@ async def _list_models_openai(api_key: str, base_url: str, provider_slug: str | 
                 "id": "openrouter/free",
                 "name": "OpenRouter Free Models Router",
                 "capabilities": infer_capabilities("openrouter/free", provider_slug="openrouter")
+                | {"tools": True},
+            },
+        ]
+
+    def _orcarouter_router_models() -> list[dict]:
+        return [
+            {
+                "id": "orcarouter/auto",
+                "name": "OrcaRouter Auto Router",
+                "capabilities": infer_capabilities("orcarouter/auto", provider_slug="orcarouter")
+                | {"tools": True},
+            },
+            {
+                "id": "orcarouter/free",
+                "name": "OrcaRouter Free Models Router",
+                "capabilities": infer_capabilities("orcarouter/free", provider_slug="orcarouter")
                 | {"tools": True},
             },
         ]
@@ -290,7 +311,13 @@ async def _list_models_openai(api_key: str, base_url: str, provider_slug: str | 
                 return _minimax_fallback_models()
             raise
 
-    out: list[dict] = _openrouter_router_models() if _is_openrouter_provider() else []
+    out: list[dict] = (
+        _openrouter_router_models()
+        if _is_openrouter_provider()
+        else _orcarouter_router_models()
+        if _is_orcarouter_provider()
+        else []
+    )
     seen = {str(m.get("id") or "") for m in out}
     for m in data.get("data", []):
         mid = str(m.get("id", "")).strip()

--- a/tests/llm/unit/test_orcarouter_registry.py
+++ b/tests/llm/unit/test_orcarouter_registry.py
@@ -1,0 +1,92 @@
+"""OrcaRouter 服务商注册表单测。
+
+镜像 OpenRouter 注册表的接入方式：providers.json 声明 + _CLASS_MODULE_MAP 注册。
+"""
+
+import json
+from pathlib import Path
+
+from openakita.llm import registries
+from openakita.llm.registries import ALL_REGISTRIES, get_registry
+from openakita.llm.registries.orcarouter import OrcaRouterRegistry
+
+_REGISTRIES_JSON = Path(registries.__file__).parent / "providers.json"
+
+
+def _entry() -> dict:
+    entries = json.loads(_REGISTRIES_JSON.read_text(encoding="utf-8"))
+    return next(e for e in entries if e["slug"] == "orcarouter")
+
+
+def test_orcarouter_registered():
+    """OrcaRouter 应出现在内置服务商列表里。"""
+    slugs = {r.info.slug for r in ALL_REGISTRIES}
+    assert "orcarouter" in slugs
+
+
+def test_get_registry_returns_orcarouter():
+    reg = get_registry("orcarouter")
+    assert isinstance(reg, OrcaRouterRegistry)
+    assert reg.info.slug == "orcarouter"
+    assert reg.info.default_base_url == "https://api.orcarouter.ai/v1"
+    assert reg.info.api_key_env_suggestion == "ORCAROUTER_API_KEY"
+    assert reg.info.api_type == "openai"
+    assert reg.info.supports_capability_api is True
+
+
+def test_providers_json_entry():
+    entry = _entry()
+    assert entry["registry_class"] == "OrcaRouterRegistry"
+    assert entry["api_type"] == "openai"
+    assert entry["default_base_url"] == "https://api.orcarouter.ai/v1"
+    assert entry["api_key_env_suggestion"] == "ORCAROUTER_API_KEY"
+
+
+def test_router_models_in_fallback():
+    """内置的路由模型应该包含 orcarouter/auto 与 orcarouter/free。"""
+    # list_models 是 async 且需要网络，这里直接检查模块级 fallback
+    from openakita.llm.registries.orcarouter import _ROUTER_MODELS
+
+    router_ids = {m.id for m in _ROUTER_MODELS}
+    assert "orcarouter/auto" in router_ids
+    assert "orcarouter/free" in router_ids
+
+
+class TestParseCapabilities:
+    def test_vision_and_pdf_from_input_modalities(self):
+        caps = OrcaRouterRegistry()._parse_capabilities(
+            {"input_modalities": ["text", "image", "file"]}, "openai/gpt-4o"
+        )
+        assert caps["text"] is True
+        assert caps["vision"] is True
+        assert caps["video"] is False
+        assert caps["pdf"] is True
+
+    def test_audio_and_video(self):
+        caps = OrcaRouterRegistry()._parse_capabilities(
+            {"input_modalities": ["text", "image", "video", "audio", "file"]},
+            "google/gemini-2.5-flash",
+        )
+        assert caps["video"] is True
+        assert caps["audio"] is True
+
+    def test_tools_from_model_name(self):
+        caps = OrcaRouterRegistry()._parse_capabilities({}, "deepseek/deepseek-v4-pro")
+        assert caps["tools"] is True
+
+    def test_thinking_from_model_name(self):
+        caps = OrcaRouterRegistry()._parse_capabilities({}, "openai/o3")
+        assert caps["thinking"] is True
+        assert caps["tools"] is True  # 推理模型同样支持工具
+
+    def test_empty_architecture_defaults(self):
+        caps = OrcaRouterRegistry()._parse_capabilities({}, "orcarouter/auto")
+        assert caps == {
+            "text": True,
+            "vision": False,
+            "video": False,
+            "tools": False,
+            "thinking": False,
+            "audio": False,
+            "pdf": False,
+        }


### PR DESCRIPTION
## Description

Adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats OpenRouter-style aggregators. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

What's wired:

- **Provider registry**: new `OrcaRouterRegistry` (`registries/orcarouter.py`), declared in `providers.json` and registered in `_CLASS_MODULE_MAP`. `list_models` pulls the live catalog from `https://api.orcarouter.ai/v1/models` and parses capabilities from `input_modalities` (vision / video / audio / file); the `orcarouter/auto` + `orcarouter/free` router models are always offered.
- **Setup Center (frontend + bridge)**: `isOrcaRouterProvider` plus OrcaRouter router-model fallbacks in both `providers.ts` (browser direct-connect) and `bridge.py` (backend CLI), so the model picker lists OrcaRouter with its router entries.
- **Capabilities**: `orcarouter` bucket in `MODEL_CAPABILITIES` plus `api.orcarouter.ai -> orcarouter` in the base-URL slug map.
- **Endpoints & pricing**: missing-key hint for OrcaRouter endpoints; builtin price fallbacks for common models.
- **Docs**: `ORCAROUTER_API_KEY` in `examples/.env.example`; `orcarouter` slug in `llm_endpoints.json.example`.
- **Tests**: `tests/llm/unit/test_orcarouter_registry.py` (9 cases).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

N/A

## How Has This Been Tested?

- [x] L1 unit tests: `pytest tests/unit/test_capabilities.py tests/unit/test_llm_pricing.py tests/unit/test_openai_thinking_depth.py tests/llm/unit/test_orcarouter_registry.py` - 71 passed, 0 failures.
- [x] `ruff check` and `ruff format --check` clean on all touched files.
- [x] Live (real key):
  - `list_models` through `OrcaRouterRegistry` and through the Setup Center bridge CLI returns the live 189-model catalog (`orcarouter/auto`, `orcarouter/free`, `openai/gpt-4o`, `google/gemini-2.5-flash`, ...), capabilities parsed from `input_modalities`.
  - Chat completion via `https://api.orcarouter.ai/v1/chat/completions` with `openai/gpt-4o` returns 200; a wrong key returns 401.
- [ ] L2 component / L3 integration / L4 E2E suites (require the full dev environment).

## Test Configuration

- Python version: 3.14
- OS: Windows 11
