### PR TITLE
fix: install xdg-utils for Linux ARM64 AppImage packaging

### DIFF
--- a/.github/actions/desktop-build-prepare/action.yml
+++ b/.github/actions/desktop-build-prepare/action.yml
@@ -59,6 +59,7 @@ runs:
           librsvg2-dev \
           patchelf \
           libfuse2 \
+          xdg-utils \
           rpm
 
     - name: Set up Python


### PR DESCRIPTION
## Summary

Install `xdg-utils` in the shared Linux desktop build preparation used by dry runs and releases. Ubuntu 22.04 and 24.04 ARM64 builds currently fail during AppImage bundling because `/usr/bin/xdg-mime` is missing; explicitly installing its package removes the dependency on runner image defaults.

## Tests

- Passed actionlint for `release-dryrun.yml` and `release.yml`.
- Parsed the composite action YAML and confirmed `xdg-utils` is in the Linux dependency list.
- Passed `git diff --check`.
- ARM64 installer builds were not rerun locally; the next dry run must confirm packaging succeeds.