### PR TITLE
docs: restore the broken Star History charts in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,16 @@ The `OpenAkita` name, logos, icons, screenshots, and other brand assets are not 
 
 Third-party licenses: [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
 
+## Star History
+
+<a href="https://star-history.dera.page/#openakita/openakita&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date" />
+ </picture>
+</a>
+
 ---
 
 <p align="center">

--- a/README_CN.md
+++ b/README_CN.md
@@ -674,6 +674,16 @@ OpenAkita 源代码采用 GNU Affero General Public License v3.0 only（AGPL-3.0
 
 第三方许可证详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
 
+## Star History
+
+<a href="https://star-history.dera.page/#openakita/openakita&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=openakita/openakita&type=Date" />
+ </picture>
+</a>
+
 ---
 
 <p align="center">


### PR DESCRIPTION
The Star History charts on the README and README_CN were removed earlier because the chart was broken. The underlying stargazer data is now served from a token-free source, so this restores the charts at their original location to bring the project growth graph back to the landing page. The same fix has been applied to both the English and Chinese READMEs.