### PR TITLE
sync organization task progress into IM conversation history in real time

### DIFF
--- a/src/openakita/channels/gateway.py
+++ b/src/openakita/channels/gateway.py
@@ -3377,6 +3377,134 @@ class MessageGateway:
             },
         )
 
+    def _notify_org_session_update(
+        self,
+        session: Session,
+        *,
+        role: str,
+        command_id: str,
+        event: str,
+        updated: bool = False,
+    ) -> None:
+        """Tell the message viewer that an organization turn changed."""
+        _notify_im_event(
+            "im:new_message",
+            {
+                "channel": session.channel,
+                "bot_instance_id": session.bot_instance_id or session.channel,
+                "role": role,
+                "session_id": session.session_key,
+                "chat_type": session.chat_type,
+                "display_name": session.display_name,
+                "org_command_id": command_id,
+                "org_event": event,
+                "updated": updated,
+            },
+        )
+
+    def _record_org_session_message(
+        self,
+        session: Session,
+        *,
+        role: str,
+        content: str,
+        command_id: str,
+        event: str,
+        source_message: UnifiedMessage | None = None,
+        persist: bool = False,
+    ) -> bool:
+        """Persist one organization turn and refresh the IM message viewer."""
+        text = str(content or "").strip()
+        if not text:
+            return False
+
+        metadata: dict[str, Any] = {
+            "source": "org_command",
+            "org_command_id": command_id,
+            "org_event": event,
+        }
+        if source_message is not None:
+            metadata.update(
+                {
+                    "message_id": source_message.id,
+                    "channel_message_id": source_message.channel_message_id,
+                    "bot_instance_id": session.bot_instance_id or session.channel,
+                }
+            )
+
+        with session.context._msg_lock:
+            already_recorded = any(
+                item.get("org_command_id") == command_id and item.get("org_event") == event
+                for item in session.context.messages
+            )
+        if already_recorded:
+            return False
+
+        added = session.add_message(role=role, content=text, **metadata)
+        if not added:
+            # Generic history dedup keys on role/content/time. Distinct
+            # organization commands may legitimately repeat the same prompt or
+            # result, so preserve them while still deduping by command/event.
+            session.append_marker(role=role, content=text, **metadata)
+
+        if persist:
+            self.session_manager.persist()
+        else:
+            self.session_manager.mark_dirty()
+        self._notify_org_session_update(
+            session,
+            role=role,
+            command_id=command_id,
+            event=event,
+        )
+        return True
+
+    def _sync_org_status_message(
+        self,
+        session: Session,
+        *,
+        command_id: str,
+        content: str,
+        status: str,
+    ) -> None:
+        """Create or update the single live status row shown for an org command."""
+        text = str(content or "").strip()
+        if not text:
+            return
+
+        updated = False
+        now = datetime.now().isoformat()
+        with session.context._msg_lock:
+            for item in reversed(session.context.messages):
+                if item.get("org_command_id") == command_id and item.get("org_event") == "status":
+                    item["content"] = text
+                    item["timestamp"] = now
+                    item["org_status"] = status
+                    updated = True
+                    break
+
+        if updated:
+            session.touch()
+        else:
+            session.add_message(
+                role="system",
+                content=text,
+                source="org_command",
+                org_command_id=command_id,
+                org_event="status",
+                org_status=status,
+                transient_for_llm=True,
+            )
+
+        self.session_manager.mark_dirty()
+        self._notify_org_session_update(
+            session,
+            role="system",
+            command_id=command_id,
+            event="status",
+            updated=updated,
+        )
+
     @staticmethod
     def _finish_current_org_command(
         session: Session,
@@ -3692,6 +3820,7 @@ class MessageGateway:
         command_id: str,
         progress_lines: list[str],
         done: bool = False,
+        failed: bool = False,
     ) -> str:
         lines = [
             f"已向组织 {org_display} 下发指令，命令 ID：`{command_id}`",
@@ -3707,7 +3836,10 @@ class MessageGateway:
                 lines.append(f"• {line}")
         else:
             lines.append("• 等待组织开始处理")
-        if done:
+        if failed:
+            lines.append("")
+            lines.append("❌ 命令执行失败")
+        elif done:
             lines.append("")
             lines.append("✅ 命令已完成")
         return "\n".join(lines)
@@ -3969,6 +4101,8 @@ class MessageGateway:
             await self._send_response(message, err)
             return True
 
+        command_id: str | None = None
+        terminal_synced = False
         try:
             from openakita.orgs.command_models import (
                 OrgCommandRequest,
@@ -4001,7 +4135,15 @@ class MessageGateway:
                     ),
                 )
             )
