### PR TITLE
feat(ppt-maker): add Atlas Cloud image provider

### DIFF
--- a/plugins/ppt-maker/README.md
+++ b/plugins/ppt-maker/README.md
@@ -72,6 +72,9 @@ Generation-v2 artifacts:
   it looks more poster-like but is less editable.
 - `exporter`: `python-pptx` or `pptxgenjs`. `pptxgenjs` is optional and falls
   back to `python-pptx` when Node dependencies are not installed.
+- `image_provider`: `none`, `pexels`, `pixabay`, `dashscope`, or `atlascloud`.
+  Atlas Cloud is opt-in and uses `atlascloud_api_key` plus the configurable
+  `atlascloud_image_model` (default: `z-image/turbo`).
 
 ## Optional Dependencies
 
@@ -112,4 +115,3 @@ are unavailable, the plugin automatically uses the Python fallback exporter.
 - If export fails, check `audit_report.json`, `repair_plan.json`, `logs/`, and whether `python-pptx` is installed.
 - If `pptxgenjs` output falls back, install Node dependencies in
   `renderers/pptxgenjs/` or switch `exporter` back to `python-pptx`.
-

--- a/plugins/ppt-maker/plugin.py
+++ b/plugins/ppt-maker/plugin.py
@@ -1521,6 +1521,8 @@ def _default_settings() -> dict[str, str]:
         "pixabay_api_key": "",
         "dashscope_api_key": "",
         "dashscope_image_model": "wanx-v1",
+        "atlascloud_api_key": "",
+        "atlascloud_image_model": "z-image/turbo",
         # Optional relay-station overrides — empty string keeps the
         # official DashScope endpoint. See src/openakita/relay/.
         "dashscope_relay_endpoint": "",

