### PR TITLE
Fix memory owner propagation through session extraction and graph encoding

### DIFF
--- a/src/openakita/api/routes/memory.py
+++ b/src/openakita/api/routes/memory.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from openakita.memory.retention import apply_retention
+from openakita.memory.session_identity import DESKTOP_USER_ID
 from openakita.memory.types import MemoryPriority, MemoryType, SemanticMemory
 
 logger = logging.getLogger(__name__)
@@ -248,7 +249,7 @@ def _current_owner(request: Request) -> tuple[str, str]:
     #    ContextVar value above is trusted; when it is the generic fallback we
     #    resolve to the desktop identity.
     if user_id in ("default", "", "anonymous"):
-        user_id = "desktop_user"
+        user_id = DESKTOP_USER_ID
 
     return user_id, workspace_id
 

--- a/src/openakita/core/_agent_runtime.py
+++ b/src/openakita/core/_agent_runtime.py
@@ -4630,22 +4630,20 @@ class Agent:
         # memory safe_id 统一用 session.session_key 派生，与 im_channel fallback
         # 和 sessions/manager backfill 的查询逻辑保持一致。
         try:
-            _memory_key = (
-                session.session_key
-                if session and hasattr(session, "session_key")
-                else conversation_id
-            )
-            conversation_safe_id = _memory_key.replace(":", "__")
-            conversation_safe_id = re.sub(r'[/\\+=%?*<>|"\x00-\x1f]', "_", conversation_safe_id)
+            from ..memory.session_identity import memory_session_id, memory_session_user
+
+            conversation_safe_id = memory_session_id(session, conversation_id)
+            memory_user_id = memory_session_user(session)
             memory_workspace_id = self._resolve_memory_workspace_id(session)
             if (
                 getattr(self.memory_manager, "_current_session_id", None) != conversation_safe_id
                 or getattr(self.memory_manager, "_current_workspace_id", None)
                 != memory_workspace_id
+                or getattr(self.memory_manager, "_current_user_id", None) != memory_user_id
             ):
                 self.memory_manager.start_session(
                     conversation_safe_id,
-                    user_id=getattr(session, "user_id", None) if session else None,
+                    user_id=memory_user_id,
                     workspace_id=memory_workspace_id,
                     focus_terms=getattr(getattr(session, "context", None), "focus_terms", None),
                 )
@@ -4662,18 +4660,19 @@ class Agent:
                     if store and hasattr(store, "save_scratchpad"):
                         from ..memory.types import Scratchpad as _SpClear
 
-                        store.save_scratchpad(
-                            _SpClear(
-                                user_id=getattr(session, "user_id", "default")
-                                if session
-                                else "default"
-                            )
-                        )
+                        store.save_scratchpad(_SpClear(user_id=memory_user_id))
                         logger.debug(
                             f"[Session] Cleared scratchpad for new conversation {conversation_id}"
                         )
                 except Exception as _e:
                     logger.debug(f"[Session] Scratchpad clear failed (non-critical): {_e}")
+            # Older truncation jobs used Session.id instead of the stable
+            # memory key. Register that known alias from the actual Session,
+            # so queued historical jobs can resolve their owner without ID parsing.
+            if session is not None and getattr(session, "id", None):
+                self.memory_manager.store.upsert_session_tenant(
+                    session.id, memory_user_id, memory_workspace_id
+                )
         except Exception as e:
             logger.warning(f"[Memory] Failed to align memory session: {e}")
 

--- a/src/openakita/memory/lifecycle.py
+++ b/src/openakita/memory/lifecycle.py
@@ -351,8 +351,8 @@ class LifecycleManager:
     ) -> int | dict:
         """处理未归纳的原文 → 生成 Episode → 提取语义记忆"""
         unextracted = self.store.get_unextracted_turns(limit=200)
-        if not unextracted:
-            return {"processed": 0, "partial": False} if deadline_monotonic else 0
+        # The retry queue can contain dropped/compressed turns even when the
+        # normal turn table is empty or fully extracted. Drain it below too.
 
         # v1.27.15 (S2 P1-6): drop ``preempted`` / ``aborted_partial``
         # markers before they reach the LLM-driven extractor.  These
@@ -387,9 +387,6 @@ class LifecycleManager:
                         _sid,
                         _exc,
                     )