-            command_id = started["command_id"]
+            command_id = str(started["command_id"])
+            self._record_org_session_message(
+                session,
+                role="user",
+                content=text,
+                command_id=command_id,
+                event="submitted",
+                source_message=message,
+            )
             queue = svc.subscribe_summary(
                 command_id,
                 surface="im",
@@ -4028,21 +4170,28 @@ class MessageGateway:
                 progress_seen: set[str] = set()
                 org_display = f"「{org_name}」" if org_name else org_id
                 status_card_id: str | None = None
+                status_text = self._format_org_command_status_card(
+                    org_display=org_display,
+                    command_id=command_id,
+                    progress_lines=progress_lines,
+                )
                 if chat_type != "group":
                     status_card_id = await self._send_org_status_card(
                         message,
-                        self._format_org_command_status_card(
-                            org_display=org_display,
-                            command_id=command_id,
-                            progress_lines=progress_lines,
-                        ),
+                        status_text,
                     )
+                self._sync_org_status_message(
+                    session,
+                    command_id=command_id,
+                    content=status_text,
+                    status="running",
+                )
                 final_text = ""
                 while True:
                     item = await queue.get()
                     if item.get("type") == "org_progress":
                         summary = str(item.get("summary") or "").strip()
-                        if summary and chat_type != "group":
+                        if summary:
                             if summary in progress_seen:
                                 continue
                             progress_seen.add(summary)
@@ -4052,17 +4201,25 @@ class MessageGateway:
                                 command_id=command_id,
                                 progress_lines=progress_lines,
                             )
