### PR TITLE
migrate platform inbox and updater defaults to admin.openakita.cn

### DIFF
--- a/apps/setup-center/src-tauri/tauri.conf.json
+++ b/apps/setup-center/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ1RTQ1NjM2RkMxQ0Y4MDMKUldRRCtCejhObGJrUmR2VWdtbDMwSmhqdlE2RURSYTJKUTIxV25wRE1mcFA0Sy82Vi9zbUo3YWQK",
       "endpoints": [
-        "https://openakita-admin-api.fzstack.com/updater/release.json?version={{current_version}}&platform={{target}}",
+        "https://admin.openakita.cn/updater/release.json?version={{current_version}}&platform={{target}}",
         "https://dl-openakita.fzstack.com/api/release.json"
       ],
       "windows": {

--- a/apps/setup-center/src/platform/__tests__/updaterConfig.test.ts
+++ b/apps/setup-center/src/platform/__tests__/updaterConfig.test.ts
@@ -5,7 +5,7 @@ import tauriConfig from "../../../src-tauri/tauri.conf.json";
 describe("desktop updater configuration", () => {
   it("uses the platform API with the Tauri-compatible OSS manifest as fallback", () => {
     expect(tauriConfig.plugins.updater.endpoints).toEqual([
-      "https://openakita-admin-api.fzstack.com/updater/release.json?version={{current_version}}&platform={{target}}",
+      "https://admin.openakita.cn/updater/release.json?version={{current_version}}&platform={{target}}",
       "https://dl-openakita.fzstack.com/api/release.json",
     ]);
     expect(tauriConfig.plugins.updater.pubkey).toBe(

--- a/src/openakita/config.py
+++ b/src/openakita/config.py
@@ -861,7 +861,7 @@ class Settings(BaseSettings):
         description="站内信 L0 公开广播 JSON URL。",
     )
     inbox_api_url: str = Field(
-        default="https://openakita-admin-api.fzstack.com",
+        default="https://admin.openakita.cn",
         description="OpenAkita Platform L1 客户端 API base URL。",
     )
     inbox_poll_interval_sec: int = Field(
@@ -890,7 +890,7 @@ class Settings(BaseSettings):
         description="是否允许匿名遥测/升级事件上报。当前站内信 ack 仍受 inbox_* 开关控制。",
     )
     updater_policy_endpoint: str = Field(
-        default="https://openakita-admin-api.fzstack.com/updater",
+        default="https://admin.openakita.cn/updater",
         description="在线升级策略层 endpoint base URL，setup-center/updater 可按需使用。",
     )
 


### PR DESCRIPTION
## Summary

- Change the default platform inbox API from the legacy infrastructure hostname to `https://admin.openakita.cn`.
- Change backend and Tauri updater policy requests to `https://admin.openakita.cn/updater` while preserving the existing download manifest fallback.

## Tests

- `npm run test:run -- src/platform/__tests__/updaterConfig.test.ts` (`1 passed`)
- `uvx ruff check src/openakita/config.py`
- `uv run --no-sync python -c` assertions for both updated default endpoints