--- a/plugins/ppt-maker/ppt_asset_provider.py
+++ b/plugins/ppt-maker/ppt_asset_provider.py
@@ -1,10 +1,11 @@
 """Image / icon resolution for ppt-maker.
 
-Three image paths (chosen via the ``image_provider`` setting), all independent
+Four image paths (chosen via the ``image_provider`` setting), all independent
 of any other plugin:
   - ``pexels``    — `Pexels <https://www.pexels.com/api/>`_ free stock photos.
   - ``pixabay``   — `Pixabay <https://pixabay.com/api/docs/>`_ free stock photos.
   - ``dashscope`` — Alibaba 百炼 image generation (T2I task) for synthetic art.
+  - ``atlascloud`` — Atlas Cloud image generation for synthetic art.
   - ``none``      — disabled; falls back to icon-only or plain layout.
 
 Icons are resolved deterministically: a small in-memory ``ICON_TABLE`` maps
@@ -50,6 +51,10 @@ PIXABAY_ENDPOINT = "https://pixabay.com/api/"
 DASHSCOPE_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com"
 DASHSCOPE_T2I_SUBMIT_PATH = "/api/v1/services/aigc/text2image/image-synthesis"
 DASHSCOPE_TASK_QUERY_PATH = "/api/v1/tasks/{task_id}"
+ATLASCLOUD_DEFAULT_BASE_URL = "https://api.atlascloud.ai"
+ATLASCLOUD_IMAGE_SUBMIT_PATH = "/api/v1/model/generateImage"
+ATLASCLOUD_PREDICTION_PATH = "/api/v1/model/prediction/{prediction_id}"
+ATLASCLOUD_POLL_DELAYS = (1, 2, 4, 8, 15, 30)
 
 # Kept as module-level constants for backwards compat — callers that
 # don't override base_url still see the official endpoints.
@@ -105,11 +110,13 @@ class PptAssetProvider:
     """Resolve image/icon queries to local files / shapes.
 
     Settings keys (all stored in the plugin's ``settings.json``):
-      - ``image_provider``   ∈ {none, pexels, pixabay, dashscope}
+      - ``image_provider``   ∈ {none, pexels, pixabay, dashscope, atlascloud}
       - ``pexels_api_key``
       - ``pixabay_api_key``
       - ``dashscope_api_key``
       - ``dashscope_image_model`` (default ``wanx-v1``)
+      - ``atlascloud_api_key``
+      - ``atlascloud_image_model`` (default ``z-image/turbo``)
     """
 
     def __init__(self, *, settings: dict[str, str], data_root: str | Path) -> None:
@@ -122,7 +129,8 @@ class PptAssetProvider:
     @property
     def provider(self) -> str:
         raw = (self._settings.get("image_provider") or "none").strip().lower()
-        return raw if raw in {"none", "pexels", "pixabay", "dashscope"} else "none"
+        supported = {"none", "pexels", "pixabay", "dashscope", "atlascloud"}
+        return raw if raw in supported else "none"
 
     # ── Image ──────────────────────────────────────────────────────────
 
@@ -141,6 +149,8 @@ class PptAssetProvider:
                 return await self._fetch_pixabay(query, out_dir)
             if provider == "dashscope":
                 return await self._gen_dashscope(query, out_dir)
+            if provider == "atlascloud":
+                return await self._gen_atlascloud(query, out_dir)
         except Exception as exc:  # noqa: BLE001
             logger.info("ppt-maker image resolve failed (%s/%s): %s", provider, query, exc)
             return None
@@ -276,6 +286,65 @@ class PptAssetProvider:
                 if status in {"FAILED", "UNKNOWN", "CANCELED"}:
                     return None
             return None
+
+    async def _gen_atlascloud(self, query: str, out_dir: Path) -> str | None:
+        api_key = (self._settings.get("atlascloud_api_key") or "").strip()
+        if not api_key:
+            return None
+        model = (self._settings.get("atlascloud_image_model") or "z-image/turbo").strip()
+        base_url = (self._settings.get("atlascloud_base_url") or "").strip().rstrip(
+            "/"
+        ) or ATLASCLOUD_DEFAULT_BASE_URL
+        submit_url = f"{base_url}{ATLASCLOUD_IMAGE_SUBMIT_PATH}"
+        prediction_url = f"{base_url}{ATLASCLOUD_PREDICTION_PATH}"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        import httpx
+
+        async with httpx.AsyncClient(timeout=60) as client:
+            # Generation submission is intentionally attempted exactly once.
+            submit = await client.post(
+                submit_url,
+                headers=headers,
+                json={"model": model, "prompt": query, "size": "1536*1024"},
+            )
+            submit.raise_for_status()
+            submit_body = submit.json()
+            payload = submit_body.get("data") or submit_body
+            output_url = self._atlascloud_output_url(payload)
+            if output_url:
+                return await self._download(client, output_url, out_dir, suffix=".png")
+            prediction_id = payload.get("id")
+            if not prediction_id:
+                return None
+
+            for delay in ATLASCLOUD_POLL_DELAYS:
+                await asyncio.sleep(delay)
+                poll = await client.get(
+                    prediction_url.format(prediction_id=prediction_id),
+                    headers=headers,
+                )
+                poll.raise_for_status()
+                poll_body = poll.json()
+                result = poll_body.get("data") or poll_body
+                status = str(result.get("status") or "").lower()
+                if status in {"completed", "succeeded"}:
+                    output_url = self._atlascloud_output_url(result)
+                    if not output_url:
+                        return None
+                    return await self._download(client, output_url, out_dir, suffix=".png")
+                if status in {"failed", "canceled", "cancelled"}:
+                    return None
+            return None
+
+    @staticmethod
+    def _atlascloud_output_url(payload: dict[str, Any]) -> str | None:
+        outputs = payload.get("outputs") or payload.get("output") or []
+        if isinstance(outputs, str):
+            outputs = [outputs]
+        return outputs[0] if outputs and isinstance(outputs[0], str) else None
 
     @staticmethod
     async def _download(client: Any, url: str, out_dir: Path, *, suffix: str) -> str | None:

--- a/plugins/ppt-maker/tests/test_asset_provider.py
+++ b/plugins/ppt-maker/tests/test_asset_provider.py
@@ -1,4 +1,4 @@
-"""Tests for PptAssetProvider (Pexels / Pixabay / DashScope + icon resolver)."""
+"""Tests for PptAssetProvider image backends and icon resolver."""
 
 from __future__ import annotations
 
@@ -8,6 +8,9 @@ from typing import Any
 import httpx
 import pytest
 from ppt_asset_provider import (
+    ATLASCLOUD_IMAGE_SUBMIT_PATH,
+    ATLASCLOUD_POLL_DELAYS,
+    ATLASCLOUD_PREDICTION_PATH,
     DASHSCOPE_T2I_SUBMIT,
     PEXELS_ENDPOINT,
     PIXABAY_ENDPOINT,
@@ -194,6 +197,85 @@ async def test_resolve_image_dashscope_succeeds_after_polling(tmp_path, monkeypa
 
     assert path and path.endswith(".png")
     assert state["poll_count"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_atlascloud_posts_once_then_polls(tmp_path, monkeypatch) -> None:
+    download_url = "https://atlas-result.example/img.png"
+    state = {"post_count": 0, "poll_count": 0, "delays": []}
+
+    async def handler(method, url, *, params, headers, json):
+        if method == "POST" and url.endswith(ATLASCLOUD_IMAGE_SUBMIT_PATH):
+            state["post_count"] += 1
+            assert headers and headers["Authorization"] == "Bearer atlas-key"
+            assert json == {
+                "model": "z-image/turbo",
+                "prompt": "editorial illustration",
+                "size": "1536*1024",
+            }
+            return _make_response(payload={"data": {"id": "prediction-1"}})
+        if method == "GET" and url.endswith(
+            ATLASCLOUD_PREDICTION_PATH.format(prediction_id="prediction-1")
+        ):
+            state["poll_count"] += 1
+            if state["poll_count"] == 1:
+                return _make_response(payload={"data": {"status": "processing"}})
+            return _make_response(
+                payload={
+                    "data": {
+                        "status": "completed",
+                        "outputs": [download_url],
+                    }
+                }
+            )
+        if url == download_url:
+            return _make_response(content=b"atlas-png")
+        raise AssertionError(f"unexpected url {url}")
+
+    async def fast_sleep(seconds):
+        state["delays"].append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+    _patch_async_client(monkeypatch, handler)
+    provider = _provider(
+        tmp_path,
+        image_provider="atlascloud",
+        atlascloud_api_key="atlas-key",
+    )
+
+    path = await provider.resolve_image(query="editorial illustration", project_id="p5")
+
+    assert path and path.endswith(".png")
+    assert state["post_count"] == 1
+    assert state["poll_count"] == 2
+    assert state["delays"] == list(ATLASCLOUD_POLL_DELAYS[:2])
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_atlascloud_stops_after_bounded_polling(tmp_path, monkeypatch) -> None:
+    state = {"post_count": 0, "poll_count": 0}
+
+    async def handler(method, url, *, params, headers, json):
+        if method == "POST":
+            state["post_count"] += 1
+            return _make_response(payload={"data": {"id": "prediction-2"}})
+        state["poll_count"] += 1
+        return _make_response(payload={"data": {"status": "processing"}})
+
+    async def fast_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+    _patch_async_client(monkeypatch, handler)
+    provider = _provider(
+        tmp_path,
+        image_provider="atlascloud",
+        atlascloud_api_key="atlas-key",
+    )
+
+    assert (await provider.resolve_image(query="x", project_id="p6")) is None
+    assert state["post_count"] == 1
+    assert state["poll_count"] == len(ATLASCLOUD_POLL_DELAYS)
 
 
 @pytest.mark.asyncio

--- a/plugins/ppt-maker/ui/dist/index.html
+++ b/plugins/ppt-maker/ui/dist/index.html
@@ -2288,7 +2288,7 @@
               <div className="setting-section">
                 <h3 className="setting-title">图片资源（独立配置，与其它插件不联动）</h3>
                 <div className="deps-help">
-                  <strong>三选一：免费图库 Pexels / Pixabay，或自配百炼 DashScope Key 直接调用 AI 生图。</strong>
+                  <strong>可选免费图库 Pexels / Pixabay，或使用 DashScope / Atlas Cloud 直接调用 AI 生图。</strong>
                   <div>选择 “none” 时只渲染图标 / 占位，导出仍可正常完成。Key 仅保存在本机 settings.json 中，不会上传到主程序。</div>
                 </div>
                 <div className="form-row">
@@ -2298,6 +2298,7 @@
                     <option value="pexels">Pexels（免费图库）</option>
                     <option value="pixabay">Pixabay（免费图库）</option>
                     <option value="dashscope">百炼 DashScope（AI 生成）</option>
+                    <option value="atlascloud">Atlas Cloud（AI 生成）</option>
                   </select>
                 </div>
                 <div className="form-row">
@@ -2311,6 +2312,14 @@
                 <div className="form-row">
                   <div className="text-xs text-muted">百炼 DashScope API Key</div>
                   <input type="password" className="input" placeholder="https://dashscope.console.aliyun.com 申请" value={settings.dashscope_api_key || ""} onChange={(e) => setSettings({ ...settings, dashscope_api_key: e.target.value })} onBlur={(e) => saveSettings({ dashscope_api_key: e.target.value }).catch(setError)} />
+                </div>
+                <div className="form-row">
+                  <div className="text-xs text-muted">Atlas Cloud API Key</div>
+                  <input type="password" className="input" placeholder="https://www.atlascloud.ai/console/api-key" value={settings.atlascloud_api_key || ""} onChange={(e) => setSettings({ ...settings, atlascloud_api_key: e.target.value })} onBlur={(e) => saveSettings({ atlascloud_api_key: e.target.value }).catch(setError)} />
+                </div>
+                <div className="form-row">
+                  <div className="text-xs text-muted">Atlas Cloud 图像模型</div>
+                  <input className="input" value={settings.atlascloud_image_model || "z-image/turbo"} onChange={(e) => setSettings({ ...settings, atlascloud_image_model: e.target.value })} onBlur={(e) => saveSettings({ atlascloud_image_model: e.target.value.trim() }).catch(setError)} />
                 </div>
                 <div className="form-row">
                   <div className="text-xs text-muted">共享中转站名称（可选）</div>


### PR DESCRIPTION
## Description

Add Atlas Cloud as an optional image provider for `ppt-maker` while preserving
the existing `none` default and all current providers.

- submit image generation exactly once, then use bounded GET polling
- expose local API key and model settings in the plugin UI
- document the provider and cover success and timeout paths with unit tests

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Related Issues

N/A

## 测试检查清单

- [x] Added two cases to `plugins/ppt-maker/tests/test_asset_provider.py`.
- [x] Provider behavior is covered with in-process HTTP fakes.
- [ ] L3 integration test; no paid generation request was made.
- [ ] LLM E2E replay; this provider does not call the LLM path.

## How Has This Been Tested?

- [x] `pytest plugins/ppt-maker/tests/test_asset_provider.py plugins/ppt-maker/tests/test_ui.py -q` (15 passed)
- [x] `ruff check` for the changed Python files
- [x] `ruff format --check` for the changed provider and tests
- [x] Python 3.11 syntax compilation for the plugin and provider

## Test Configuration

- Python version: 3.11
- OS: macOS

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented the non-obvious retry behavior
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing focused tests pass locally with my changes
- [x] No dependent changes are required

## Screenshots (if applicable)

N/A

## Additional Notes

The default model and request fields were verified against the live Atlas Cloud
catalog and model schema before implementation. No generation POST was made.