-
-        if not _real_turns:
-            return {"processed": 0, "partial": False} if deadline_monotonic else 0
 
         by_session: dict[str, list[dict]] = defaultdict(list)
         for turn in _real_turns:
@@ -654,17 +651,21 @@ class LifecycleManager:
     # Deduplication
     # ==================================================================
 
+    @staticmethod
+    def _owner_key(memory: SemanticMemory) -> tuple[str, str, str, str]:
+        return (memory.scope, memory.scope_owner, memory.user_id, memory.workspace_id)
+
     async def deduplicate_batch(self) -> int:
         """基于聚类的批量去重"""
         all_memories = self.store.load_all_memories()
         if len(all_memories) < 2:
             return 0
 
-        by_type: dict[str, list[SemanticMemory]] = defaultdict(list)
+        by_type: dict[tuple, list[SemanticMemory]] = defaultdict(list)
         for mem in all_memories:
             if mem.superseded_by:
                 continue
-            by_type[mem.type.value].append(mem)
+            by_type[(*self._owner_key(mem), mem.type.value)].append(mem)
 
         deleted = 0
         for _mem_type, group in by_type.items():
@@ -1115,8 +1116,18 @@ class LifecycleManager:
                         elif action == "merge":
                             target_id = dec.get("merged_with")
                             new_content = dec.get("new_content")
-                            if target_id and new_content:
-                                self.store.update_semantic(target_id, {"content": new_content})
+                            target = (
+                                self.store.get_semantic(target_id)
+                                if isinstance(target_id, str) and target_id in batch_ids
+                                else None
+                            )
+                            if (
+                                target is not None
+                                and target.id != mem.id
+                                and new_content
+                                and self._owner_key(target) == self._owner_key(mem)
+                                and self.store.update_semantic(target_id, {"content": new_content})
+                            ):
                                 self.store.delete_semantic(mem.id)
                                 report["merged"] += 1
                             else:

--- a/src/openakita/memory/manager.py
+++ b/src/openakita/memory/manager.py
@@ -40,6 +40,7 @@ from .extractor import MemoryExtractor
 from .json_utils import coerce_text
 from .retention import apply_retention
 from .retrieval import RetrievalEngine
+from .session_identity import DESKTOP_USER_ID
 from .telemetry import emit_memory_health_event
 from .types import (
     Attachment,
@@ -72,9 +73,10 @@ class MemoryManager:
                 default=None,
             )
         if not hasattr(self, "_current_user_id_var"):
+            default_user = getattr(self, "_default_user_id", "default")
             self._current_user_id_var = contextvars.ContextVar(
                 f"openakita_memory_user_id_{id(self)}",
-                default="default",
+                default=default_user,
             )
         if not hasattr(self, "_current_workspace_id_var"):
             self._current_workspace_id_var = contextvars.ContextVar(
@@ -96,6 +98,24 @@ class MemoryManager:
                 f"openakita_memory_cited_{id(self)}",
                 default=None,
             )
+        if not hasattr(self, "_relational_pending_nodes_var"):
+            self._relational_pending_nodes_var = contextvars.ContextVar(
+                f"openakita_memory_relational_pending_{id(self)}", default=None
+            )
+
+    @property
+    def _relational_pending_nodes(self) -> list:
+        self._ensure_context_vars()
+        nodes = self._relational_pending_nodes_var.get()
+        if nodes is None:
+            nodes = []
+            self._relational_pending_nodes_var.set(nodes)
+        return nodes
+
+    @_relational_pending_nodes.setter
+    def _relational_pending_nodes(self, nodes: list) -> None:
+        self._ensure_context_vars()
+        self._relational_pending_nodes_var.set(nodes)
 
     @property
     def _current_session_id(self) -> str | None:
@@ -110,14 +130,7 @@ class MemoryManager:
     @property
     def _current_user_id(self) -> str:
         self._ensure_context_vars()
-        user_id = self._current_user_id_var.get()
-        if (
-            user_id == "default"
-            and getattr(self, "_desktop_owner_aligned", False)
-            and self._current_workspace_id == "default"
-        ):
-            return "desktop_user"
-        return user_id
+        return self._current_user_id_var.get()
 
     @_current_user_id.setter
     def _current_user_id(self, value: str) -> None:
@@ -197,6 +210,14 @@ class MemoryManager:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.agent_id = agent_id
         self._desktop_owner_alignment_requested = desktop_owner_alignment