-                            patched = await self._patch_org_status_card(
-                                message,
-                                status_card_id,
-                                status_text,
+                            self._sync_org_status_message(
+                                session,
+                                command_id=command_id,
+                                content=status_text,
+                                status="running",
                             )
-                            if not patched and not status_card_id:
-                                await self._send_response(message, f"组织进度：{summary}")
+                            if chat_type != "group":
+                                patched = await self._patch_org_status_card(
+                                    message,
+                                    status_card_id,
+                                    status_text,
+                                )
+                                if not patched and not status_card_id:
+                                    await self._send_response(message, f"组织进度：{summary}")
                         continue
                     if item.get("type") == "org_command_done":
                         result = item.get("result")
                         error = item.get("error")
+                        terminal_failed = bool(error) and not result
                         attachments: list[dict] = []
                         if isinstance(result, dict):
                             final_text = str(
@@ -4070,7 +4227,8 @@ class MessageGateway:
                                 or result.get("deliverable")
                                 or result.get("final_message")
                                 or result.get("error")
-                                or ""
+                                or error
+                                or "组织命令已完成"
                             )
                             attachments = self._extract_org_result_attachments(result)
                         else:
@@ -4079,20 +4237,34 @@ class MessageGateway:
                             final_text = self._append_attachment_media_lines(
                                 final_text, attachments
                             )
-                        session.add_message("user", text, message_id=message.id)
-                        session.add_message("assistant", final_text)
                         self._finish_current_org_command(session, result_text=final_text)
-                        self.session_manager.mark_dirty()
+                        done_status_text = self._format_org_command_status_card(
+                            org_display=org_display,
+                            command_id=command_id,
+                            progress_lines=progress_lines,
+                            done=not terminal_failed,
+                            failed=terminal_failed,
+                        )
+                        self._sync_org_status_message(
+                            session,
+                            command_id=command_id,
+                            content=done_status_text,
+                            status="failed" if terminal_failed else "done",
+                        )
+                        self._record_org_session_message(
+                            session,
+                            role="assistant",
+                            content=final_text,
+                            command_id=command_id,
+                            event="failed" if terminal_failed else "done",
+                            persist=True,
+                        )
+                        terminal_synced = True
                         if chat_type != "group":
                             await self._patch_org_status_card(
                                 message,
                                 status_card_id,
-                                self._format_org_command_status_card(
-                                    org_display=org_display,
-                                    command_id=command_id,
-                                    progress_lines=progress_lines,
-                                    done=True,
-                                ),
+                                done_status_text,
                                 done=True,
                             )
                         await self._send_response(message, final_text)
@@ -4106,8 +4278,31 @@ class MessageGateway:
                     self._finish_current_org_command(session, result_text="(无最终回复)")
                     self.session_manager.mark_dirty()
         except Exception as exc:
+            if terminal_synced:
+                logger.warning(
+                    "[IM] org command completed but final response delivery failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return True
             logger.warning("[IM] org command failed: %s", exc, exc_info=True)
-            await self._send_response(message, f"组织命令提交失败：{_format_user_error(exc)}")
+            failure_text = f"组织命令提交失败：{_format_user_error(exc)}"
+            if command_id and not terminal_synced:
+                self._sync_org_status_message(
+                    session,
+                    command_id=command_id,
+                    content=f"❌ 组织任务执行失败\n\n{failure_text}",
+                    status="failed",
+                )
+                self._record_org_session_message(
+                    session,
+                    role="assistant",
+                    content=failure_text,
+                    command_id=command_id,
+                    event="failed",
+                    persist=True,
+                )
+            await self._send_response(message, failure_text)
             return True
 
     async def _handle_message(self, message: UnifiedMessage) -> None:

--- a/tests/integration/test_gateway_org_control.py
+++ b/tests/integration/test_gateway_org_control.py
@@ -326,6 +326,271 @@ class TestOrgCommandsDoNotStartTyping:
         reply = gateway._send_response.await_args.args[1]
         assert reply == "组织任务完成"
 
+    def test_org_session_dedup_is_scoped_to_command_and_event(self, gateway, session_manager):
+        """Equal text from separate commands must remain as separate history turns."""
+        session = create_test_session(
+            chat_id="chat-command-dedup",
+            channel="telegram",
+            user_id="user-command-dedup",
+        )
+
+        with patch.object(gateway_module, "_notify_im_event") as notify:
+            assert gateway._record_org_session_message(
+                session,
+                role="user",
+                content="生成相同报告",
+                command_id="cmd-one",
+                event="submitted",
+            )
+            assert not gateway._record_org_session_message(
+                session,
+                role="user",
+                content="生成相同报告",
+                command_id="cmd-one",
+                event="submitted",
+            )
+            assert gateway._record_org_session_message(
+                session,
+                role="user",
+                content="生成相同报告",
+                command_id="cmd-two",
+                event="submitted",
+            )
+
+        assert [item["org_command_id"] for item in session.context.messages] == [
+            "cmd-one",
+            "cmd-two",
+        ]
+        assert notify.call_count == 2
+        assert session_manager.mark_dirty.call_count == 2
+
+    async def test_org_task_syncs_live_status_into_im_session(self, gateway, session_manager):
+        """Submitted, progress, and terminal turns must refresh the IM message viewer."""
+        session = create_test_session(
+            chat_id="chat-live-sync",
+            channel="telegram",
+            user_id="user-live-sync",
+        )
+        session.set_metadata("bound_org_id", "org_content")
+
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_live_sync"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value="status-card-1")
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+
+        msg = create_channel_message(
+            text="@org 写一段产品文案",
+            chat_id="chat-live-sync",
+            user_id="user-live-sync",
+        )
+        from openakita.orgs import command_service as cs_module
+
+        async def wait_for(predicate) -> None:
+            for _ in range(20):
+                if predicate():
+                    return
+                await asyncio.sleep(0)
+            raise AssertionError("timed out waiting for organization session sync")
+
+        with (
+            patch.object(cs_module, "get_command_service", return_value=fake_svc),
+            patch.object(gateway_module, "_notify_im_event") as notify,
+        ):
+            handling = asyncio.create_task(
+                gateway._try_handle_org_command(msg, session, "@org 写一段产品文案")
+            )
+
+            await wait_for(lambda: len(session.context.messages) == 2)
+            assert [item["role"] for item in session.context.messages] == ["user", "system"]
+            assert session.context.messages[0]["content"] == "@org 写一段产品文案"
+            status_item = session.context.messages[1]
+            assert status_item["org_command_id"] == "cmd_live_sync"
+            assert status_item["org_status"] == "running"
+            assert status_item["transient_for_llm"] is True
+
+            queue.put_nowait({"type": "org_progress", "summary": "文案节点正在撰写"})
+            await wait_for(lambda: "文案节点正在撰写" in status_item["content"])
+            assert len(session.context.messages) == 2
+
+            queue.put_nowait(
+                {
+                    "type": "org_command_done",
+                    "result": {"result": "组织任务完成", "file_attachments": []},
+                }
+            )
+            assert await handling is True
+
+            assert [item["role"] for item in session.context.messages] == [
+                "user",
+                "system",
+                "assistant",
+            ]
+            assert status_item["org_status"] == "done"
+            assert "✅ 命令已完成" in status_item["content"]
+            assert session.context.messages[-1]["content"] == "组织任务完成"
+            assert session.context.messages[-1]["org_event"] == "done"
+
+            payloads = [call.args[1] for call in notify.call_args_list]
+            assert any(item["org_event"] == "submitted" for item in payloads)
+            assert any(item["org_event"] == "status" and item["updated"] for item in payloads)
+            assert any(item["org_event"] == "done" for item in payloads)
+
+        session_manager.persist.assert_called_once()
+        fake_svc.unsubscribe_summary.assert_called_once_with("cmd_live_sync", queue)
+
+    async def test_group_org_task_syncs_progress_without_sending_private_status_card(
+        self, gateway, session_manager
+    ):
+        """Group organization progress belongs in history even when IM cards are suppressed."""
+        session = create_test_session(
+            chat_id="group-live-sync",
+            channel="telegram",
+            user_id="group-user",
+        )
+        session.chat_type = "group"
+        session.set_metadata("bound_org_id", "org_content")
+
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        queue.put_nowait({"type": "org_progress", "summary": "群聊任务正在执行"})
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "result": {"result": "群聊组织任务完成", "file_attachments": []},
+            }
+        )
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_group_sync"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value=None)
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+
+        msg = create_channel_message(
+            text="@org 完成群聊任务",
+            chat_id="group-live-sync",
+            user_id="group-user",
+        )
+        msg.chat_type = "group"
+        from openakita.orgs import command_service as cs_module
+
+        with patch.object(cs_module, "get_command_service", return_value=fake_svc):
+            assert await gateway._try_handle_org_command(msg, session, msg.plain_text) is True
+
+        gateway._send_org_status_card.assert_not_awaited()
+        status_item = session.context.messages[1]
+        assert status_item["role"] == "system"
+        assert "群聊任务正在执行" in status_item["content"]
+        assert status_item["org_status"] == "done"
+        assert session.context.messages[-1]["content"] == "群聊组织任务完成"
+
+    async def test_failed_org_terminal_syncs_failure_state(self, gateway, session_manager):
+        """A terminal error must be visible as a failed organization turn."""
+        session = create_test_session(
+            chat_id="chat-failed-sync",
+            channel="telegram",
+            user_id="user-failed-sync",
+        )
+        session.set_metadata("bound_org_id", "org_content")
+
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "error": "Supervisor 编排端点认证失败",
+            }
+        )
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_failed_sync"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value="status-card-failed")
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+
+        msg = create_channel_message(
+            text="@org 执行失败任务",
+            chat_id="chat-failed-sync",
+            user_id="user-failed-sync",
+        )
+        from openakita.orgs import command_service as cs_module
+
+        with patch.object(cs_module, "get_command_service", return_value=fake_svc):
+            assert await gateway._try_handle_org_command(msg, session, msg.plain_text) is True
+
+        assert [item["role"] for item in session.context.messages] == [
+            "user",
+            "system",
+            "assistant",
+        ]
+        assert session.context.messages[1]["org_status"] == "failed"
+        assert "❌ 命令执行失败" in session.context.messages[1]["content"]
+        assert session.context.messages[-1]["org_event"] == "failed"
+        assert session.context.messages[-1]["content"] == "Supervisor 编排端点认证失败"
+
+    async def test_delivery_failure_does_not_reclassify_completed_history(
+        self, gateway, session_manager
+    ):
+        """Adapter delivery errors after completion must not append a false failed turn."""
+        session = create_test_session(
+            chat_id="chat-delivery-failed",
+            channel="telegram",
+            user_id="user-delivery-failed",
+        )
+        session.set_metadata("bound_org_id", "org_content")
+
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        queue.put_nowait(
+            {
+                "type": "org_command_done",
+                "result": {"result": "结果已经生成", "file_attachments": []},
+            }
+        )
+        fake_svc = MagicMock()
+        fake_svc.submit = AsyncMock(return_value={"command_id": "cmd_delivery_failed"})
+        fake_svc.subscribe_summary = MagicMock(return_value=queue)
+        fake_svc.unsubscribe_summary = MagicMock()
+
+        fake_manager = MagicMock()
+        fake_manager.resolve_id_by_name_or_id.return_value = ("org_content", [])
+        fake_manager.get.return_value = SimpleNamespace(name="内容工作室")
+        gateway._get_org_manager = MagicMock(return_value=fake_manager)
+        gateway._send_org_status_card = AsyncMock(return_value="status-card-delivery-failed")
+        gateway._patch_org_status_card = AsyncMock(return_value=True)
+        gateway._send_response = AsyncMock(side_effect=RuntimeError("adapter offline"))
+
+        msg = create_channel_message(
+            text="@org 生成结果",
+            chat_id="chat-delivery-failed",
+            user_id="user-delivery-failed",
+        )
+        from openakita.orgs import command_service as cs_module
+
+        with patch.object(cs_module, "get_command_service", return_value=fake_svc):
+            assert await gateway._try_handle_org_command(msg, session, msg.plain_text) is True
+
+        assistant_items = [item for item in session.context.messages if item["role"] == "assistant"]
+        assert len(assistant_items) == 1
+        assert assistant_items[0]["content"] == "结果已经生成"
+        assert assistant_items[0]["org_event"] == "done"
+        assert session.context.messages[1]["org_status"] == "done"
+
     async def test_org_task_sends_delivery_manifest_media(self, gateway, session_manager):
         """Final manifest paths must enter the normal IM media delivery pipeline."""
         session = create_test_session(

--- a/tests/unit/test_im_content_coercion.py
+++ b/tests/unit/test_im_content_coercion.py
@@ -65,6 +65,55 @@ def test_im_routes_preview_structured_content_without_slice_keyerror():
     assert message["content"] == "插件 seedance-video 任务更新: succeeded (e53d8a5a-a76)"
 
 
+def test_im_routes_expose_live_organization_status_messages():
+    app = FastAPI()
+    app.include_router(im_router)
+
+    status_text = "已向组织「内容工作室」下发指令\n\n组织进度：\n• 文案节点正在撰写"
+    session = SimpleNamespace(
+        channel="wechat:main",
+        chat_id="chat-org-live",
+        user_id="user-org-live",
+        chat_type="private",
+        display_name="tester",
+        chat_name="",
+        state="active",
+        last_active="2026-08-12T10:00:00",
+        context=SimpleNamespace(
+            messages=[
+                {
+                    "role": "user",
+                    "content": "@组织 写一段产品文案",
+                    "timestamp": "2026-08-12T10:00:00",
+                    "org_command_id": "cmd-live",
+                    "org_event": "submitted",
+                },
+                {
+                    "role": "system",
+                    "content": status_text,
+                    "timestamp": "2026-08-12T10:00:01",
+                    "org_command_id": "cmd-live",
+                    "org_event": "status",
+                    "org_status": "running",
+                    "transient_for_llm": True,
+                },
+            ]
+        ),
+    )
+    app.state.session_manager = SimpleNamespace(_sessions={"wechat-org-session": session})
+    app.state.gateway = None
+
+    client = TestClient(app)
+    listed = client.get("/api/im/sessions").json()["sessions"][0]
+    assert listed["messageCount"] == 2
+    assert "文案节点正在撰写" in listed["lastMessage"]
+
+    body = client.get("/api/im/sessions/wechat-org-session/messages").json()
+    assert body["total"] == 2
+    assert [item["role"] for item in body["messages"]] == ["user", "system"]
+    assert body["messages"][-1]["content"] == status_text
+
+
 def test_memory_encoder_handles_structured_turn_content():
     encoder = MemoryEncoder(session_id="s1")
     turns = [


### PR DESCRIPTION
## Summary

- Sync organization command submissions, live progress, and terminal results into IM conversation history.
- Broadcast message refresh events while updating one command-scoped status entry in place.
- Preserve repeated text across distinct commands and keep completed history intact when final IM delivery fails.

## Tests

- `uv run --no-sync pytest tests/integration/test_gateway_org_control.py tests/unit/test_im_content_coercion.py tests/integration/test_gateway.py -q` (77 passed)
- `uvx ruff check src/openakita/channels/gateway.py tests/integration/test_gateway_org_control.py tests/unit/test_im_content_coercion.py`
- `git diff --check`