+        # New desktop sessions must use the same identity as the panel even
+        # when historical data is ambiguous or its backup cannot be written.
+        # This changes only the implicit owner, not explicit IM/CLI identities.
+        self._default_user_id = (
+            DESKTOP_USER_ID
+            if desktop_owner_alignment and os.environ.get("OPENAKITA_DESKTOP_SESSION_TOKEN")
+            else "default"
+        )
 
         self.memory_md_path = Path(memory_md_path)
         self.identity_dir = Path(identity_dir) if identity_dir else self.memory_md_path.parent
@@ -236,7 +257,7 @@ class MemoryManager:
         )
         self._current_user_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
             f"openakita_memory_user_id_{id(self)}",
-            default="default",
+            default=self._default_user_id,
         )
         self._current_workspace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
             f"openakita_memory_workspace_id_{id(self)}",
@@ -256,7 +277,7 @@ class MemoryManager:
         )
 
         self._current_session_id: str | None = None
-        self._current_user_id: str = "default"
+        self._current_user_id: str = self._default_user_id
         self._current_workspace_id: str = "default"
         self._session_turns: list[ConversationTurn] = []
         self._recent_messages: list[dict] = []
@@ -373,7 +394,8 @@ class MemoryManager:
             logger.info("[Memory] Desktop owner alignment: %s", report)
         except Exception:
             # A failed backup/migration must leave the original data usable.
-            # Retry on next startup; do not enable the new fallback on failure.
+            # Retry on next startup. New implicit desktop sessions still use
+            # desktop_user; explicit owners are never silently rewritten.
             self.store.db._desktop_owner_alignment_report = {"status": "failed"}
             logger.exception("[Memory] Desktop owner alignment failed; keeping original owners")
 
@@ -645,6 +667,7 @@ class MemoryManager:
         focus_terms: list[str] | None = None,
     ) -> None:
         self._current_session_id = session_id
+        self._relational_pending_nodes = []
         if user_id is not _UNSET_OWNER:
             self._current_user_id = str(user_id).strip() if user_id else "anonymous"
         if workspace_id is not _UNSET_OWNER:
@@ -848,6 +871,10 @@ class MemoryManager:
         write_scope, write_owner = self._current_write_scope()
         if scope:
             write_scope = "user" if scope == "global" else scope
+            if write_scope != "session":
+                # An explicit cross-session scope must not inherit the active
+                # session's scope_owner, which the panel/recall cannot see.
+                write_owner = ""
         if scope_owner is not None:
             write_owner = scope_owner
         if write_scope == "system":
@@ -1633,6 +1660,21 @@ class MemoryManager:
 
     # ==================== Relational Memory (Mode 2) ====================
 
+    def _save_relational_encoding(
+        self, result, *, user_id: str, workspace_id: str, session_id: str
+    ) -> None:
+        """Stamp every encoding layer with its captured, trusted session owner."""
+        for node in result.nodes:
+            node.user_id = user_id
+            node.workspace_id = workspace_id
+            node.session_id = session_id
+            if self.agent_id and not node.agent_id:
+                node.agent_id = self.agent_id
+        if result.nodes:
+            self.relational_store.save_nodes_batch(result.nodes)
+        if result.edges:
+            self.relational_store.save_edges_batch(result.edges)
+
     def _ensure_relational(self) -> bool:
         """Lazily initialize relational memory components. Returns True if available."""
         if self.relational_store is not None:
@@ -1698,6 +1740,7 @@ class MemoryManager:
                         loop_for_backends.create_task(end())
 
         session_id = self._current_session_id
+        session_user, session_workspace = self._current_owner()
         turns = list(self._session_turns)
         cited = self._consume_cited_memories()
 
@@ -1826,13 +1869,12 @@ class MemoryManager:
                             existing_nodes=existing or None,
                             session_id=session_id,
                         )
-                        if result.nodes:
-                            for n in result.nodes:
-                                if self.agent_id and not n.agent_id:
-                                    n.agent_id = self.agent_id
-                            self.relational_store.save_nodes_batch(result.nodes)
-                        if result.edges:
-                            self.relational_store.save_edges_batch(result.edges)
+                        self._save_relational_encoding(
+                            result,
+                            user_id=session_user,
+                            workspace_id=session_workspace,
+                            session_id=session_id,
+                        )
                         if result.nodes or result.edges:
                             logger.info(
                                 f"[Memory] Relational encoding: "
@@ -1975,18 +2017,14 @@ class MemoryManager:
                 result = self.relational_encoder.encode_quick(
                     messages, self._current_session_id or ""
                 )
+                self._save_relational_encoding(
+                    result,
+                    user_id=write_user,
+                    workspace_id=write_workspace,
+                    session_id=self._current_session_id or "",
+                )
                 if result.nodes:
-                    for n in result.nodes:
-                        if self.agent_id and not n.agent_id:
-                            n.agent_id = self.agent_id
-                        if not getattr(n, "user_id", "") or n.user_id == "default":
-                            n.user_id = write_user
-                        if not getattr(n, "workspace_id", "") or n.workspace_id == "default":
-                            n.workspace_id = write_workspace
-                    self.relational_store.save_nodes_batch(result.nodes)
                     self._relational_pending_nodes.extend(result.nodes)
-                if result.edges:
-                    self.relational_store.save_edges_batch(result.edges)
                 if result.nodes:
                     logger.info(
                         f"[Memory] Relational quick encode: "
@@ -2035,13 +2073,13 @@ class MemoryManager:
             return
         try:
             result = self.relational_encoder.backfill_from_summary(summary, pending)
-            if result.nodes:
-                for n in result.nodes:
-                    if self.agent_id and not n.agent_id:
-                        n.agent_id = self.agent_id
-                self.relational_store.save_nodes_batch(result.nodes)
-            if result.edges:
-                self.relational_store.save_edges_batch(result.edges)
+            user_id, workspace_id = self._current_owner()
+            self._save_relational_encoding(
+                result,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                session_id=self._current_session_id or "",
+            )
             if result.nodes or result.edges:
                 logger.info(
                     f"[Memory] Relational backfill from summary: "

--- a/src/openakita/memory/owner_migration.py
+++ b/src/openakita/memory/owner_migration.py
@@ -45,6 +45,16 @@ def align_desktop_owner(storage: MemoryStorage) -> dict[str, Any]:
             if "mdrm_nodes" in tables:
                 targets.append(("mdrm_nodes", "id", "1=1", "'graph'"))
 
+            # A default identity can also be explicitly supplied by an IM
+            # adapter. A known non-desktop session namespace makes that bucket
+            # ambiguous even when no named IM user has written memories yet.
+            default_sessions = conn.execute(
+                "SELECT session_id FROM session_tenants WHERE user_id='default'"
+            ).fetchall()
+            if any("__" in sid and not sid.startswith("desktop__") for (sid,) in default_sessions):
+                conn.rollback()
+                return {"status": "skipped", "reason": "non_desktop_default_sessions"}
+
             # Inspect all workspaces, not just the one being renamed. Another
             # real/unknown user anywhere in this DB makes automatic attribution
             # unsafe, including users with sessions but no semantic memories.

--- a/src/openakita/memory/session_identity.py
+++ b/src/openakita/memory/session_identity.py
@@ -1,0 +1,20 @@
+"""Memory identity comes from session metadata, never substrings of its ID."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+DESKTOP_USER_ID = "desktop_user"
+
+
+def memory_session_id(session: Any | None, fallback: str = "") -> str:
+    key = getattr(session, "session_key", None) or fallback
+    return re.sub(r'[/\\+=%?*<>|"\x00-\x1f]', "_", key.replace(":", "__"))
+
+
+def memory_session_user(session: Any | None) -> str:
+    user_id = str(getattr(session, "user_id", None) or "").strip()
+    if getattr(session, "channel", None) == "desktop" and user_id in {"", "default", "anonymous"}:
+        return DESKTOP_USER_ID
+    return user_id or "anonymous"

--- a/src/openakita/sessions/session.py
+++ b/src/openakita/sessions/session.py
@@ -1038,12 +1038,22 @@ class Session:
         if store is None:
             return
         try:
+            from ..memory.session_identity import memory_session_id, memory_session_user
+            from ..memory.workspace_resolver import resolve_memory_workspace_id
+
+            safe_id = memory_session_id(self, self.id)
+            owner = memory_session_user(self)
+            workspace = resolve_memory_workspace_id(self)
+            # This may execute outside the chat task. Never borrow the mutable
+            # manager's current owner; the session being trimmed is authoritative.
+            store.upsert_session_tenant(safe_id, owner, workspace)
+            store.upsert_session_tenant(self.id, owner, workspace)
             for i, msg in enumerate(dropped):
                 content = msg.get("content", "")
                 if not content or not isinstance(content, str) or len(content) < 10:
                     continue
                 store.enqueue_extraction(
-                    session_id=self.id,
+                    session_id=safe_id,
                     turn_index=i,
                     content=content,
                     tool_calls=msg.get("tool_calls"),

--- a/tests/unit/test_memory_desktop_owner_migration.py
+++ b/tests/unit/test_memory_desktop_owner_migration.py
@@ -175,10 +175,15 @@ def test_desktop_only_main_manager_and_future_background_sessions(manager, monke
     manager._align_desktop_owner()
     assert manager.store.get_semantic(memory.id).user_id == "default"
     manager._desktop_owner_alignment_requested = True
-    manager._align_desktop_owner()
+    manager = MemoryManager(
+        manager.data_dir,
+        manager.memory_md_path,
+        search_backend="fts5",
+        desktop_owner_alignment=True,
+    )
 
     async def background_session():
-        manager.start_session("desktop:new", user_id="default")
+        manager.start_session("desktop:new")
         fresh = SemanticMemory(type=MemoryType.FACT, content="New background memory")
         manager.save_user_memory(fresh)
         assert fresh.user_id == "desktop_user"

--- a/tests/unit/test_memory_owner_pipeline.py
+++ b/tests/unit/test_memory_owner_pipeline.py
@@ -1,0 +1,333 @@
+"""Exercise owner propagation through real session, extraction and graph paths."""
+
+import asyncio
+import contextvars
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openakita.agent.core import Agent
+from openakita.api.routes.memory import router
+from openakita.memory.lifecycle import LifecycleManager
+from openakita.memory.manager import MemoryManager
+from openakita.memory.session_identity import memory_session_id, memory_session_user
+from openakita.memory.types import ConversationTurn, Episode, MemoryType, SemanticMemory
+from openakita.sessions.session import Session
+from openakita.tools.handlers.memory import MemoryHandler
+
+
+@pytest.fixture
+def make_manager(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAKITA_DESKTOP_SESSION_TOKEN", raising=False)
+    monkeypatch.setattr(MemoryManager, "_maybe_schedule_snapshot", lambda self: None)
+    managers = []
+
+    def make(name="memory", **kwargs):
+        mm = MemoryManager(tmp_path / name, tmp_path / f"{name}.md", **kwargs)
+        managers.append(mm)
+        return mm
+
+    yield make
+    for mm in managers:
+        mm.store.db.close()
+
+
+def panel(mm):
+    app = FastAPI()
+    app.include_router(router)
+    app.state.agent = SimpleNamespace(memory_manager=mm)
+    return TestClient(app)
+
+
+def visible_memories(mm):
+    # A real HTTP request does not inherit the currently executing agent's
+    # ContextVars (TestClient otherwise copies the test caller's context).
+    return contextvars.Context().run(lambda: panel(mm).get("/api/memories").json())
+
+
+def extractor():
+    async def episode(turns, session_id, **kwargs):
+        return Episode(session_id=session_id, summary="A completed conversation")
+
+    async def extract(turn):
+        return [{"type": "FACT", "content": turn.content, "importance": 0.8}]
+
+    return SimpleNamespace(
+        brain=None,
+        generate_episode=AsyncMock(side_effect=episode),
+        extract_from_turn_v2=AsyncMock(side_effect=extract),
+        extract_from_conversation=AsyncMock(return_value=([], [])),
+        extract_experience_from_conversation=AsyncMock(return_value=[]),
+    )
+
+
+@pytest.mark.parametrize("reason", ["ambiguous_owners", "backup_failed"])
+def test_new_desktop_fallback_does_not_depend_on_historical_migration(
+    make_manager, monkeypatch, reason
+):
+    mm = make_manager()
+    old = SemanticMemory(content="Historical default memory", type=MemoryType.FACT)
+    mm.store.save_semantic(old)
+    if reason == "ambiguous_owners":
+        mm.store.upsert_session_tenant("feishu__chat__alice", "alice", "default")
+    else:
+
+        def fail_backup(*args):
+            raise OSError("backup disk full")
+
+        monkeypatch.setattr("openakita.memory.owner_migration.align_desktop_owner", fail_backup)
+    monkeypatch.setenv("OPENAKITA_DESKTOP_SESSION_TOKEN", "test-launch")
+    desktop = make_manager(desktop_owner_alignment=True)
+    # History remains untouched, but new implicit desktop sessions must agree
+    # with the panel even when history cannot be safely migrated.
+    assert desktop.store.db.get_memory(old.id)["user_id"] == "default"
+    desktop.start_session("new-bootstrap-session")
+    fresh = SemanticMemory(content="New local desktop fact", type=MemoryType.FACT)
+    desktop.save_user_memory(fresh, scope="user")
+    assert desktop.store.get_session_tenant("new-bootstrap-session") == ("desktop_user", "default")
+    assert visible_memories(desktop)["total"] == 1
+    assert fresh.user_id == "desktop_user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user,workspace", [("desktop_user", "default"), ("alice", "project-a")])
+async def test_session_end_graph_uses_captured_owner(make_manager, monkeypatch, user, workspace):
+    mm = make_manager()
+    mm.extractor = extractor()
+    monkeypatch.setattr(mm, "_get_memory_mode", lambda: "mode2")
+    mm.start_session("original-session", user_id=user, workspace_id=workspace)
+    mm._session_turns = [
+        ConversationTurn(role="user", content="Remember the violet orchard project")
+    ]
+    mm.end_session()
+    pending = list(mm._pending_tasks)
+    mm.start_session("another-session", user_id="bob", workspace_id="project-b")
+    await asyncio.gather(*pending)
+    nodes = mm.relational_store.get_all_nodes()
+    assert nodes
+    assert {(n.user_id, n.workspace_id, n.session_id) for n in nodes} == {
+        (user, workspace, "original-session")
+    }
+
+
+@pytest.mark.asyncio
+async def test_summary_backfill_keeps_session_owner_and_edges_isolated(make_manager, monkeypatch):
+    mm = make_manager()
+    monkeypatch.setattr(mm, "_get_memory_mode", lambda: "mode2")
+    assert mm._ensure_relational()
+
+    async def summarize(user):
+        mm.start_session(f"session-{user}", user_id=user, workspace_id=f"project-{user}")
+        result = mm.relational_encoder.encode_quick(
+            [{"role": "user", "content": f"Detailed private conversation for {user}"}],
+            session_id=f"session-{user}",
+        )
+        for node in result.nodes:
+            node.user_id, node.workspace_id = user, f"project-{user}"
+        mm.relational_store.save_nodes_batch(result.nodes)
+        mm._relational_pending_nodes.extend(result.nodes)
+        await asyncio.sleep(0)
+        await mm.on_summary_generated(f"A complete conversation summary belonging to {user}")
+
+    await asyncio.gather(summarize("alice"), summarize("bob"))
+    nodes = {n.id: n for n in mm.relational_store.get_all_nodes()}
+    summaries = [n for n in nodes.values() if n.action_verb == "summarized"]
+    assert len(summaries) == 2
+    for summary in summaries:
+        user = "alice" if "alice" in summary.content else "bob"
+        assert (summary.user_id, summary.workspace_id, summary.session_id) == (
+            user,
+            f"project-{user}",
+            f"session-{user}",
+        )
+    for edge in mm.relational_store.get_all_edges(set(nodes)):
+        assert nodes[edge.source_id].user_id == nodes[edge.target_id].user_id
+
+
+@pytest.mark.asyncio
+async def test_truncated_session_runs_nightly_extraction_into_visible_owner(make_manager):
+    mm = make_manager()
+    session = Session.create(channel="desktop", chat_id="conversation", user_id="desktop_user")
+    safe_id = session.session_key.replace(":", "__")
+    mm.start_session(safe_id, user_id=session.user_id)
+    session.set_metadata("_memory_manager", mm)
+    # The manager may already be handling another user when persistence trims
+    # this session. The queue must take its owner from the Session itself.
+    mm.start_session("im:other", user_id="alice")
+    session._mark_dropped_for_extraction(
+        [{"role": "user", "content": "The user's preferred office is the violet orchard"}]
+    )
+    lifecycle = LifecycleManager(mm.store, extractor())
+    await lifecycle.process_unextracted_turns()
+    data = visible_memories(mm)
+    assert data["total"] == 1
+    assert data["memories"][0]["user_id"] == "desktop_user"
+    assert mm.store.count_memories(scope="pending_consolidation", user_id="pending") == 0
+
+
+@pytest.mark.asyncio
+async def test_existing_session_is_realigned_when_only_owner_changed(make_manager, monkeypatch):
+    mm = make_manager()
+    session = Session.create(channel="desktop", chat_id="conversation", user_id="desktop_user")
+    safe_id = session.session_key.replace(":", "__")
+    mm.start_session(safe_id, user_id="default")
+    agent = Agent.__new__(Agent)
+    agent.memory_manager = mm
+    agent._resolve_memory_workspace_id = lambda s: "default"
+
+    class PreparedMemory(Exception):
+        pass
+
+    def stop_after_memory(**kwargs):
+        raise PreparedMemory
+
+    monkeypatch.setattr("openakita.core.im_context.ensure_im_context", stop_after_memory)
+    with pytest.raises(PreparedMemory):
+        await agent._prepare_session_context("hello", [], session.id, session, None, "conversation")
+    assert mm._current_owner() == ("desktop_user", "default")
+    assert mm.store.get_session_tenant(safe_id) == ("desktop_user", "default")
+
+
+@pytest.mark.asyncio
+async def test_migration_tool_recall_nightly_extraction_and_restart_agree(
+    make_manager, monkeypatch
+):
+    mm = make_manager()
+    mm.store.save_semantic(SemanticMemory(content="The old office was in Reykjavik"))
+    mm.store.upsert_session_tenant("old-session", "default", "default")
+    mm.store.save_turn(
+        session_id="old-session",
+        turn_index=0,
+        role="user",
+        content="The legal department uses the copper ledger for invoices",
+    )
+    monkeypatch.setenv("OPENAKITA_DESKTOP_SESSION_TOKEN", "test-launch")
+    mm = make_manager(desktop_owner_alignment=True)
+    mm.start_session("new-session")
+    monkeypatch.setattr(mm, "_get_memory_mode", lambda: "mode1")
+    monkeypatch.setattr(MemoryHandler, "_compute_guide_marker_path", lambda self: None)
+    handler = MemoryHandler(
+        SimpleNamespace(memory_manager=mm, _current_user_message="Remember this")
+    )
+    handler._add_memory(
+        {
+            "content": "The user's observatory project is named VioletOrchard",
+            "type": "fact",
+            "importance": 0.8,
+            "scope": "global",
+        }
+    )
+    assert "VioletOrchard" in handler._search_memory({"query": "VioletOrchard"})
+    assert visible_memories(mm)["total"] == 2
+    lifecycle = LifecycleManager(mm.store, extractor())
+    first = await lifecycle.consolidate_daily()
+    assert first["unextracted_processed"] == 1
+    second = await lifecycle.consolidate_daily()
+    assert second["unextracted_processed"] == 0
+    assert visible_memories(mm)["total"] == 3
+    assert mm.store.count_memories(user_id="default") == 0
+    mm.store.db.close()
+    reopened = make_manager(desktop_owner_alignment=True)
+    assert visible_memories(reopened)["total"] == 3
+    assert reopened.store.get_session_tenant("old-session") == ("desktop_user", "default")
+    assert reopened.store.get_session_tenant("new-session") == ("desktop_user", "default")
+
+
+@pytest.mark.asyncio
+async def test_nightly_dedup_never_removes_another_owner_or_scope(make_manager):
+    mm = make_manager()
+    identities = [
+        ("user", "", "desktop_user", "default"),
+        ("user", "", "alice", "default"),
+        ("user", "", "desktop_user", "project-a"),
+        ("session", "session-a", "desktop_user", "default"),
+        ("session", "session-b", "desktop_user", "default"),
+    ]
+    for scope, scope_owner, user, workspace in identities:
+        mm.store.save_semantic(
+            SemanticMemory(content="The project operates a violet orchard observatory"),
+            scope=scope,
+            scope_owner=scope_owner,
+            user_id=user,
+            workspace_id=workspace,
+            skip_dedup=True,
+        )
+    lifecycle = LifecycleManager(mm.store, extractor())
+    assert await lifecycle.deduplicate_batch() == 0
+    assert len(mm.store.load_all_memories()) == len(identities)
+
+
+@pytest.mark.parametrize(
+    "channel,user,expected",
+    [
+        ("desktop", "default", "desktop_user"),
+        ("desktop", "desktop_user", "desktop_user"),
+        ("feishu", "default", "default"),
+        ("feishu", "alice", "alice"),
+        ("feishu", "", "anonymous"),
+    ],
+)
+def test_session_identity_never_guesses_from_id(channel, user, expected):
+    session = SimpleNamespace(
+        channel=channel, user_id=user, session_key="bot:desktop_user_in_chat_id:alice"
+    )
+    assert memory_session_user(session) == expected
+    assert memory_session_id(session) == "bot__desktop_user_in_chat_id__alice"
+
+
+def test_explicit_im_default_is_not_a_desktop_alias(make_manager, monkeypatch):
+    monkeypatch.setenv("OPENAKITA_DESKTOP_SESSION_TOKEN", "test-launch")
+    mm = make_manager(desktop_owner_alignment=True)
+    mm.start_session("feishu__chat__default", user_id="default")
+    assert mm._current_owner() == ("default", "default")
+    mm.save_user_memory(SemanticMemory(content="Explicit IM default user fact"), scope="user")
+    mm.store.db.close()
+    restarted = make_manager(desktop_owner_alignment=True)
+    assert (
+        restarted.store.db._desktop_owner_alignment_report["reason"]
+        == "non_desktop_default_sessions"
+    )
+    assert restarted.store.count_memories(scope="user", user_id="default") == 1
+    assert visible_memories(restarted)["total"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_user,target_workspace",
+    [
+        ("alice", "default"),
+        ("desktop_user", "project-a"),
+    ],
+)
+async def test_llm_review_cannot_merge_across_owners(make_manager, target_user, target_workspace):
+    mm = make_manager()
+    source = SemanticMemory(content="Local desktop fact")
+    target = SemanticMemory(content="Independent tenant fact")
+    mm.store.save_semantic(source, user_id="desktop_user")
+    mm.store.save_semantic(target, user_id=target_user, workspace_id=target_workspace)
+    ext = extractor()
+    ext.brain = SimpleNamespace(
+        think=AsyncMock(
+            return_value=SimpleNamespace(
+                content=json.dumps(
+                    [
+                        {
+                            "id": source.id,
+                            "action": "merge",
+                            "merged_with": target.id,
+                            "new_content": "A wrongly merged fact",
+                        },
+                        {"id": target.id, "action": "keep"},
+                    ]
+                )
+            )
+        )
+    )
+    report = await LifecycleManager(mm.store, ext).review_memories_with_llm()
+    assert report["merged"] == 0
+    assert mm.store.db.get_memory(source.id)["content"] == source.content
+    assert mm.store.db.get_memory(target.id)["content"] == target.content


### PR DESCRIPTION
## Summary

Follow up on #848: migrating historical desktop memories did not close several paths that could write new memories under a different owner from the memory panel.

- Establish the implicit desktop owner independently of migration success, preserve explicit IM identities, and skip automatic attribution when default-owned sessions have a known non-desktop namespace.
- Resolve memory identity from trusted session metadata, rebind when the user changes, and register stable session keys plus historical queue aliases. Drain queued extraction even when no ordinary turns remain.
- Carry the captured user, workspace, and session into every graph encoding path and isolate pending graph nodes between concurrent sessions. Clear inherited session ownership for explicitly cross-session semantic writes.
- Restrict nightly deduplication and LLM merge operations to the same user, workspace, and scope so one tenant's memory cannot replace another's.

## Tests

- Added regressions for migration failure/ambiguity, owner-only session changes, truncated-turn extraction, graph finalization/backfill, concurrent graph isolation, explicit IM identities, and cross-owner deduplication/merges. The first seven pipeline regressions failed against the original fix before these changes.
- Exercised historical migration, actual memory tool add/search, two daily consolidation runs, restart, and HTTP panel visibility using real stores and deterministic extraction responses.
- After rebasing onto current upstream main: 294 passed, 1 skipped across memory unit tests, agent rebinding, sessions, lifecycle/manager components, and session lifecycle integration. The skip requires Windows symbolic-link support. Existing test output also includes a TestClient deprecation warning and an unfinished background snapshot task at teardown.
- Ruff passed for the changed memory, API, session, and test modules; `git diff --check upstream/main` passed.
